### PR TITLE
feat(E03-S03a): booking creation API + Android data layer

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
     "otplib": "^13.4.0",
     "posthog-node": "^4",
     "qrcode": "^1.5.4",
+    "razorpay": "^2.9.6",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
+      razorpay:
+        specifier: ^2.9.6
+        version: 2.9.6
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -3214,6 +3217,9 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  razorpay@2.9.6:
+    resolution: {integrity: sha512-zsHAQzd6e1Cc6BNoCNZQaf65ElL6O6yw0wulxmoG5VQDr363fZC90Mp1V5EktVzG45yPyNomNXWlf4cQ3622gQ==}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -7549,6 +7555,12 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  razorpay@2.9.6:
+    dependencies:
+      axios: 1.15.0
+    transitivePeerDependencies:
+      - debug
 
   readable-stream@2.3.8:
     dependencies:

--- a/api/src/cosmos/booking-repository.ts
+++ b/api/src/cosmos/booking-repository.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from 'node:crypto';
+import { getBookingsContainer } from './client.js';
+import type { BookingDoc, CreateBookingRequest } from '../schemas/booking.js';
+
+function now() { return new Date().toISOString(); }
+
+export const bookingRepo = {
+  async createPending(
+    req: CreateBookingRequest,
+    customerId: string,
+    paymentOrderId: string,
+    amount: number,
+  ): Promise<BookingDoc> {
+    const doc: BookingDoc = {
+      id: randomUUID(), customerId, ...req,
+      status: 'PENDING_PAYMENT', paymentOrderId,
+      paymentId: null, paymentSignature: null,
+      amount, createdAt: now(),
+    };
+    const { resource } = await getBookingsContainer().items.create<BookingDoc>(doc);
+    return resource!;
+  },
+
+  async getById(id: string): Promise<BookingDoc | null> {
+    const { resource } = await getBookingsContainer().item(id, id).read<BookingDoc>();
+    return resource ?? null;
+  },
+
+  async confirmPayment(
+    id: string,
+    paymentId: string,
+    paymentSignature: string,
+  ): Promise<BookingDoc | null> {
+    const existing = await this.getById(id);
+    if (!existing || existing.status !== 'PENDING_PAYMENT') return null;
+    const updated: BookingDoc = { ...existing, status: 'SEARCHING', paymentId, paymentSignature };
+    const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+    return resource!;
+  },
+};

--- a/api/src/cosmos/client.ts
+++ b/api/src/cosmos/client.ts
@@ -24,6 +24,10 @@ export function getCatalogueContainers(): { categories: Container; services: Con
   };
 }
 
+export function getBookingsContainer(): Container {
+  return getCosmosClient().database(DB_NAME).container('bookings');
+}
+
 /** Inject a mock CosmosClient in tests. */
 export function _setCosmosClientForTest(mock: CosmosClient): void {
   _client = mock;

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -1,4 +1,4 @@
-import type { HttpRequest, InvocationContext, HttpResponseInit, HttpHandler } from '@azure/functions';
+import type { HttpHandler } from '@azure/functions';
 import { app } from '@azure/functions';
 import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
 import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -1,0 +1,53 @@
+import type { HttpRequest, InvocationContext, HttpResponseInit, HttpHandler } from '@azure/functions';
+import { app } from '@azure/functions';
+import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
+import { bookingRepo } from '../cosmos/booking-repository.js';
+import { createRazorpayOrder, verifyPaymentSignature } from '../services/razorpay.service.js';
+import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+
+const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const body = await req.json().catch(() => null);
+  const parsed = CreateBookingRequestSchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+
+  const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
+  if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+
+  const order = await createRazorpayOrder({
+    amount: service.basePrice,
+    currency: 'INR',
+    receipt: `${customer.customerId}-${Date.now()}`,
+  });
+
+  const booking = await bookingRepo.createPending(parsed.data, customer.customerId, order.id, service.basePrice);
+  return { status: 201, jsonBody: { bookingId: booking.id, razorpayOrderId: order.id, amount: order.amount } };
+};
+
+const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const id = (req as unknown as { params: { id: string } }).params.id;
+  const body = await req.json().catch(() => null);
+  const parsed = ConfirmBookingRequestSchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+
+  const booking = await bookingRepo.getById(id);
+  if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+  if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+
+  if (!verifyPaymentSignature({
+    razorpayOrderId: parsed.data.razorpayOrderId,
+    razorpayPaymentId: parsed.data.razorpayPaymentId,
+    razorpaySignature: parsed.data.razorpaySignature,
+  })) return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+
+  const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
+  if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
+
+  return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
+};
+
+export const createBookingHandler: HttpHandler = requireCustomer(createHandler);
+export const confirmBookingHandler: HttpHandler = requireCustomer(confirmHandler);
+
+app.http('createBooking', { route: 'v1/bookings', methods: ['POST'], handler: createBookingHandler });
+app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: confirmBookingHandler });

--- a/api/src/middleware/requireCustomer.ts
+++ b/api/src/middleware/requireCustomer.ts
@@ -1,0 +1,22 @@
+import type { HttpHandler, HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { verifyFirebaseIdToken } from '../services/firebaseAdmin.js';
+import type { CustomerContext } from '../types/customer.js';
+
+export type CustomerHttpHandler = (
+  req: HttpRequest,
+  ctx: InvocationContext,
+  customer: CustomerContext,
+) => Promise<HttpResponseInit>;
+
+export function requireCustomer(handler: CustomerHttpHandler): HttpHandler {
+  return async (req, ctx) => {
+    const auth = req.headers.get('authorization') ?? '';
+    if (!auth.startsWith('Bearer ')) return { status: 401, jsonBody: { code: 'UNAUTHENTICATED' } };
+    try {
+      const decoded = await verifyFirebaseIdToken(auth.slice(7));
+      return handler(req, ctx, { customerId: decoded.uid });
+    } catch {
+      return { status: 401, jsonBody: { code: 'TOKEN_INVALID' } };
+    }
+  };
+}

--- a/api/src/schemas/booking.ts
+++ b/api/src/schemas/booking.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+const BOOKING_STATUSES = [
+  'PENDING_PAYMENT', 'SEARCHING', 'ASSIGNED', 'EN_ROUTE',
+  'REACHED', 'IN_PROGRESS', 'COMPLETED', 'PAID', 'CLOSED',
+  'UNFULFILLED', 'CUSTOMER_CANCELLED',
+] as const;
+
+export const LatLngSchema = z.object({ lat: z.number(), lng: z.number() });
+
+export const BookingDocSchema = z.object({
+  id: z.string(),
+  customerId: z.string(),
+  serviceId: z.string(),
+  categoryId: z.string(),
+  slotDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  slotWindow: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  addressText: z.string().min(1),
+  addressLatLng: LatLngSchema,
+  status: z.enum(BOOKING_STATUSES),
+  paymentOrderId: z.string(),
+  paymentId: z.string().nullable(),
+  paymentSignature: z.string().nullable(),
+  amount: z.number().int().positive(),
+  createdAt: z.string(),
+});
+
+export const CreateBookingRequestSchema = z.object({
+  serviceId: z.string().min(1),
+  categoryId: z.string().min(1),
+  slotDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  slotWindow: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  addressText: z.string().min(1),
+  addressLatLng: LatLngSchema,
+});
+
+export const ConfirmBookingRequestSchema = z.object({
+  razorpayPaymentId: z.string().min(1),
+  razorpayOrderId: z.string().min(1),
+  razorpaySignature: z.string().min(1),
+});
+
+export type BookingDoc = z.infer<typeof BookingDocSchema>;
+export type CreateBookingRequest = z.infer<typeof CreateBookingRequestSchema>;
+export type ConfirmBookingRequest = z.infer<typeof ConfirmBookingRequestSchema>;

--- a/api/src/services/razorpay.service.ts
+++ b/api/src/services/razorpay.service.ts
@@ -15,7 +15,7 @@ function getRazorpay(): Razorpay {
 
 export async function createRazorpayOrder(opts: { amount: number; currency: string; receipt: string }) {
   const order = await getRazorpay().orders.create(opts);
-  return { id: order.id as string, amount: order.amount as number, currency: order.currency as string };
+  return { id: order.id, amount: order.amount, currency: order.currency };
 }
 
 export function verifyPaymentSignature(opts: {

--- a/api/src/services/razorpay.service.ts
+++ b/api/src/services/razorpay.service.ts
@@ -1,0 +1,32 @@
+import Razorpay from 'razorpay';
+import { createHmac } from 'node:crypto';
+
+let _rzp: Razorpay | null = null;
+
+function getRazorpay(): Razorpay {
+  if (!_rzp) {
+    const keyId = process.env.RAZORPAY_KEY_ID;
+    const keySecret = process.env.RAZORPAY_KEY_SECRET;
+    if (!keyId || !keySecret) throw new Error('Missing RAZORPAY_KEY_ID or RAZORPAY_KEY_SECRET');
+    _rzp = new Razorpay({ key_id: keyId, key_secret: keySecret });
+  }
+  return _rzp;
+}
+
+export async function createRazorpayOrder(opts: { amount: number; currency: string; receipt: string }) {
+  const order = await getRazorpay().orders.create(opts);
+  return { id: order.id as string, amount: order.amount as number, currency: order.currency as string };
+}
+
+export function verifyPaymentSignature(opts: {
+  razorpayOrderId: string;
+  razorpayPaymentId: string;
+  razorpaySignature: string;
+}): boolean {
+  const secret = process.env.RAZORPAY_KEY_SECRET;
+  if (!secret) throw new Error('Missing RAZORPAY_KEY_SECRET');
+  const expected = createHmac('sha256', secret)
+    .update(`${opts.razorpayOrderId}|${opts.razorpayPaymentId}`)
+    .digest('hex');
+  return expected === opts.razorpaySignature;
+}

--- a/api/src/types/customer.ts
+++ b/api/src/types/customer.ts
@@ -1,0 +1,3 @@
+export interface CustomerContext {
+  customerId: string;
+}

--- a/api/tests/bookings/confirm.test.ts
+++ b/api/tests/bookings/confirm.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HttpRequest, type HttpResponseInit } from '@azure/functions';
+
+vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_secret');
+
+vi.mock('../../src/middleware/requireCustomer.js', () => ({
+  requireCustomer: (handler: Function) => (req: HttpRequest, ctx: unknown) =>
+    handler(req, ctx, { customerId: 'cust-1' }),
+}));
+
+vi.mock('../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: {
+    getById: vi.fn().mockResolvedValue({
+      id: 'bk-1', customerId: 'cust-1', status: 'PENDING_PAYMENT', paymentOrderId: 'order_1',
+    }),
+    confirmPayment: vi.fn().mockResolvedValue({ id: 'bk-1', status: 'SEARCHING' }),
+    createPending: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/services/razorpay.service.js', () => ({
+  createRazorpayOrder: vi.fn(),
+  verifyPaymentSignature: vi.fn().mockReturnValue(true),
+}));
+
+import { confirmBookingHandler } from '../../src/functions/bookings.js';
+
+function confirmReq(id: string, body: unknown) {
+  const req = new HttpRequest({
+    url: `http://localhost/api/v1/bookings/${id}/confirm`, method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: { 'content-type': 'application/json' },
+  });
+  Object.assign(req, { params: { id } });
+  return req;
+}
+
+describe('POST /v1/bookings/:id/confirm', () => {
+  it('returns 200 with SEARCHING status on valid signature', async () => {
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'pay_1', razorpayOrderId: 'order_1', razorpaySignature: 'sig' }),
+      {} as never,
+    ) as HttpResponseInit;
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { status: string }).status).toBe('SEARCHING');
+  });
+
+  it('returns 400 on invalid signature', async () => {
+    const { verifyPaymentSignature } = await import('../../src/services/razorpay.service.js');
+    (verifyPaymentSignature as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 'bad' }),
+      {} as never,
+    ) as HttpResponseInit;
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('SIGNATURE_INVALID');
+  });
+
+  it('returns 404 when booking not found', async () => {
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    (bookingRepo.getById as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const res = await confirmBookingHandler(
+      confirmReq('missing', { razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 'sig' }),
+      {} as never,
+    ) as HttpResponseInit;
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when customerId does not match booking', async () => {
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    (bookingRepo.getById as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'bk-1', customerId: 'other-customer', status: 'PENDING_PAYMENT' });
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 'sig' }),
+      {} as never,
+    ) as HttpResponseInit;
+    expect(res.status).toBe(403);
+  });
+});

--- a/api/tests/bookings/confirm.test.ts
+++ b/api/tests/bookings/confirm.test.ts
@@ -4,8 +4,8 @@ import { HttpRequest, type HttpResponseInit } from '@azure/functions';
 vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_secret');
 
 vi.mock('../../src/middleware/requireCustomer.js', () => ({
-  requireCustomer: (handler: Function) => (req: HttpRequest, ctx: unknown) =>
-    handler(req, ctx, { customerId: 'cust-1' }),
+  requireCustomer: (handler: (req: HttpRequest, ctx: unknown, claims: { customerId: string }) => Promise<unknown>) =>
+    (req: HttpRequest, ctx: unknown) => handler(req, ctx, { customerId: 'cust-1' }),
 }));
 
 vi.mock('../../src/cosmos/booking-repository.js', () => ({

--- a/api/tests/bookings/create.test.ts
+++ b/api/tests/bookings/create.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HttpRequest, type HttpResponseInit } from '@azure/functions';
+
+vi.stubEnv('RAZORPAY_KEY_ID', 'rzp_test');
+vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_secret');
+
+vi.mock('../../src/middleware/requireCustomer.js', () => ({
+  requireCustomer: (handler: Function) => (req: HttpRequest, ctx: unknown) =>
+    handler(req, ctx, { customerId: 'cust-1' }),
+}));
+
+vi.mock('../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: {
+    createPending: vi.fn().mockResolvedValue({
+      id: 'bk-1', customerId: 'cust-1', serviceId: 'svc-1', categoryId: 'cat-1',
+      slotDate: '2026-05-01', slotWindow: '10:00-12:00',
+      addressText: '123 St', addressLatLng: { lat: 12.0, lng: 77.0 },
+      status: 'PENDING_PAYMENT', paymentOrderId: 'order_xyz',
+      paymentId: null, paymentSignature: null, amount: 59900,
+      createdAt: '2026-04-20T00:00:00.000Z',
+    }),
+    getById: vi.fn(),
+    confirmPayment: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/services/razorpay.service.js', () => ({
+  createRazorpayOrder: vi.fn().mockResolvedValue({ id: 'order_xyz', amount: 59900, currency: 'INR' }),
+  verifyPaymentSignature: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
+  catalogueRepo: {
+    getServiceByIdCrossPartition: vi.fn().mockResolvedValue({ id: 'svc-1', basePrice: 59900, isActive: true }),
+  },
+}));
+
+import { createBookingHandler } from '../../src/functions/bookings.js';
+
+function postReq(body: unknown) {
+  return new HttpRequest({
+    url: 'http://localhost/api/v1/bookings', method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST /v1/bookings', () => {
+  it('returns 201 with bookingId, razorpayOrderId, amount', async () => {
+    const res = (await createBookingHandler(postReq({
+      serviceId: 'svc-1', categoryId: 'cat-1', slotDate: '2026-05-01',
+      slotWindow: '10:00-12:00', addressText: '123 St', addressLatLng: { lat: 12.0, lng: 77.0 },
+    }), {} as never)) as HttpResponseInit;
+    expect(res.status).toBe(201);
+    const b = res.jsonBody as { bookingId: string; razorpayOrderId: string; amount: number };
+    expect(b.bookingId).toBe('bk-1');
+    expect(b.razorpayOrderId).toBe('order_xyz');
+    expect(b.amount).toBe(59900);
+  });
+
+  it('returns 422 on invalid body', async () => {
+    const res = (await createBookingHandler(postReq({ serviceId: '' }), {} as never)) as HttpResponseInit;
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 404 when service not found', async () => {
+    const { catalogueRepo } = await import('../../src/cosmos/catalogue-repository.js');
+    (catalogueRepo.getServiceByIdCrossPartition as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const res = (await createBookingHandler(postReq({
+      serviceId: 'missing', categoryId: 'c1', slotDate: '2026-05-01',
+      slotWindow: '10:00-12:00', addressText: 'addr', addressLatLng: { lat: 0, lng: 0 },
+    }), {} as never)) as HttpResponseInit;
+    expect(res.status).toBe(404);
+  });
+});

--- a/api/tests/bookings/create.test.ts
+++ b/api/tests/bookings/create.test.ts
@@ -5,8 +5,8 @@ vi.stubEnv('RAZORPAY_KEY_ID', 'rzp_test');
 vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_secret');
 
 vi.mock('../../src/middleware/requireCustomer.js', () => ({
-  requireCustomer: (handler: Function) => (req: HttpRequest, ctx: unknown) =>
-    handler(req, ctx, { customerId: 'cust-1' }),
+  requireCustomer: (handler: (req: HttpRequest, ctx: unknown, claims: { customerId: string }) => Promise<unknown>) =>
+    (req: HttpRequest, ctx: unknown) => handler(req, ctx, { customerId: 'cust-1' }),
 }));
 
 vi.mock('../../src/cosmos/booking-repository.js', () => ({

--- a/api/tests/schemas/booking.test.ts
+++ b/api/tests/schemas/booking.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { BookingDocSchema, CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../../src/schemas/booking.js';
+
+const validDoc = {
+  id: 'bk-1', customerId: 'c1', serviceId: 's1', categoryId: 'cat1',
+  slotDate: '2026-05-01', slotWindow: '10:00-12:00',
+  addressText: '123 Main St', addressLatLng: { lat: 12.97, lng: 77.59 },
+  status: 'SEARCHING', paymentOrderId: 'order_xyz',
+  paymentId: null, paymentSignature: null, amount: 59900,
+  createdAt: '2026-04-20T10:00:00.000Z',
+};
+
+describe('BookingDocSchema', () => {
+  it('parses a valid booking document', () => { expect(() => BookingDocSchema.parse(validDoc)).not.toThrow(); });
+  it('rejects invalid status', () => { expect(() => BookingDocSchema.parse({ ...validDoc, status: 'BOGUS' })).toThrow(); });
+  it('rejects malformed slotWindow', () => { expect(() => BookingDocSchema.parse({ ...validDoc, slotWindow: 'morning' })).toThrow(); });
+  it('accepts PENDING_PAYMENT status', () => { expect(() => BookingDocSchema.parse({ ...validDoc, status: 'PENDING_PAYMENT' })).not.toThrow(); });
+});
+
+describe('CreateBookingRequestSchema', () => {
+  const v = { serviceId: 's1', categoryId: 'c1', slotDate: '2026-05-01', slotWindow: '08:00-10:00', addressText: '123 St', addressLatLng: { lat: 12.0, lng: 77.0 } };
+  it('parses valid request', () => { expect(() => CreateBookingRequestSchema.parse(v)).not.toThrow(); });
+  it('rejects empty serviceId', () => { expect(() => CreateBookingRequestSchema.parse({ ...v, serviceId: '' })).toThrow(); });
+  it('rejects invalid slotWindow format', () => { expect(() => CreateBookingRequestSchema.parse({ ...v, slotWindow: 'morning' })).toThrow(); });
+});
+
+describe('ConfirmBookingRequestSchema', () => {
+  it('parses valid confirm', () => {
+    expect(() => ConfirmBookingRequestSchema.parse({ razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 's1' })).not.toThrow();
+  });
+  it('rejects empty signature', () => {
+    expect(() => ConfirmBookingRequestSchema.parse({ razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: '' })).toThrow();
+  });
+});

--- a/api/tests/unit/razorpay.service.test.ts
+++ b/api/tests/unit/razorpay.service.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
+
+vi.stubEnv('RAZORPAY_KEY_ID', 'rzp_test_key');
+vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_test_secret');
+
+vi.mock('razorpay', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    orders: { create: vi.fn().mockResolvedValue({ id: 'order_abc', amount: 59900, currency: 'INR' }) },
+  })),
+}));
+
+import { createRazorpayOrder, verifyPaymentSignature } from '../../src/services/razorpay.service.js';
+
+describe('createRazorpayOrder', () => {
+  it('returns id and amount from Razorpay', async () => {
+    const r = await createRazorpayOrder({ amount: 59900, currency: 'INR', receipt: 'bk-1' });
+    expect(r.id).toBe('order_abc');
+    expect(r.amount).toBe(59900);
+  });
+});
+
+describe('verifyPaymentSignature', () => {
+  it('returns true for valid HMAC', () => {
+    const sig = createHmac('sha256', 'rzp_test_secret').update('order_1|pay_1').digest('hex');
+    expect(verifyPaymentSignature({ razorpayOrderId: 'order_1', razorpayPaymentId: 'pay_1', razorpaySignature: sig })).toBe(true);
+  });
+  it('returns false for tampered signature', () => {
+    expect(verifyPaymentSignature({ razorpayOrderId: 'o1', razorpayPaymentId: 'p1', razorpaySignature: 'tampered' })).toBe(false);
+  });
+});

--- a/api/tests/unit/requireCustomer.test.ts
+++ b/api/tests/unit/requireCustomer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HttpRequest } from '@azure/functions';
+import { HttpRequest, type HttpResponseInit } from '@azure/functions';
 
 vi.mock('../../src/services/firebaseAdmin.js', () => ({
   verifyFirebaseIdToken: vi.fn().mockImplementation(async (token: string) => {
@@ -21,19 +21,19 @@ const ctx = {} as never;
 
 describe('requireCustomer', () => {
   it('returns 401 when Authorization header absent', async () => {
-    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req(), ctx);
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req(), ctx) as HttpResponseInit;
     expect(res.status).toBe(401);
     expect((res.jsonBody as { code: string }).code).toBe('UNAUTHENTICATED');
   });
 
   it('returns 401 when token invalid', async () => {
-    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer bad'), ctx);
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer bad'), ctx) as HttpResponseInit;
     expect(res.status).toBe(401);
     expect((res.jsonBody as { code: string }).code).toBe('TOKEN_INVALID');
   });
 
   it('passes customerId to handler on valid token', async () => {
-    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer valid-token'), ctx);
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer valid-token'), ctx) as HttpResponseInit;
     expect(res.status).toBe(200);
     expect((res.jsonBody as { id: string }).id).toBe('cust-uid-1');
   });

--- a/api/tests/unit/requireCustomer.test.ts
+++ b/api/tests/unit/requireCustomer.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HttpRequest } from '@azure/functions';
+
+vi.mock('../../src/services/firebaseAdmin.js', () => ({
+  verifyFirebaseIdToken: vi.fn().mockImplementation(async (token: string) => {
+    if (token === 'valid-token') return { uid: 'cust-uid-1' };
+    throw new Error('INVALID_TOKEN');
+  }),
+}));
+
+import { requireCustomer } from '../../src/middleware/requireCustomer.js';
+
+function req(auth?: string) {
+  return new HttpRequest({
+    url: 'http://localhost/test',
+    method: 'POST',
+    headers: auth ? { authorization: auth } : {},
+  });
+}
+const ctx = {} as never;
+
+describe('requireCustomer', () => {
+  it('returns 401 when Authorization header absent', async () => {
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req(), ctx);
+    expect(res.status).toBe(401);
+    expect((res.jsonBody as { code: string }).code).toBe('UNAUTHENTICATED');
+  });
+
+  it('returns 401 when token invalid', async () => {
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer bad'), ctx);
+    expect(res.status).toBe(401);
+    expect((res.jsonBody as { code: string }).code).toBe('TOKEN_INVALID');
+  });
+
+  it('passes customerId to handler on valid token', async () => {
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer valid-token'), ctx);
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { id: string }).id).toBe('cust-uid-1');
+  });
+});

--- a/customer-app/app/build.gradle.kts
+++ b/customer-app/app/build.gradle.kts
@@ -42,6 +42,17 @@ android {
             "API_BASE_URL",
             "\"${System.getenv("API_BASE_URL") ?: "http://10.0.2.2:7071"}\"",
         )
+        buildConfigField(
+            "String",
+            "RAZORPAY_KEY_ID",
+            "\"${System.getenv("RAZORPAY_KEY_ID") ?: ""}\"",
+        )
+        buildConfigField(
+            "String",
+            "MAPS_API_KEY",
+            "\"${System.getenv("MAPS_API_KEY") ?: ""}\"",
+        )
+        manifestPlaceholders["MAPS_API_KEY"] = System.getenv("MAPS_API_KEY") ?: ""
     }
 
     buildTypes {
@@ -284,6 +295,11 @@ dependencies {
     implementation(libs.moshi.kotlin)
     ksp(libs.moshi.kotlin.codegen)
     implementation(libs.coil.compose)
+
+    // Payments + Maps
+    implementation(libs.razorpay.checkout)
+    implementation(libs.google.places)
+    implementation(libs.play.services.maps)
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit.jupiter.api)

--- a/customer-app/app/src/main/AndroidManifest.xml
+++ b/customer-app/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
         android:theme="@style/Theme.HomeservicesCustomer"
         android:usesCleartextTraffic="false">
 
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${MAPS_API_KEY}" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt
@@ -1,0 +1,16 @@
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import kotlinx.coroutines.flow.Flow
+
+public interface BookingRepository {
+    public fun createBooking(request: BookingRequest): Flow<Result<BookingResult>>
+
+    public fun confirmBooking(
+        bookingId: String,
+        paymentId: String,
+        orderId: String,
+        signature: String,
+    ): Flow<Result<String>>
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
@@ -10,44 +10,49 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
-internal class BookingRepositoryImpl @Inject constructor(
-    private val api: BookingApiService,
-) : BookingRepository {
+internal class BookingRepositoryImpl
+    @Inject
+    constructor(
+        private val api: BookingApiService,
+    ) : BookingRepository {
+        override fun createBooking(request: BookingRequest): Flow<Result<BookingResult>> =
+            flow {
+                emit(
+                    runCatching {
+                        api
+                            .createBooking(
+                                CreateBookingRequestDto(
+                                    serviceId = request.serviceId,
+                                    categoryId = request.categoryId,
+                                    slotDate = request.slot.date,
+                                    slotWindow = request.slot.window,
+                                    addressText = request.addressText,
+                                    addressLatLng = LatLngDto(lat = request.addressLat, lng = request.addressLng),
+                                ),
+                            ).toDomain()
+                    },
+                )
+            }
 
-    override fun createBooking(request: BookingRequest): Flow<Result<BookingResult>> = flow {
-        emit(
-            runCatching {
-                api.createBooking(
-                    CreateBookingRequestDto(
-                        serviceId = request.serviceId,
-                        categoryId = request.categoryId,
-                        slotDate = request.slot.date,
-                        slotWindow = request.slot.window,
-                        addressText = request.addressText,
-                        addressLatLng = LatLngDto(lat = request.addressLat, lng = request.addressLng),
-                    ),
-                ).toDomain()
-            },
-        )
+        override fun confirmBooking(
+            bookingId: String,
+            paymentId: String,
+            orderId: String,
+            signature: String,
+        ): Flow<Result<String>> =
+            flow {
+                emit(
+                    runCatching {
+                        api
+                            .confirmBooking(
+                                bookingId,
+                                ConfirmBookingRequestDto(
+                                    razorpayPaymentId = paymentId,
+                                    razorpayOrderId = orderId,
+                                    razorpaySignature = signature,
+                                ),
+                            ).bookingId
+                    },
+                )
+            }
     }
-
-    override fun confirmBooking(
-        bookingId: String,
-        paymentId: String,
-        orderId: String,
-        signature: String,
-    ): Flow<Result<String>> = flow {
-        emit(
-            runCatching {
-                api.confirmBooking(
-                    bookingId,
-                    ConfirmBookingRequestDto(
-                        razorpayPaymentId = paymentId,
-                        razorpayOrderId = orderId,
-                        razorpaySignature = signature,
-                    ),
-                ).bookingId
-            },
-        )
-    }
-}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.LatLngDto
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+internal class BookingRepositoryImpl @Inject constructor(
+    private val api: BookingApiService,
+) : BookingRepository {
+
+    override fun createBooking(request: BookingRequest): Flow<Result<BookingResult>> = flow {
+        emit(
+            runCatching {
+                api.createBooking(
+                    CreateBookingRequestDto(
+                        serviceId = request.serviceId,
+                        categoryId = request.categoryId,
+                        slotDate = request.slot.date,
+                        slotWindow = request.slot.window,
+                        addressText = request.addressText,
+                        addressLatLng = LatLngDto(lat = request.addressLat, lng = request.addressLng),
+                    ),
+                ).toDomain()
+            },
+        )
+    }
+
+    override fun confirmBooking(
+        bookingId: String,
+        paymentId: String,
+        orderId: String,
+        signature: String,
+    ): Flow<Result<String>> = flow {
+        emit(
+            runCatching {
+                api.confirmBooking(
+                    bookingId,
+                    ConfirmBookingRequestDto(
+                        razorpayPaymentId = paymentId,
+                        razorpayOrderId = orderId,
+                        razorpaySignature = signature,
+                    ),
+                ).bookingId
+            },
+        )
+    }
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/PaymentResultBus.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/PaymentResultBus.kt
@@ -1,0 +1,18 @@
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.domain.booking.model.PaymentResult
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+public class PaymentResultBus @Inject constructor() {
+    private val _results = MutableSharedFlow<PaymentResult>(extraBufferCapacity = 1)
+    public val results: SharedFlow<PaymentResult> = _results.asSharedFlow()
+
+    public fun post(result: PaymentResult) {
+        _results.tryEmit(result)
+    }
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/PaymentResultBus.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/PaymentResultBus.kt
@@ -8,11 +8,13 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-public class PaymentResultBus @Inject constructor() {
-    private val _results = MutableSharedFlow<PaymentResult>(extraBufferCapacity = 1)
-    public val results: SharedFlow<PaymentResult> = _results.asSharedFlow()
+public class PaymentResultBus
+    @Inject
+    constructor() {
+        private val _results = MutableSharedFlow<PaymentResult>(extraBufferCapacity = 1)
+        public val results: SharedFlow<PaymentResult> = _results.asSharedFlow()
 
-    public fun post(result: PaymentResult) {
-        _results.tryEmit(result)
+        public fun post(result: PaymentResult) {
+            _results.tryEmit(result)
+        }
     }
-}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
@@ -1,0 +1,83 @@
+package com.homeservices.customer.data.booking.di
+
+import com.google.firebase.auth.FirebaseAuth
+import com.homeservices.customer.BuildConfig
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.data.booking.BookingRepositoryImpl
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.squareup.moshi.Moshi
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+public annotation class AuthOkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+public abstract class BookingModule {
+
+    @Binds
+    internal abstract fun bindBookingRepository(impl: BookingRepositoryImpl): BookingRepository
+
+    public companion object {
+
+        @Provides
+        @Singleton
+        @AuthOkHttpClient
+        public fun provideAuthOkHttpClient(): OkHttpClient =
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val token = runBlocking {
+                        FirebaseAuth.getInstance().currentUser
+                            ?.getIdToken(false)
+                            ?.await()
+                            ?.token
+                    }
+                    val req =
+                        if (token != null) {
+                            chain.request().newBuilder()
+                                .header("Authorization", "Bearer $token")
+                                .build()
+                        } else {
+                            chain.request()
+                        }
+                    chain.proceed(req)
+                }
+                .addInterceptor(
+                    HttpLoggingInterceptor().apply {
+                        level =
+                            if (BuildConfig.DEBUG) {
+                                HttpLoggingInterceptor.Level.BODY
+                            } else {
+                                HttpLoggingInterceptor.Level.NONE
+                            }
+                    },
+                )
+                .build()
+
+        @Provides
+        @Singleton
+        public fun provideBookingApiService(
+            @AuthOkHttpClient client: OkHttpClient,
+            moshi: Moshi,
+        ): BookingApiService =
+            Retrofit.Builder()
+                .baseUrl(BuildConfig.API_BASE_URL + "/")
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .client(client)
+                .build()
+                .create(BookingApiService::class.java)
+    }
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
@@ -27,35 +27,38 @@ public annotation class AuthOkHttpClient
 @Module
 @InstallIn(SingletonComponent::class)
 public abstract class BookingModule {
-
     @Binds
     internal abstract fun bindBookingRepository(impl: BookingRepositoryImpl): BookingRepository
 
     public companion object {
-
         @Provides
         @Singleton
         @AuthOkHttpClient
         public fun provideAuthOkHttpClient(): OkHttpClient =
-            OkHttpClient.Builder()
+            OkHttpClient
+                .Builder()
                 .addInterceptor { chain ->
-                    val token = runBlocking {
-                        FirebaseAuth.getInstance().currentUser
-                            ?.getIdToken(false)
-                            ?.await()
-                            ?.token
-                    }
+                    val token =
+                        runBlocking {
+                            FirebaseAuth
+                                .getInstance()
+                                .currentUser
+                                ?.getIdToken(false)
+                                ?.await()
+                                ?.token
+                        }
                     val req =
                         if (token != null) {
-                            chain.request().newBuilder()
+                            chain
+                                .request()
+                                .newBuilder()
                                 .header("Authorization", "Bearer $token")
                                 .build()
                         } else {
                             chain.request()
                         }
                     chain.proceed(req)
-                }
-                .addInterceptor(
+                }.addInterceptor(
                     HttpLoggingInterceptor().apply {
                         level =
                             if (BuildConfig.DEBUG) {
@@ -64,8 +67,7 @@ public abstract class BookingModule {
                                 HttpLoggingInterceptor.Level.NONE
                             }
                     },
-                )
-                .build()
+                ).build()
 
         @Provides
         @Singleton
@@ -73,7 +75,8 @@ public abstract class BookingModule {
             @AuthOkHttpClient client: OkHttpClient,
             moshi: Moshi,
         ): BookingApiService =
-            Retrofit.Builder()
+            Retrofit
+                .Builder()
                 .baseUrl(BuildConfig.API_BASE_URL + "/")
                 .addConverterFactory(MoshiConverterFactory.create(moshi))
                 .client(client)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
@@ -10,7 +10,9 @@ import retrofit2.http.Path
 
 public interface BookingApiService {
     @POST("v1/bookings")
-    public suspend fun createBooking(@Body body: CreateBookingRequestDto): CreateBookingResponseDto
+    public suspend fun createBooking(
+        @Body body: CreateBookingRequestDto,
+    ): CreateBookingResponseDto
 
     @POST("v1/bookings/{id}/confirm")
     public suspend fun confirmBooking(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
@@ -1,0 +1,20 @@
+package com.homeservices.customer.data.booking.remote
+
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingResponseDto
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+public interface BookingApiService {
+    @POST("v1/bookings")
+    public suspend fun createBooking(@Body body: CreateBookingRequestDto): CreateBookingResponseDto
+
+    @POST("v1/bookings/{id}/confirm")
+    public suspend fun confirmBooking(
+        @Path("id") bookingId: String,
+        @Body body: ConfirmBookingRequestDto,
+    ): ConfirmBookingResponseDto
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/BookingDtos.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/BookingDtos.kt
@@ -1,0 +1,36 @@
+package com.homeservices.customer.data.booking.remote.dto
+
+import com.homeservices.customer.domain.booking.model.BookingResult
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+public data class CreateBookingRequestDto(
+    val serviceId: String,
+    val categoryId: String,
+    val slotDate: String,
+    val slotWindow: String,
+    val addressText: String,
+    val addressLatLng: LatLngDto,
+)
+
+@JsonClass(generateAdapter = true)
+public data class LatLngDto(val lat: Double, val lng: Double)
+
+@JsonClass(generateAdapter = true)
+public data class CreateBookingResponseDto(
+    val bookingId: String,
+    val razorpayOrderId: String,
+    val amount: Int,
+) {
+    public fun toDomain(): BookingResult = BookingResult(bookingId, razorpayOrderId, amount)
+}
+
+@JsonClass(generateAdapter = true)
+public data class ConfirmBookingRequestDto(
+    val razorpayPaymentId: String,
+    val razorpayOrderId: String,
+    val razorpaySignature: String,
+)
+
+@JsonClass(generateAdapter = true)
+public data class ConfirmBookingResponseDto(val bookingId: String, val status: String)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/BookingDtos.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/BookingDtos.kt
@@ -14,7 +14,10 @@ public data class CreateBookingRequestDto(
 )
 
 @JsonClass(generateAdapter = true)
-public data class LatLngDto(val lat: Double, val lng: Double)
+public data class LatLngDto(
+    val lat: Double,
+    val lng: Double,
+)
 
 @JsonClass(generateAdapter = true)
 public data class CreateBookingResponseDto(
@@ -33,4 +36,7 @@ public data class ConfirmBookingRequestDto(
 )
 
 @JsonClass(generateAdapter = true)
-public data class ConfirmBookingResponseDto(val bookingId: String, val status: String)
+public data class ConfirmBookingResponseDto(
+    val bookingId: String,
+    val status: String,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCase.kt
@@ -1,0 +1,18 @@
+package com.homeservices.customer.domain.booking
+
+import com.homeservices.customer.data.booking.BookingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+public class ConfirmBookingUseCase
+    @Inject
+    constructor(
+        private val repo: BookingRepository,
+    ) {
+        public operator fun invoke(
+            bookingId: String,
+            paymentId: String,
+            orderId: String,
+            signature: String,
+        ): Flow<Result<String>> = repo.confirmBooking(bookingId, paymentId, orderId, signature)
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/CreateBookingUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/CreateBookingUseCase.kt
@@ -1,0 +1,15 @@
+package com.homeservices.customer.domain.booking
+
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+public class CreateBookingUseCase
+    @Inject
+    constructor(
+        private val repo: BookingRepository,
+    ) {
+        public operator fun invoke(request: BookingRequest): Flow<Result<BookingResult>> = repo.createBooking(request)
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/BookingRequest.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/BookingRequest.kt
@@ -1,0 +1,10 @@
+package com.homeservices.customer.domain.booking.model
+
+public data class BookingRequest(
+    val serviceId: String,
+    val categoryId: String,
+    val slot: BookingSlot,
+    val addressText: String,
+    val addressLat: Double,
+    val addressLng: Double,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/BookingResult.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/BookingResult.kt
@@ -1,0 +1,7 @@
+package com.homeservices.customer.domain.booking.model
+
+public data class BookingResult(
+    val bookingId: String,
+    val razorpayOrderId: String,
+    val amount: Int,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/BookingSlot.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/BookingSlot.kt
@@ -1,0 +1,6 @@
+package com.homeservices.customer.domain.booking.model
+
+public data class BookingSlot(
+    val date: String,
+    val window: String,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/PaymentResult.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/PaymentResult.kt
@@ -1,0 +1,14 @@
+package com.homeservices.customer.domain.booking.model
+
+public sealed class PaymentResult {
+    public data class Success(
+        val paymentId: String,
+        val orderId: String,
+        val signature: String,
+    ) : PaymentResult()
+
+    public data class Failure(
+        val code: Int,
+        val description: String,
+    ) : PaymentResult()
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCaseTest.kt
@@ -1,0 +1,31 @@
+package com.homeservices.customer.domain.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.BookingRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+public class ConfirmBookingUseCaseTest {
+    private val repo: BookingRepository = mockk()
+    private val sut = ConfirmBookingUseCase(repo)
+
+    @Test
+    public fun `invoke returns confirmed bookingId on success`(): Unit =
+        runTest {
+            every { repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1") } returns flowOf(Result.success("bk-1"))
+            assertThat(sut("bk-1", "pay_1", "order_1", "sig_1").first().getOrThrow()).isEqualTo("bk-1")
+            verify(exactly = 1) { repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1") }
+        }
+
+    @Test
+    public fun `invoke propagates failure`(): Unit =
+        runTest {
+            every { repo.confirmBooking(any(), any(), any(), any()) } returns flowOf(Result.failure(RuntimeException("confirm failed")))
+            assertThat(sut("bk-1", "pay_1", "order_1", "sig_1").first().isFailure).isTrue()
+        }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/CreateBookingUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/CreateBookingUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.homeservices.customer.domain.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+public class CreateBookingUseCaseTest {
+    private val repo: BookingRepository = mockk()
+    private val sut = CreateBookingUseCase(repo)
+
+    private val request =
+        BookingRequest(
+            serviceId = "svc-1",
+            categoryId = "cat-1",
+            slot = BookingSlot(date = "2026-05-01", window = "10:00-12:00"),
+            addressText = "123 Main St",
+            addressLat = 12.97,
+            addressLng = 77.59,
+        )
+
+    @Test
+    public fun `invoke returns BookingResult on success`(): Unit =
+        runTest {
+            val expected = BookingResult(bookingId = "bk-1", razorpayOrderId = "order_1", amount = 59900)
+            every { repo.createBooking(request) } returns flowOf(Result.success(expected))
+            assertThat(sut(request).first().getOrThrow()).isEqualTo(expected)
+            verify(exactly = 1) { repo.createBooking(request) }
+        }
+
+    @Test
+    public fun `invoke propagates repository failure`(): Unit =
+        runTest {
+            every { repo.createBooking(request) } returns flowOf(Result.failure(RuntimeException("network error")))
+            assertThat(sut(request).first().isFailure).isTrue()
+        }
+}

--- a/customer-app/gradle/libs.versions.toml
+++ b/customer-app/gradle/libs.versions.toml
@@ -34,6 +34,11 @@ okhttp = "4.12.0"
 moshi = "1.15.1"
 coil = "2.7.0"
 
+# Payments + Maps
+razorpay       = "1.6.40"
+googlePlaces   = "3.5.0"
+playServicesMaps = "19.0.0"
+
 # KYC-specific (Custom Tabs for DigiLocker redirect)
 androidxBrowser = "1.8.0"
 
@@ -103,6 +108,11 @@ okhttp-logging       = { module = "com.squareup.okhttp3:logging-interceptor",   
 moshi-kotlin         = { module = "com.squareup.moshi:moshi-kotlin",               version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen",       version.ref = "moshi" }
 coil-compose         = { module = "io.coil-kt:coil-compose",                       version.ref = "coil" }
+
+# Payments + Maps
+razorpay-checkout  = { module = "com.razorpay:checkout",                                  version.ref = "razorpay" }
+google-places      = { module = "com.google.android.libraries.places:places",            version.ref = "googlePlaces" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps",             version.ref = "playServicesMaps" }
 
 # Test
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }

--- a/plans/E03-S03a.md
+++ b/plans/E03-S03a.md
@@ -1,0 +1,1266 @@
+# E03-S03a — Booking Creation: API + Android Data Layer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** API booking endpoints (POST /v1/bookings + POST /v1/bookings/:id/confirm) + Android domain models, repository, and Hilt DI — everything needed before UI can be built in E03-S03b.
+
+**Architecture:** `requireCustomer` Firebase ID-token middleware mirrors `requireAdmin`. A two-phase Cosmos booking: POST /v1/bookings creates a `PENDING_PAYMENT` stub and a Razorpay order; POST /v1/bookings/:id/confirm verifies HMAC-SHA256 and upgrades to `SEARCHING`. Android domain layer defines sealed models and use cases; data layer provides Retrofit + Firebase-token OkHttp interceptor + `PaymentResultBus` SharedFlow bridge for the Razorpay Activity callback.
+
+**Tech Stack:** Node 22 + TypeScript, Zod, `razorpay` npm SDK, Firebase Admin SDK, Azure Cosmos DB. Kotlin + Compose, Retrofit, OkHttp, Hilt, `kotlinx-coroutines-play-services`.
+
+---
+
+## Pattern References
+
+| Pattern | File | Applies to |
+|---|---|---|
+| Kotlin explicit-API strict mode | `docs/patterns/kotlin-explicit-api-public-modifier.md` | ALL new Kotlin files |
+| Hilt test scope by test type | `docs/patterns/hilt-module-android-test-scope.md` | BookingModule + tests |
+
+---
+
+## File Map
+
+### API
+| | Path |
+|---|---|
+| Create | `api/src/types/customer.ts` |
+| Create | `api/src/middleware/requireCustomer.ts` |
+| Create | `api/src/schemas/booking.ts` |
+| Modify | `api/src/cosmos/client.ts` — add `getBookingsContainer()` |
+| Create | `api/src/cosmos/booking-repository.ts` |
+| Create | `api/src/services/razorpay.service.ts` |
+| Create | `api/src/functions/bookings.ts` |
+| Create | `api/tests/unit/requireCustomer.test.ts` |
+| Create | `api/tests/schemas/booking.test.ts` |
+| Create | `api/tests/bookings/create.test.ts` |
+| Create | `api/tests/bookings/confirm.test.ts` |
+
+### Android
+| | Path |
+|---|---|
+| Modify | `customer-app/gradle/libs.versions.toml` |
+| Modify | `technician-app/gradle/libs.versions.toml` (byte-for-byte sync) |
+| Modify | `customer-app/app/build.gradle.kts` |
+| Create | `…/domain/booking/model/BookingSlot.kt` |
+| Create | `…/domain/booking/model/BookingRequest.kt` |
+| Create | `…/domain/booking/model/BookingResult.kt` |
+| Create | `…/domain/booking/model/PaymentResult.kt` |
+| Create | `…/domain/booking/CreateBookingUseCase.kt` |
+| Create | `…/domain/booking/ConfirmBookingUseCase.kt` |
+| Create | `…/data/booking/BookingRepository.kt` |
+| Create | `…/data/booking/BookingRepositoryImpl.kt` |
+| Create | `…/data/booking/remote/BookingApiService.kt` |
+| Create | `…/data/booking/remote/dto/BookingDtos.kt` |
+| Create | `…/data/booking/PaymentResultBus.kt` |
+| Create | `…/data/booking/di/BookingModule.kt` |
+| Create | `…/app/src/test/…/domain/booking/CreateBookingUseCaseTest.kt` |
+| Create | `…/app/src/test/…/domain/booking/ConfirmBookingUseCaseTest.kt` |
+
+Shorthand `…` = `customer-app/app/src/main/kotlin/com/homeservices/customer`
+
+---
+
+## WS-A: API
+
+### Task A1: `requireCustomer` middleware
+
+**Files:** `api/src/types/customer.ts`, `api/src/middleware/requireCustomer.ts`, `api/tests/unit/requireCustomer.test.ts`
+
+- [ ] **Step 1: Write failing test** — `api/tests/unit/requireCustomer.test.ts`
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { HttpRequest } from '@azure/functions';
+
+vi.mock('../../src/services/firebaseAdmin.js', () => ({
+  verifyFirebaseIdToken: vi.fn().mockImplementation(async (token: string) => {
+    if (token === 'valid-token') return { uid: 'cust-uid-1' };
+    throw new Error('INVALID_TOKEN');
+  }),
+}));
+
+import { requireCustomer } from '../../src/middleware/requireCustomer.js';
+
+function req(auth?: string) {
+  const h = new Headers();
+  if (auth) h.set('authorization', auth);
+  return new HttpRequest({ url: 'http://localhost/test', method: 'POST', headers: h });
+}
+const ctx = {} as never;
+
+describe('requireCustomer', () => {
+  it('returns 401 when Authorization header absent', async () => {
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req(), ctx);
+    expect(res.status).toBe(401);
+    expect((res.jsonBody as { code: string }).code).toBe('UNAUTHENTICATED');
+  });
+
+  it('returns 401 when token invalid', async () => {
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer bad'), ctx);
+    expect(res.status).toBe(401);
+    expect((res.jsonBody as { code: string }).code).toBe('TOKEN_INVALID');
+  });
+
+  it('passes customerId to handler on valid token', async () => {
+    const res = await requireCustomer(async (_r, _c, c) => ({ status: 200, jsonBody: { id: c.customerId } }))(req('Bearer valid-token'), ctx);
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { id: string }).id).toBe('cust-uid-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd api && pnpm test tests/unit/requireCustomer.test.ts
+```
+Expected: `Error: Cannot find module '../../src/middleware/requireCustomer.js'`
+
+- [ ] **Step 3: Create `api/src/types/customer.ts`**
+
+```typescript
+export interface CustomerContext {
+  customerId: string;
+}
+```
+
+- [ ] **Step 4: Create `api/src/middleware/requireCustomer.ts`**
+
+```typescript
+import type { HttpHandler, HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { verifyFirebaseIdToken } from '../services/firebaseAdmin.js';
+import type { CustomerContext } from '../types/customer.js';
+
+export type CustomerHttpHandler = (
+  req: HttpRequest,
+  ctx: InvocationContext,
+  customer: CustomerContext,
+) => Promise<HttpResponseInit>;
+
+export function requireCustomer(handler: CustomerHttpHandler): HttpHandler {
+  return async (req, ctx) => {
+    const auth = req.headers.get('authorization') ?? '';
+    if (!auth.startsWith('Bearer ')) return { status: 401, jsonBody: { code: 'UNAUTHENTICATED' } };
+    try {
+      const decoded = await verifyFirebaseIdToken(auth.slice(7));
+      return handler(req, ctx, { customerId: decoded.uid });
+    } catch {
+      return { status: 401, jsonBody: { code: 'TOKEN_INVALID' } };
+    }
+  };
+}
+```
+
+- [ ] **Step 5: Run — expect PASS (3 tests)**
+
+```bash
+pnpm test tests/unit/requireCustomer.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/types/customer.ts api/src/middleware/requireCustomer.ts api/tests/unit/requireCustomer.test.ts
+git commit -m "feat(E03-S03a/WS-A): requireCustomer Firebase ID-token middleware"
+```
+
+---
+
+### Task A2: Booking Zod schema + Cosmos container
+
+**Files:** `api/src/schemas/booking.ts`, `api/tests/schemas/booking.test.ts`; modify `api/src/cosmos/client.ts`
+
+- [ ] **Step 1: Write failing test** — `api/tests/schemas/booking.test.ts`
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { BookingDocSchema, CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../../src/schemas/booking.js';
+
+const validDoc = {
+  id: 'bk-1', customerId: 'c1', serviceId: 's1', categoryId: 'cat1',
+  slotDate: '2026-05-01', slotWindow: '10:00-12:00',
+  addressText: '123 Main St', addressLatLng: { lat: 12.97, lng: 77.59 },
+  status: 'SEARCHING', paymentOrderId: 'order_xyz',
+  paymentId: null, paymentSignature: null, amount: 59900,
+  createdAt: '2026-04-20T10:00:00.000Z',
+};
+
+describe('BookingDocSchema', () => {
+  it('parses a valid booking document', () => { expect(() => BookingDocSchema.parse(validDoc)).not.toThrow(); });
+  it('rejects invalid status', () => { expect(() => BookingDocSchema.parse({ ...validDoc, status: 'BOGUS' })).toThrow(); });
+  it('rejects malformed slotWindow', () => { expect(() => BookingDocSchema.parse({ ...validDoc, slotWindow: 'morning' })).toThrow(); });
+  it('accepts PENDING_PAYMENT status', () => { expect(() => BookingDocSchema.parse({ ...validDoc, status: 'PENDING_PAYMENT' })).not.toThrow(); });
+});
+
+describe('CreateBookingRequestSchema', () => {
+  const v = { serviceId: 's1', categoryId: 'c1', slotDate: '2026-05-01', slotWindow: '08:00-10:00', addressText: '123 St', addressLatLng: { lat: 12.0, lng: 77.0 } };
+  it('parses valid request', () => { expect(() => CreateBookingRequestSchema.parse(v)).not.toThrow(); });
+  it('rejects empty serviceId', () => { expect(() => CreateBookingRequestSchema.parse({ ...v, serviceId: '' })).toThrow(); });
+  it('rejects invalid slotWindow format', () => { expect(() => CreateBookingRequestSchema.parse({ ...v, slotWindow: 'morning' })).toThrow(); });
+});
+
+describe('ConfirmBookingRequestSchema', () => {
+  it('parses valid confirm', () => {
+    expect(() => ConfirmBookingRequestSchema.parse({ razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 's1' })).not.toThrow();
+  });
+  it('rejects empty signature', () => {
+    expect(() => ConfirmBookingRequestSchema.parse({ razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: '' })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+pnpm test tests/schemas/booking.test.ts
+```
+
+- [ ] **Step 3: Create `api/src/schemas/booking.ts`**
+
+```typescript
+import { z } from 'zod';
+
+const BOOKING_STATUSES = [
+  'PENDING_PAYMENT', 'SEARCHING', 'ASSIGNED', 'EN_ROUTE',
+  'REACHED', 'IN_PROGRESS', 'COMPLETED', 'PAID', 'CLOSED',
+  'UNFULFILLED', 'CUSTOMER_CANCELLED',
+] as const;
+
+export const LatLngSchema = z.object({ lat: z.number(), lng: z.number() });
+
+export const BookingDocSchema = z.object({
+  id: z.string(),
+  customerId: z.string(),
+  serviceId: z.string(),
+  categoryId: z.string(),
+  slotDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  slotWindow: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  addressText: z.string().min(1),
+  addressLatLng: LatLngSchema,
+  status: z.enum(BOOKING_STATUSES),
+  paymentOrderId: z.string(),
+  paymentId: z.string().nullable(),
+  paymentSignature: z.string().nullable(),
+  amount: z.number().int().positive(),
+  createdAt: z.string(),
+});
+
+export const CreateBookingRequestSchema = z.object({
+  serviceId: z.string().min(1),
+  categoryId: z.string().min(1),
+  slotDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  slotWindow: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  addressText: z.string().min(1),
+  addressLatLng: LatLngSchema,
+});
+
+export const ConfirmBookingRequestSchema = z.object({
+  razorpayPaymentId: z.string().min(1),
+  razorpayOrderId: z.string().min(1),
+  razorpaySignature: z.string().min(1),
+});
+
+export type BookingDoc = z.infer<typeof BookingDocSchema>;
+export type CreateBookingRequest = z.infer<typeof CreateBookingRequestSchema>;
+export type ConfirmBookingRequest = z.infer<typeof ConfirmBookingRequestSchema>;
+```
+
+- [ ] **Step 4: Append `getBookingsContainer()` to `api/src/cosmos/client.ts`**
+
+```typescript
+export function getBookingsContainer(): Container {
+  return getCosmosClient().database(DB_NAME).container('bookings');
+}
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+```bash
+pnpm test tests/schemas/booking.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/schemas/booking.ts api/src/cosmos/client.ts api/tests/schemas/booking.test.ts
+git commit -m "feat(E03-S03a/WS-A): booking Zod schema + Cosmos bookings container"
+```
+
+---
+
+### Task A3: Razorpay service + booking repository
+
+**Files:** `api/src/services/razorpay.service.ts`, `api/src/cosmos/booking-repository.ts`, `api/tests/unit/razorpay.service.test.ts`
+
+- [ ] **Step 1: Install Razorpay Node SDK**
+
+```bash
+cd api && pnpm add razorpay && pnpm add -D @types/razorpay
+```
+
+> `@types/razorpay` may not exist on npm — if install fails, omit it and type the SDK inline.
+
+- [ ] **Step 2: Write failing Razorpay service test** — `api/tests/unit/razorpay.service.test.ts`
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
+
+vi.stubEnv('RAZORPAY_KEY_ID', 'rzp_test_key');
+vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_test_secret');
+
+vi.mock('razorpay', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    orders: { create: vi.fn().mockResolvedValue({ id: 'order_abc', amount: 59900, currency: 'INR' }) },
+  })),
+}));
+
+import { createRazorpayOrder, verifyPaymentSignature } from '../../src/services/razorpay.service.js';
+
+describe('createRazorpayOrder', () => {
+  it('returns id and amount from Razorpay', async () => {
+    const r = await createRazorpayOrder({ amount: 59900, currency: 'INR', receipt: 'bk-1' });
+    expect(r.id).toBe('order_abc');
+    expect(r.amount).toBe(59900);
+  });
+});
+
+describe('verifyPaymentSignature', () => {
+  it('returns true for valid HMAC', () => {
+    const sig = createHmac('sha256', 'rzp_test_secret').update('order_1|pay_1').digest('hex');
+    expect(verifyPaymentSignature({ razorpayOrderId: 'order_1', razorpayPaymentId: 'pay_1', razorpaySignature: sig })).toBe(true);
+  });
+  it('returns false for tampered signature', () => {
+    expect(verifyPaymentSignature({ razorpayOrderId: 'o1', razorpayPaymentId: 'p1', razorpaySignature: 'tampered' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run — expect FAIL**
+
+```bash
+pnpm test tests/unit/razorpay.service.test.ts
+```
+
+- [ ] **Step 4: Create `api/src/services/razorpay.service.ts`**
+
+```typescript
+import Razorpay from 'razorpay';
+import { createHmac } from 'node:crypto';
+
+let _rzp: Razorpay | null = null;
+
+function getRazorpay(): Razorpay {
+  if (!_rzp) {
+    const keyId = process.env.RAZORPAY_KEY_ID;
+    const keySecret = process.env.RAZORPAY_KEY_SECRET;
+    if (!keyId || !keySecret) throw new Error('Missing RAZORPAY_KEY_ID or RAZORPAY_KEY_SECRET');
+    _rzp = new Razorpay({ key_id: keyId, key_secret: keySecret });
+  }
+  return _rzp;
+}
+
+export async function createRazorpayOrder(opts: { amount: number; currency: string; receipt: string }) {
+  const order = await getRazorpay().orders.create(opts);
+  return { id: order.id as string, amount: order.amount as number, currency: order.currency as string };
+}
+
+export function verifyPaymentSignature(opts: {
+  razorpayOrderId: string;
+  razorpayPaymentId: string;
+  razorpaySignature: string;
+}): boolean {
+  const secret = process.env.RAZORPAY_KEY_SECRET;
+  if (!secret) throw new Error('Missing RAZORPAY_KEY_SECRET');
+  const expected = createHmac('sha256', secret)
+    .update(`${opts.razorpayOrderId}|${opts.razorpayPaymentId}`)
+    .digest('hex');
+  return expected === opts.razorpaySignature;
+}
+```
+
+- [ ] **Step 5: Create `api/src/cosmos/booking-repository.ts`**
+
+```typescript
+import { randomUUID } from 'node:crypto';
+import { getBookingsContainer } from './client.js';
+import type { BookingDoc, CreateBookingRequest } from '../schemas/booking.js';
+
+function now() { return new Date().toISOString(); }
+
+export const bookingRepo = {
+  async createPending(
+    req: CreateBookingRequest,
+    customerId: string,
+    paymentOrderId: string,
+    amount: number,
+  ): Promise<BookingDoc> {
+    const doc: BookingDoc = {
+      id: randomUUID(), customerId, ...req,
+      status: 'PENDING_PAYMENT', paymentOrderId,
+      paymentId: null, paymentSignature: null,
+      amount, createdAt: now(),
+    };
+    const { resource } = await getBookingsContainer().items.create<BookingDoc>(doc);
+    return resource!;
+  },
+
+  async getById(id: string): Promise<BookingDoc | null> {
+    const { resource } = await getBookingsContainer().item(id, id).read<BookingDoc>();
+    return resource ?? null;
+  },
+
+  async confirmPayment(
+    id: string,
+    paymentId: string,
+    paymentSignature: string,
+  ): Promise<BookingDoc | null> {
+    const existing = await this.getById(id);
+    if (!existing || existing.status !== 'PENDING_PAYMENT') return null;
+    const updated: BookingDoc = { ...existing, status: 'SEARCHING', paymentId, paymentSignature };
+    const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+    return resource!;
+  },
+};
+```
+
+- [ ] **Step 6: Run Razorpay tests — expect PASS**
+
+```bash
+pnpm test tests/unit/razorpay.service.test.ts
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/src/services/razorpay.service.ts api/src/cosmos/booking-repository.ts \
+        api/tests/unit/razorpay.service.test.ts api/package.json pnpm-lock.yaml
+git commit -m "feat(E03-S03a/WS-A): Razorpay service (order creation + HMAC verify) + booking repository"
+```
+
+---
+
+### Task A4: POST /v1/bookings + POST /v1/bookings/:id/confirm
+
+**Files:** `api/src/functions/bookings.ts`, `api/tests/bookings/create.test.ts`, `api/tests/bookings/confirm.test.ts`
+
+- [ ] **Step 1: Write failing create test** — `api/tests/bookings/create.test.ts`
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { HttpRequest } from '@azure/functions';
+
+vi.stubEnv('RAZORPAY_KEY_ID', 'rzp_test');
+vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_secret');
+
+vi.mock('../../src/middleware/requireCustomer.js', () => ({
+  requireCustomer: (handler: Function) => (req: HttpRequest, ctx: unknown) =>
+    handler(req, ctx, { customerId: 'cust-1' }),
+}));
+
+vi.mock('../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: {
+    createPending: vi.fn().mockResolvedValue({
+      id: 'bk-1', customerId: 'cust-1', serviceId: 'svc-1', categoryId: 'cat-1',
+      slotDate: '2026-05-01', slotWindow: '10:00-12:00',
+      addressText: '123 St', addressLatLng: { lat: 12.0, lng: 77.0 },
+      status: 'PENDING_PAYMENT', paymentOrderId: 'order_xyz',
+      paymentId: null, paymentSignature: null, amount: 59900,
+      createdAt: '2026-04-20T00:00:00.000Z',
+    }),
+    getById: vi.fn(),
+    confirmPayment: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/services/razorpay.service.js', () => ({
+  createRazorpayOrder: vi.fn().mockResolvedValue({ id: 'order_xyz', amount: 59900, currency: 'INR' }),
+  verifyPaymentSignature: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
+  catalogueRepo: {
+    getServiceByIdCrossPartition: vi.fn().mockResolvedValue({ id: 'svc-1', basePrice: 59900, isActive: true }),
+  },
+}));
+
+import { createBookingHandler } from '../../src/functions/bookings.js';
+
+function postReq(body: unknown) {
+  return new HttpRequest({
+    url: 'http://localhost/api/v1/bookings', method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: new Headers({ 'content-type': 'application/json' }),
+  });
+}
+
+describe('POST /v1/bookings', () => {
+  it('returns 201 with bookingId, razorpayOrderId, amount', async () => {
+    const res = await createBookingHandler(postReq({
+      serviceId: 'svc-1', categoryId: 'cat-1', slotDate: '2026-05-01',
+      slotWindow: '10:00-12:00', addressText: '123 St', addressLatLng: { lat: 12.0, lng: 77.0 },
+    }), {} as never);
+    expect(res.status).toBe(201);
+    const b = res.jsonBody as { bookingId: string; razorpayOrderId: string; amount: number };
+    expect(b.bookingId).toBe('bk-1');
+    expect(b.razorpayOrderId).toBe('order_xyz');
+    expect(b.amount).toBe(59900);
+  });
+
+  it('returns 422 on invalid body', async () => {
+    const res = await createBookingHandler(postReq({ serviceId: '' }), {} as never);
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 404 when service not found', async () => {
+    const { catalogueRepo } = await import('../../src/cosmos/catalogue-repository.js');
+    (catalogueRepo.getServiceByIdCrossPartition as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const res = await createBookingHandler(postReq({
+      serviceId: 'missing', categoryId: 'c1', slotDate: '2026-05-01',
+      slotWindow: '10:00-12:00', addressText: 'addr', addressLatLng: { lat: 0, lng: 0 },
+    }), {} as never);
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Write failing confirm test** — `api/tests/bookings/confirm.test.ts`
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { HttpRequest } from '@azure/functions';
+
+vi.stubEnv('RAZORPAY_KEY_SECRET', 'rzp_secret');
+
+vi.mock('../../src/middleware/requireCustomer.js', () => ({
+  requireCustomer: (handler: Function) => (req: HttpRequest, ctx: unknown) =>
+    handler(req, ctx, { customerId: 'cust-1' }),
+}));
+
+vi.mock('../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: {
+    getById: vi.fn().mockResolvedValue({
+      id: 'bk-1', customerId: 'cust-1', status: 'PENDING_PAYMENT', paymentOrderId: 'order_1',
+    }),
+    confirmPayment: vi.fn().mockResolvedValue({ id: 'bk-1', status: 'SEARCHING' }),
+    createPending: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/services/razorpay.service.js', () => ({
+  createRazorpayOrder: vi.fn(),
+  verifyPaymentSignature: vi.fn().mockReturnValue(true),
+}));
+
+import { confirmBookingHandler } from '../../src/functions/bookings.js';
+
+function confirmReq(id: string, body: unknown) {
+  const req = new HttpRequest({
+    url: `http://localhost/api/v1/bookings/${id}/confirm`, method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: new Headers({ 'content-type': 'application/json' }),
+  });
+  Object.assign(req, { params: { id } });
+  return req;
+}
+
+describe('POST /v1/bookings/:id/confirm', () => {
+  it('returns 200 with SEARCHING status on valid signature', async () => {
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'pay_1', razorpayOrderId: 'order_1', razorpaySignature: 'sig' }),
+      {} as never,
+    );
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { status: string }).status).toBe('SEARCHING');
+  });
+
+  it('returns 400 on invalid signature', async () => {
+    const { verifyPaymentSignature } = await import('../../src/services/razorpay.service.js');
+    (verifyPaymentSignature as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 'bad' }),
+      {} as never,
+    );
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('SIGNATURE_INVALID');
+  });
+
+  it('returns 404 when booking not found', async () => {
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    (bookingRepo.getById as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    const res = await confirmBookingHandler(
+      confirmReq('missing', { razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 'sig' }),
+      {} as never,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when customerId does not match booking', async () => {
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    (bookingRepo.getById as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'bk-1', customerId: 'other-customer', status: 'PENDING_PAYMENT' });
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'p1', razorpayOrderId: 'o1', razorpaySignature: 'sig' }),
+      {} as never,
+    );
+    expect(res.status).toBe(403);
+  });
+});
+```
+
+- [ ] **Step 3: Run both — expect FAIL**
+
+```bash
+pnpm test tests/bookings/
+```
+
+- [ ] **Step 4: Create `api/src/functions/bookings.ts`**
+
+```typescript
+import type { HttpRequest, InvocationContext, HttpResponseInit, HttpHandler } from '@azure/functions';
+import { app } from '@azure/functions';
+import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
+import { bookingRepo } from '../cosmos/booking-repository.js';
+import { createRazorpayOrder, verifyPaymentSignature } from '../services/razorpay.service.js';
+import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+import type { CustomerContext } from '../types/customer.js';
+
+const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const body = await req.json().catch(() => null);
+  const parsed = CreateBookingRequestSchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+
+  const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
+  if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+
+  const order = await createRazorpayOrder({
+    amount: service.basePrice,
+    currency: 'INR',
+    receipt: `${customer.customerId}-${Date.now()}`,
+  });
+
+  const booking = await bookingRepo.createPending(parsed.data, customer.customerId, order.id, service.basePrice);
+  return { status: 201, jsonBody: { bookingId: booking.id, razorpayOrderId: order.id, amount: order.amount } };
+};
+
+const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const id = (req as unknown as { params: Record<string, string> }).params['id'];
+  const body = await req.json().catch(() => null);
+  const parsed = ConfirmBookingRequestSchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+
+  const booking = await bookingRepo.getById(id);
+  if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+  if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+
+  if (!verifyPaymentSignature({
+    razorpayOrderId: parsed.data.razorpayOrderId,
+    razorpayPaymentId: parsed.data.razorpayPaymentId,
+    razorpaySignature: parsed.data.razorpaySignature,
+  })) return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+
+  const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
+  if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
+
+  return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
+};
+
+export const createBookingHandler: HttpHandler = requireCustomer(createHandler);
+export const confirmBookingHandler: HttpHandler = requireCustomer(confirmHandler);
+
+app.http('createBooking', { route: 'v1/bookings', methods: ['POST'], handler: createBookingHandler });
+app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: confirmBookingHandler });
+```
+
+- [ ] **Step 5: Run all handler tests — expect PASS**
+
+```bash
+pnpm test tests/bookings/ tests/unit/requireCustomer.test.ts tests/schemas/booking.test.ts
+```
+Expected: all green.
+
+- [ ] **Step 6: Full API test suite**
+
+```bash
+pnpm test
+```
+Expected: no regressions (existing tests still pass).
+
+- [ ] **Step 7: Type-check**
+
+```bash
+pnpm typecheck
+```
+Expected: 0 errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/src/functions/bookings.ts api/tests/bookings/
+git commit -m "feat(E03-S03a/WS-A): POST /v1/bookings + POST /v1/bookings/:id/confirm (HMAC-verified)"
+```
+
+---
+
+## WS-B: Android Data Layer
+
+### Task B1: libs.versions.toml — Razorpay + Places SDK
+
+**Files:** `customer-app/gradle/libs.versions.toml`, `technician-app/gradle/libs.versions.toml`, `customer-app/app/build.gradle.kts`
+
+- [ ] **Step 1: Add to `[versions]` in `customer-app/gradle/libs.versions.toml`**
+
+```toml
+razorpay       = "1.6.40"
+googlePlaces   = "3.5.0"
+playServicesMaps = "19.0.0"
+```
+
+- [ ] **Step 2: Add to `[libraries]` in `customer-app/gradle/libs.versions.toml`**
+
+```toml
+razorpay-checkout  = { module = "com.razorpay:checkout",                                  version.ref = "razorpay" }
+google-places      = { module = "com.google.android.libraries.places:places",            version.ref = "googlePlaces" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps",             version.ref = "playServicesMaps" }
+```
+
+- [ ] **Step 3: Add dependencies to `customer-app/app/build.gradle.kts`** (in `dependencies {}` block)
+
+```kotlin
+implementation(libs.razorpay.checkout)
+implementation(libs.google.places)
+implementation(libs.play.services.maps)
+```
+
+- [ ] **Step 4: Add BuildConfig fields to `defaultConfig` in `build.gradle.kts`**
+
+```kotlin
+buildConfigField("String", "RAZORPAY_KEY_ID", "\"${System.getenv("RAZORPAY_KEY_ID") ?: ""}\"")
+buildConfigField("String", "MAPS_API_KEY",    "\"${System.getenv("MAPS_API_KEY") ?: ""}\"")
+manifestPlaceholders["MAPS_API_KEY"] = System.getenv("MAPS_API_KEY") ?: ""
+```
+
+- [ ] **Step 5: Add Maps API key meta-data to `AndroidManifest.xml`** inside `<application>`:
+
+```xml
+<meta-data
+    android:name="com.google.android.geo.API_KEY"
+    android:value="${MAPS_API_KEY}" />
+```
+
+- [ ] **Step 6: Copy libs.versions.toml byte-for-byte to technician-app** (libs.versions.toml sync invariant)
+
+```bash
+cp customer-app/gradle/libs.versions.toml technician-app/gradle/libs.versions.toml
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add customer-app/gradle/libs.versions.toml technician-app/gradle/libs.versions.toml \
+        customer-app/app/build.gradle.kts customer-app/app/src/main/AndroidManifest.xml
+git commit -m "feat(E03-S03a/WS-B): add Razorpay 1.6.40 + Places 3.5.0 to libs (sync to technician-app)"
+```
+
+---
+
+### Task B2: Booking domain models + use cases (TDD)
+
+**Package root:** `com.homeservices.customer`
+
+- [ ] **Step 1: Write failing use case tests**
+
+`customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/CreateBookingUseCaseTest.kt`:
+
+```kotlin
+package com.homeservices.customer.domain.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+public class CreateBookingUseCaseTest {
+    private val repo: BookingRepository = mockk()
+    private val sut = CreateBookingUseCase(repo)
+
+    private val request = BookingRequest(
+        serviceId = "svc-1", categoryId = "cat-1",
+        slot = BookingSlot(date = "2026-05-01", window = "10:00-12:00"),
+        addressText = "123 Main St", addressLat = 12.97, addressLng = 77.59,
+    )
+
+    @Test
+    public fun `invoke returns BookingResult on success`(): Unit = runTest {
+        val expected = BookingResult(bookingId = "bk-1", razorpayOrderId = "order_1", amount = 59900)
+        every { repo.createBooking(request) } returns flowOf(Result.success(expected))
+        assertThat(sut(request).first().getOrThrow()).isEqualTo(expected)
+        verify(exactly = 1) { repo.createBooking(request) }
+    }
+
+    @Test
+    public fun `invoke propagates repository failure`(): Unit = runTest {
+        every { repo.createBooking(request) } returns flowOf(Result.failure(RuntimeException("network error")))
+        assertThat(sut(request).first().isFailure).isTrue()
+    }
+}
+```
+
+`customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCaseTest.kt`:
+
+```kotlin
+package com.homeservices.customer.domain.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.BookingRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+public class ConfirmBookingUseCaseTest {
+    private val repo: BookingRepository = mockk()
+    private val sut = ConfirmBookingUseCase(repo)
+
+    @Test
+    public fun `invoke returns confirmed bookingId on success`(): Unit = runTest {
+        every { repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1") } returns flowOf(Result.success("bk-1"))
+        assertThat(sut("bk-1", "pay_1", "order_1", "sig_1").first().getOrThrow()).isEqualTo("bk-1")
+        verify(exactly = 1) { repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1") }
+    }
+
+    @Test
+    public fun `invoke propagates failure`(): Unit = runTest {
+        every { repo.confirmBooking(any(), any(), any(), any()) } returns flowOf(Result.failure(RuntimeException("confirm failed")))
+        assertThat(sut("bk-1", "pay_1", "order_1", "sig_1").first().isFailure).isTrue()
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL (compilation error — models not yet created)**
+
+```bash
+cd customer-app && ./gradlew testDebugUnitTest --tests "*.domain.booking.*" 2>&1 | tail -20
+```
+
+- [ ] **Step 3: Create domain model files**
+
+`domain/booking/model/BookingSlot.kt`:
+```kotlin
+package com.homeservices.customer.domain.booking.model
+
+public data class BookingSlot(val date: String, val window: String)
+```
+
+`domain/booking/model/BookingRequest.kt`:
+```kotlin
+package com.homeservices.customer.domain.booking.model
+
+public data class BookingRequest(
+    val serviceId: String,
+    val categoryId: String,
+    val slot: BookingSlot,
+    val addressText: String,
+    val addressLat: Double,
+    val addressLng: Double,
+)
+```
+
+`domain/booking/model/BookingResult.kt`:
+```kotlin
+package com.homeservices.customer.domain.booking.model
+
+public data class BookingResult(
+    val bookingId: String,
+    val razorpayOrderId: String,
+    val amount: Int,
+)
+```
+
+`domain/booking/model/PaymentResult.kt`:
+```kotlin
+package com.homeservices.customer.domain.booking.model
+
+public sealed class PaymentResult {
+    public data class Success(
+        val paymentId: String,
+        val orderId: String,
+        val signature: String,
+    ) : PaymentResult()
+
+    public data class Failure(
+        val code: Int,
+        val description: String,
+    ) : PaymentResult()
+}
+```
+
+- [ ] **Step 4: Create `BookingRepository` interface**
+
+`data/booking/BookingRepository.kt`:
+```kotlin
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import kotlinx.coroutines.flow.Flow
+
+public interface BookingRepository {
+    public fun createBooking(request: BookingRequest): Flow<Result<BookingResult>>
+    public fun confirmBooking(
+        bookingId: String,
+        paymentId: String,
+        orderId: String,
+        signature: String,
+    ): Flow<Result<String>>
+}
+```
+
+- [ ] **Step 5: Create use cases**
+
+`domain/booking/CreateBookingUseCase.kt`:
+```kotlin
+package com.homeservices.customer.domain.booking
+
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+public class CreateBookingUseCase @Inject constructor(private val repo: BookingRepository) {
+    public operator fun invoke(request: BookingRequest): Flow<Result<BookingResult>> =
+        repo.createBooking(request)
+}
+```
+
+`domain/booking/ConfirmBookingUseCase.kt`:
+```kotlin
+package com.homeservices.customer.domain.booking
+
+import com.homeservices.customer.data.booking.BookingRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+public class ConfirmBookingUseCase @Inject constructor(private val repo: BookingRepository) {
+    public operator fun invoke(
+        bookingId: String,
+        paymentId: String,
+        orderId: String,
+        signature: String,
+    ): Flow<Result<String>> = repo.confirmBooking(bookingId, paymentId, orderId, signature)
+}
+```
+
+- [ ] **Step 6: Run use case tests — expect PASS**
+
+```bash
+./gradlew testDebugUnitTest --tests "*.domain.booking.*"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ \
+        customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/
+git commit -m "feat(E03-S03a/WS-B): booking domain models + CreateBookingUseCase + ConfirmBookingUseCase TDD"
+```
+
+---
+
+### Task B3: BookingApiService + DTOs + BookingRepositoryImpl + PaymentResultBus + BookingModule
+
+**Files:** `data/booking/remote/dto/BookingDtos.kt`, `data/booking/remote/BookingApiService.kt`, `data/booking/BookingRepositoryImpl.kt`, `data/booking/PaymentResultBus.kt`, `data/booking/di/BookingModule.kt`
+
+- [ ] **Step 1: Create `data/booking/remote/dto/BookingDtos.kt`**
+
+```kotlin
+package com.homeservices.customer.data.booking.remote.dto
+
+import com.squareup.moshi.JsonClass
+import com.homeservices.customer.domain.booking.model.BookingResult
+
+@JsonClass(generateAdapter = true)
+public data class CreateBookingRequestDto(
+    val serviceId: String,
+    val categoryId: String,
+    val slotDate: String,
+    val slotWindow: String,
+    val addressText: String,
+    val addressLatLng: LatLngDto,
+)
+
+@JsonClass(generateAdapter = true)
+public data class LatLngDto(val lat: Double, val lng: Double)
+
+@JsonClass(generateAdapter = true)
+public data class CreateBookingResponseDto(
+    val bookingId: String,
+    val razorpayOrderId: String,
+    val amount: Int,
+) {
+    public fun toDomain(): BookingResult = BookingResult(bookingId, razorpayOrderId, amount)
+}
+
+@JsonClass(generateAdapter = true)
+public data class ConfirmBookingRequestDto(
+    val razorpayPaymentId: String,
+    val razorpayOrderId: String,
+    val razorpaySignature: String,
+)
+
+@JsonClass(generateAdapter = true)
+public data class ConfirmBookingResponseDto(val bookingId: String, val status: String)
+```
+
+- [ ] **Step 2: Create `data/booking/remote/BookingApiService.kt`**
+
+```kotlin
+package com.homeservices.customer.data.booking.remote
+
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingResponseDto
+import retrofit2.http.Body
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+public interface BookingApiService {
+    @POST("v1/bookings")
+    public suspend fun createBooking(@Body body: CreateBookingRequestDto): CreateBookingResponseDto
+
+    @POST("v1/bookings/{id}/confirm")
+    public suspend fun confirmBooking(
+        @Path("id") bookingId: String,
+        @Body body: ConfirmBookingRequestDto,
+    ): ConfirmBookingResponseDto
+}
+```
+
+- [ ] **Step 3: Create `data/booking/BookingRepositoryImpl.kt`**
+
+```kotlin
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.LatLngDto
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+internal class BookingRepositoryImpl @Inject constructor(
+    private val api: BookingApiService,
+) : BookingRepository {
+
+    override fun createBooking(request: BookingRequest): Flow<Result<BookingResult>> = flow {
+        emit(runCatching {
+            api.createBooking(
+                CreateBookingRequestDto(
+                    serviceId = request.serviceId,
+                    categoryId = request.categoryId,
+                    slotDate = request.slot.date,
+                    slotWindow = request.slot.window,
+                    addressText = request.addressText,
+                    addressLatLng = LatLngDto(lat = request.addressLat, lng = request.addressLng),
+                ),
+            ).toDomain()
+        })
+    }
+
+    override fun confirmBooking(
+        bookingId: String,
+        paymentId: String,
+        orderId: String,
+        signature: String,
+    ): Flow<Result<String>> = flow {
+        emit(runCatching {
+            api.confirmBooking(
+                bookingId,
+                ConfirmBookingRequestDto(
+                    razorpayPaymentId = paymentId,
+                    razorpayOrderId = orderId,
+                    razorpaySignature = signature,
+                ),
+            ).bookingId
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Create `data/booking/PaymentResultBus.kt`**
+
+```kotlin
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.domain.booking.model.PaymentResult
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+public class PaymentResultBus @Inject constructor() {
+    private val _results = MutableSharedFlow<PaymentResult>(extraBufferCapacity = 1)
+    public val results: SharedFlow<PaymentResult> = _results.asSharedFlow()
+
+    public fun post(result: PaymentResult) {
+        _results.tryEmit(result)
+    }
+}
+```
+
+- [ ] **Step 5: Create `data/booking/di/BookingModule.kt`**
+
+```kotlin
+package com.homeservices.customer.data.booking.di
+
+import com.google.firebase.auth.FirebaseAuth
+import com.homeservices.customer.BuildConfig
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.data.booking.BookingRepositoryImpl
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.squareup.moshi.Moshi
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+public annotation class AuthOkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+public abstract class BookingModule {
+
+    @Binds
+    internal abstract fun bindBookingRepository(impl: BookingRepositoryImpl): BookingRepository
+
+    public companion object {
+
+        @Provides
+        @Singleton
+        @AuthOkHttpClient
+        public fun provideAuthOkHttpClient(): OkHttpClient =
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val token = runBlocking {
+                        FirebaseAuth.getInstance().currentUser
+                            ?.getIdToken(false)
+                            ?.await()
+                            ?.token
+                    }
+                    val req = if (token != null) {
+                        chain.request().newBuilder()
+                            .header("Authorization", "Bearer $token")
+                            .build()
+                    } else {
+                        chain.request()
+                    }
+                    chain.proceed(req)
+                }
+                .addInterceptor(
+                    HttpLoggingInterceptor().apply {
+                        level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+                        else HttpLoggingInterceptor.Level.NONE
+                    },
+                )
+                .build()
+
+        @Provides
+        @Singleton
+        public fun provideBookingApiService(
+            @AuthOkHttpClient client: OkHttpClient,
+            moshi: Moshi,
+        ): BookingApiService =
+            Retrofit.Builder()
+                .baseUrl(BuildConfig.API_BASE_URL + "/")
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .client(client)
+                .build()
+                .create(BookingApiService::class.java)
+    }
+}
+```
+
+> **Note:** `Moshi` is provided by `CatalogueModule`. Hilt resolves this automatically within `SingletonComponent`.
+
+- [ ] **Step 6: Verify compilation (assembleDebug)**
+
+```bash
+cd customer-app && ./gradlew assembleDebug 2>&1 | tail -20
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 7: Run all unit tests**
+
+```bash
+./gradlew testDebugUnitTest 2>&1 | tail -10
+```
+Expected: no regressions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/
+git commit -m "feat(E03-S03a/WS-B): BookingRepositoryImpl + DTOs + PaymentResultBus + BookingModule (Hilt)"
+```
+
+---
+
+## WS-E (partial): API smoke gate
+
+### Task E0: Run API smoke gate before push
+
+- [ ] **Step 1: Run API smoke gate**
+
+```bash
+cd "C:/Alok/Business Projects/Urbanclap-dup/.worktrees/e03-s03"
+bash tools/pre-codex-smoke-api.sh
+```
+Non-zero exit = stop and fix before proceeding.
+
+- [ ] **Step 2: Commit plan files**
+
+```bash
+git add plans/E03-S03a.md plans/E03-S03b.md
+git commit -m "plan(E03-S03): split plan — E03-S03a (API+data) + E03-S03b (UI+nav+smoke)"
+```
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin feature/E03-S03-booking-creation
+```
+
+---
+
+*Continued in `plans/E03-S03b.md` — UI, navigation, Razorpay Checkout, Paparazzi stubs, admin web validation, Codex review.*

--- a/plans/E03-S03b.md
+++ b/plans/E03-S03b.md
@@ -1,0 +1,1133 @@
+# E03-S03b — Booking Creation: Android UI + Navigation + Smoke Gate
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans.
+> **Depends on:** E03-S03a must be merged first (domain models, BookingRepository, PaymentResultBus required).
+
+**Goal:** 4-screen booking UI (SlotPicker → Address → Summary → Confirmed), Razorpay Checkout callbackFlow integration, navigation wiring, admin web validation, pre-Codex smoke gate.
+
+**Tech Stack:** Kotlin + Compose, Razorpay Checkout SDK 1.6.40, Google Maps Places SDK 3.5.0, Hilt, Paparazzi.
+
+---
+
+## Pattern References
+
+| Pattern | File | Applies to |
+|---|---|---|
+| callbackFlow lifecycle | `docs/patterns/firebase-callbackflow-lifecycle.md` | RazorpayPaymentUseCase |
+| Kotlin explicit-API | `docs/patterns/kotlin-explicit-api-public-modifier.md` | All new Kotlin files |
+| Paparazzi CI-only goldens | `docs/patterns/paparazzi-cross-os-goldens.md` | All 4 new screens |
+
+---
+
+## File Map
+
+| | Path |
+|---|---|
+| Create | `…/domain/booking/RazorpayPaymentUseCase.kt` |
+| Create | `…/ui/booking/BookingUiState.kt` |
+| Create | `…/ui/booking/BookingViewModel.kt` |
+| Create | `…/ui/booking/SlotPickerScreen.kt` |
+| Create | `…/ui/booking/AddressScreen.kt` |
+| Create | `…/ui/booking/BookingSummaryScreen.kt` |
+| Create | `…/ui/booking/BookingConfirmedScreen.kt` |
+| Create | `…/navigation/BookingRoutes.kt` |
+| Modify | `…/navigation/MainGraph.kt` |
+| Modify | `…/MainActivity.kt` |
+| Modify | `…/HomeservicesCustomerApplication.kt` |
+| Create | Test: `RazorpayPaymentUseCaseTest.kt` |
+| Create | Test: `BookingViewModelTest.kt` |
+| Create | Test: `SlotPickerScreenPaparazziTest.kt` |
+| Create | Test: `AddressScreenPaparazziTest.kt` |
+| Create | Test: `BookingSummaryScreenPaparazziTest.kt` |
+| Create | Test: `BookingConfirmedScreenPaparazziTest.kt` |
+
+---
+
+## WS-C: Razorpay Checkout SDK + ViewModel + Screens
+
+### Task C1: RazorpayPaymentUseCase (callbackFlow)
+
+- [ ] **Step 1: Write failing test** — `domain/booking/RazorpayPaymentUseCaseTest.kt`
+
+```kotlin
+package com.homeservices.customer.domain.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.PaymentResultBus
+import com.homeservices.customer.domain.booking.model.PaymentResult
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+public class RazorpayPaymentUseCaseTest {
+    private val bus = PaymentResultBus()
+    private val sut = RazorpayPaymentUseCase(bus)
+
+    @Test
+    public fun `resultFlow emits Success when bus posts success`(): Unit = runTest {
+        bus.post(PaymentResult.Success(paymentId = "pay_1", orderId = "order_1", signature = "sig_1"))
+        val result = sut.resultFlow().first()
+        assertThat(result).isInstanceOf(PaymentResult.Success::class.java)
+        assertThat((result as PaymentResult.Success).paymentId).isEqualTo("pay_1")
+    }
+
+    @Test
+    public fun `resultFlow emits Failure when bus posts failure`(): Unit = runTest {
+        bus.post(PaymentResult.Failure(code = 2, description = "cancelled"))
+        val result = sut.resultFlow().first()
+        assertThat(result).isInstanceOf(PaymentResult.Failure::class.java)
+        assertThat((result as PaymentResult.Failure).code).isEqualTo(2)
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd customer-app && ./gradlew testDebugUnitTest --tests "*.RazorpayPaymentUseCaseTest" 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Create `domain/booking/RazorpayPaymentUseCase.kt`**
+
+```kotlin
+package com.homeservices.customer.domain.booking
+
+import android.app.Activity
+import com.homeservices.customer.BuildConfig
+import com.homeservices.customer.data.booking.PaymentResultBus
+import com.homeservices.customer.domain.booking.model.PaymentResult
+import com.razorpay.Checkout
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import javax.inject.Inject
+
+public class RazorpayPaymentUseCase @Inject constructor(private val bus: PaymentResultBus) {
+
+    public fun resultFlow(): Flow<PaymentResult> = bus.results
+
+    public fun open(
+        activity: Activity,
+        orderId: String,
+        amount: Int,
+        customerPhone: String,
+    ): Flow<PaymentResult> = callbackFlow {
+        // Subscribe BEFORE opening checkout — avoids missing the result
+        val job = launch {
+            bus.results.first().also { trySend(it); close() }
+        }
+
+        val checkout = Checkout()
+        checkout.setKeyID(BuildConfig.RAZORPAY_KEY_ID)
+        val options = JSONObject().apply {
+            put("name", "HomeServices")
+            put("description", "Service Booking")
+            put("order_id", orderId)
+            put("amount", amount)
+            put("currency", "INR")
+            put("prefill", JSONObject().apply { put("contact", customerPhone) })
+            put("theme", JSONObject().apply { put("color", "#1A73E8") })
+        }
+        checkout.open(activity, options)
+
+        awaitClose { job.cancel() }
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+./gradlew testDebugUnitTest --tests "*.RazorpayPaymentUseCaseTest"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/RazorpayPaymentUseCase.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/RazorpayPaymentUseCaseTest.kt
+git commit -m "feat(E03-S03b/WS-C): RazorpayPaymentUseCase — callbackFlow bridging PaymentResultBus"
+```
+
+---
+
+### Task C2: BookingUiState + BookingViewModel (TDD)
+
+- [ ] **Step 1: Write failing ViewModel test** — `ui/booking/BookingViewModelTest.kt`
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.domain.booking.ConfirmBookingUseCase
+import com.homeservices.customer.domain.booking.CreateBookingUseCase
+import com.homeservices.customer.domain.booking.RazorpayPaymentUseCase
+import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import com.homeservices.customer.domain.booking.model.PaymentResult
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class BookingViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val create: CreateBookingUseCase = mockk()
+    private val confirm: ConfirmBookingUseCase = mockk()
+    private val payment: RazorpayPaymentUseCase = mockk()
+    private lateinit var vm: BookingViewModel
+
+    @Before public fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        vm = BookingViewModel(create, confirm, payment)
+    }
+
+    @After public fun tearDown() { Dispatchers.resetMain() }
+
+    @Test public fun `initial state is SelectingSlot`() {
+        assertThat(vm.uiState.value).isInstanceOf(BookingUiState.SelectingSlot::class.java)
+    }
+
+    @Test public fun `onSlotSelected transitions to EnteringAddress`() {
+        vm.onSlotSelected(BookingSlot("2026-05-01", "10:00-12:00"))
+        assertThat(vm.uiState.value).isInstanceOf(BookingUiState.EnteringAddress::class.java)
+    }
+
+    @Test public fun `onAddressSelected transitions to ReviewingSummary`() = runTest {
+        vm.onSlotSelected(BookingSlot("2026-05-01", "10:00-12:00"))
+        vm.onAddressSelected("123 St", 12.97, 77.59)
+        dispatcher.scheduler.advanceUntilIdle()
+        assertThat(vm.uiState.value).isInstanceOf(BookingUiState.ReviewingSummary::class.java)
+    }
+
+    @Test public fun `onPayTapped transitions to AwaitingPayment on successful createBooking`() = runTest {
+        vm.onSlotSelected(BookingSlot("2026-05-01", "10:00-12:00"))
+        vm.onAddressSelected("123 St", 12.97, 77.59)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        every { create(any()) } returns flowOf(Result.success(BookingResult("bk-1", "order_1", 59900)))
+        every { payment.open(any(), any(), any(), any()) } returns emptyFlow()
+
+        vm.onPayTapped(mockk(relaxed = true), "svc-1", "cat-1", "+919876543210")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertThat(vm.uiState.value).isInstanceOf(BookingUiState.AwaitingPayment::class.java)
+    }
+
+    @Test public fun `onPayTapped transitions to Error on createBooking failure`() = runTest {
+        vm.onSlotSelected(BookingSlot("2026-05-01", "10:00-12:00"))
+        vm.onAddressSelected("123 St", 12.97, 77.59)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        every { create(any()) } returns flowOf(Result.failure(RuntimeException("network")))
+
+        vm.onPayTapped(mockk(relaxed = true), "svc-1", "cat-1", "+919876543210")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertThat(vm.uiState.value).isInstanceOf(BookingUiState.Error::class.java)
+    }
+
+    @Test public fun `payment success triggers confirm and transitions to Confirmed`() = runTest {
+        vm.onSlotSelected(BookingSlot("2026-05-01", "10:00-12:00"))
+        vm.onAddressSelected("123 St", 12.97, 77.59)
+        dispatcher.scheduler.advanceUntilIdle()
+
+        val successResult = PaymentResult.Success("pay_1", "order_1", "sig_1")
+        every { create(any()) } returns flowOf(Result.success(BookingResult("bk-1", "order_1", 59900)))
+        every { payment.open(any(), any(), any(), any()) } returns flowOf(successResult)
+        every { confirm("bk-1", "pay_1", "order_1", "sig_1") } returns flowOf(Result.success("bk-1"))
+
+        vm.onPayTapped(mockk(relaxed = true), "svc-1", "cat-1", "+919876543210")
+        dispatcher.scheduler.advanceUntilIdle()
+
+        assertThat(vm.uiState.value).isInstanceOf(BookingUiState.Confirmed::class.java)
+        assertThat((vm.uiState.value as BookingUiState.Confirmed).bookingId).isEqualTo("bk-1")
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+./gradlew testDebugUnitTest --tests "*.BookingViewModelTest" 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Create `ui/booking/BookingUiState.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.BookingSlot
+
+public sealed class BookingUiState {
+    public object SelectingSlot : BookingUiState()
+    public data class EnteringAddress(val slot: BookingSlot) : BookingUiState()
+    public data class ReviewingSummary(
+        val slot: BookingSlot,
+        val addressText: String,
+        val addressLat: Double,
+        val addressLng: Double,
+    ) : BookingUiState()
+    public data class AwaitingPayment(
+        val bookingResult: BookingResult,
+        val customerPhone: String,
+    ) : BookingUiState()
+    public data class Confirmed(val bookingId: String) : BookingUiState()
+    public data class Error(val message: String, val retryable: Boolean = true) : BookingUiState()
+}
+```
+
+- [ ] **Step 4: Create `ui/booking/BookingViewModel.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import android.app.Activity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homeservices.customer.domain.booking.ConfirmBookingUseCase
+import com.homeservices.customer.domain.booking.CreateBookingUseCase
+import com.homeservices.customer.domain.booking.RazorpayPaymentUseCase
+import com.homeservices.customer.domain.booking.model.BookingRequest
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import com.homeservices.customer.domain.booking.model.PaymentResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+public class BookingViewModel @Inject constructor(
+    private val createBookingUseCase: CreateBookingUseCase,
+    private val confirmBookingUseCase: ConfirmBookingUseCase,
+    private val razorpayPaymentUseCase: RazorpayPaymentUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<BookingUiState>(BookingUiState.SelectingSlot)
+    public val uiState: StateFlow<BookingUiState> = _uiState.asStateFlow()
+
+    public fun onSlotSelected(slot: BookingSlot) {
+        _uiState.value = BookingUiState.EnteringAddress(slot = slot)
+    }
+
+    public fun onAddressSelected(addressText: String, lat: Double, lng: Double) {
+        val current = uiState.value as? BookingUiState.EnteringAddress ?: return
+        _uiState.value = BookingUiState.ReviewingSummary(
+            slot = current.slot, addressText = addressText, addressLat = lat, addressLng = lng,
+        )
+    }
+
+    public fun onPayTapped(activity: Activity, serviceId: String, categoryId: String, customerPhone: String) {
+        val summary = uiState.value as? BookingUiState.ReviewingSummary ?: return
+        viewModelScope.launch {
+            val request = BookingRequest(
+                serviceId = serviceId, categoryId = categoryId,
+                slot = summary.slot, addressText = summary.addressText,
+                addressLat = summary.addressLat, addressLng = summary.addressLng,
+            )
+            createBookingUseCase(request).collect { result ->
+                result.fold(
+                    onSuccess = { bookingResult ->
+                        _uiState.value = BookingUiState.AwaitingPayment(bookingResult, customerPhone)
+                        razorpayPaymentUseCase.open(activity, bookingResult.razorpayOrderId, bookingResult.amount, customerPhone)
+                            .collect { paymentResult -> handlePaymentResult(bookingResult.bookingId, paymentResult) }
+                    },
+                    onFailure = { _uiState.value = BookingUiState.Error(it.message ?: "Failed to create booking") },
+                )
+            }
+        }
+    }
+
+    private fun handlePaymentResult(bookingId: String, result: PaymentResult) {
+        when (result) {
+            is PaymentResult.Success -> viewModelScope.launch {
+                confirmBookingUseCase(bookingId, result.paymentId, result.orderId, result.signature)
+                    .collect { confirmResult ->
+                        confirmResult.fold(
+                            onSuccess = { _uiState.value = BookingUiState.Confirmed(bookingId) },
+                            onFailure = { _uiState.value = BookingUiState.Error("Booking confirmed but confirmation failed — contact support") },
+                        )
+                    }
+            }
+            is PaymentResult.Failure -> _uiState.value = BookingUiState.Error(
+                "Payment failed: ${result.description}", retryable = true,
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run ViewModel tests — expect PASS**
+
+```bash
+./gradlew testDebugUnitTest --tests "*.BookingViewModelTest"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/BookingUiState.kt \
+        customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/BookingViewModel.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/BookingViewModelTest.kt
+git commit -m "feat(E03-S03b/WS-C): BookingUiState + BookingViewModel TDD (SelectingSlot → Confirmed)"
+```
+
+---
+
+### Task C3: SlotPickerScreen + Paparazzi stub
+
+- [ ] **Step 1: Create `ui/booking/SlotPickerScreen.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+private val TIME_WINDOWS = listOf(
+    "08:00-10:00", "10:00-12:00", "12:00-14:00",
+    "14:00-16:00", "16:00-18:00", "18:00-20:00",
+)
+private val DATE_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE\ndd MMM")
+
+@Composable
+internal fun SlotPickerScreen(
+    onSlotSelected: (BookingSlot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SlotPickerContent(
+        today = LocalDate.now(),
+        selectedSlot = null,
+        onSlotSelected = onSlotSelected,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun SlotPickerContent(
+    today: LocalDate,
+    selectedSlot: BookingSlot?,
+    onSlotSelected: (BookingSlot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val days = (0..6).map { today.plusDays(it.toLong()) }
+    var selectedDay by remember { mutableStateOf(selectedSlot?.date ?: today.toString()) }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+    ) {
+        Text("Select Date & Time", style = MaterialTheme.typography.headlineSmall)
+        Spacer(Modifier.height(16.dp))
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            items(days) { day ->
+                val dateStr = day.toString()
+                val isSelected = selectedDay == dateStr
+                OutlinedButton(
+                    onClick = { selectedDay = dateStr },
+                    border = BorderStroke(
+                        width = if (isSelected) 2.dp else 1.dp,
+                        color = if (isSelected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.outline,
+                    ),
+                    modifier = Modifier.width(72.dp),
+                ) {
+                    Text(
+                        text = day.format(DATE_FMT),
+                        style = MaterialTheme.typography.labelSmall,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(24.dp))
+        Text("Available Slots", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.height(8.dp))
+        TIME_WINDOWS.forEach { window ->
+            val slot = BookingSlot(date = selectedDay, window = window)
+            val startHour = window.substringBefore(":").toIntOrNull() ?: 0
+            val isPast = selectedDay == today.toString() && startHour <= today.hour
+            val isSelected = selectedSlot == slot
+            OutlinedButton(
+                onClick = { if (!isPast) onSlotSelected(slot) },
+                enabled = !isPast,
+                colors = if (isSelected) ButtonDefaults.outlinedButtonColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                ) else ButtonDefaults.outlinedButtonColors(),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            ) { Text(window) }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create `SlotPickerScreenPaparazziTest.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDate
+
+public class SlotPickerScreenPaparazziTest {
+    @get:Rule
+    public val paparazzi: Paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material3.DayNight.NoActionBar",
+    )
+
+    @Test public fun noSelection_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(today = LocalDate.of(2026, 5, 1), selectedSlot = null, onSlotSelected = {})
+            }
+        }
+    }
+
+    @Test public fun withSelection_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(today = LocalDate.of(2026, 5, 1), selectedSlot = BookingSlot("2026-05-01", "10:00-12:00"), onSlotSelected = {})
+            }
+        }
+    }
+
+    @Test public fun noSelection_darkTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = true) {
+                SlotPickerContent(today = LocalDate.of(2026, 5, 1), selectedSlot = null, onSlotSelected = {})
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run Paparazzi test (compile check only — no goldens on Windows)**
+
+```bash
+./gradlew testDebugUnitTest --tests "*.SlotPickerScreenPaparazziTest" 2>&1 | grep -E "PASS|FAIL|BUILD" | head -5
+```
+Expected: `BUILD SUCCESSFUL` (Paparazzi runs but records no goldens since `snapshots/images/` is absent)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreenPaparazziTest.kt
+git commit -m "feat(E03-S03b/WS-C): SlotPickerScreen — 7-day × 6-slot grid + Paparazzi stub"
+```
+
+---
+
+### Task C4: AddressScreen + Paparazzi stub
+
+- [ ] **Step 1: Initialize Places SDK in `HomeservicesCustomerApplication.kt`**
+
+In `onCreate()` add:
+```kotlin
+if (!Places.isInitialized()) {
+    Places.initialize(applicationContext, BuildConfig.MAPS_API_KEY)
+}
+```
+Add import: `import com.google.android.libraries.places.api.Places`
+
+- [ ] **Step 2: Create `ui/booking/AddressScreen.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.widget.Autocomplete
+import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
+
+@Composable
+internal fun AddressScreen(
+    onAddressSelected: (address: String, lat: Double, lng: Double) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    var query by remember { mutableStateOf("") }
+    var selectedAddress by remember { mutableStateOf<String?>(null) }
+
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+            val place = Autocomplete.getPlaceFromIntent(result.data!!)
+            val latLng = place.latLng
+            if (latLng != null) {
+                val address = place.address ?: ""
+                selectedAddress = address
+                query = address
+                onAddressSelected(address, latLng.latitude, latLng.longitude)
+            }
+        }
+    }
+
+    AddressContent(
+        query = query,
+        selectedAddress = selectedAddress,
+        onQueryChange = { q ->
+            query = q
+            if (q.length >= 2) {
+                val intent = Autocomplete.IntentBuilder(
+                    AutocompleteActivityMode.OVERLAY,
+                    listOf(Place.Field.ADDRESS, Place.Field.LAT_LNG),
+                ).setInitialQuery(q).build(context)
+                launcher.launch(intent)
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun AddressContent(
+    query: String,
+    selectedAddress: String?,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        Text("Enter Service Address", style = MaterialTheme.typography.headlineSmall)
+        Spacer(Modifier.height(16.dp))
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            label = { Text("Search address") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+        if (selectedAddress != null) {
+            Spacer(Modifier.height(12.dp))
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(12.dp)) {
+                    Text("Confirmed address", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
+                    Text(selectedAddress, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Create `AddressScreenPaparazziTest.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import org.junit.Rule
+import org.junit.Test
+
+public class AddressScreenPaparazziTest {
+    @get:Rule
+    public val paparazzi: Paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material3.DayNight.NoActionBar",
+    )
+
+    @Test public fun empty_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                AddressContent(query = "", selectedAddress = null, onQueryChange = {})
+            }
+        }
+    }
+
+    @Test public fun withQuery_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                AddressContent(query = "MG Road", selectedAddress = null, onQueryChange = {})
+            }
+        }
+    }
+
+    @Test public fun withSelection_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                AddressContent(query = "MG Road, Bengaluru", selectedAddress = "MG Road, Bengaluru, Karnataka 560001", onQueryChange = {})
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/AddressScreen.kt \
+        customer-app/app/src/main/kotlin/com/homeservices/customer/HomeservicesCustomerApplication.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/AddressScreenPaparazziTest.kt
+git commit -m "feat(E03-S03b/WS-C): AddressScreen — Places autocomplete + Paparazzi stub"
+```
+
+---
+
+### Task C5: BookingSummaryScreen + BookingConfirmedScreen + Paparazzi stubs
+
+- [ ] **Step 1: Create `ui/booking/BookingSummaryScreen.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.homeservices.customer.domain.booking.model.BookingSlot
+
+@Composable
+internal fun BookingSummaryScreen(
+    serviceName: String,
+    servicePrice: Int,
+    slot: BookingSlot,
+    addressText: String,
+    onPayTapped: () -> Unit,
+    isLoading: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        Text("Booking Summary", style = MaterialTheme.typography.headlineSmall)
+        Spacer(Modifier.height(16.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(serviceName, style = MaterialTheme.typography.titleMedium)
+                Text("${slot.date}  ·  ${slot.window}", style = MaterialTheme.typography.bodyMedium)
+                Text(addressText, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                HorizontalDivider()
+                Text("₹${servicePrice / 100}", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.primary)
+            }
+        }
+        Spacer(Modifier.weight(1f))
+        Button(
+            onClick = onPayTapped,
+            enabled = !isLoading,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+        ) {
+            if (isLoading) CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            else Text("Pay ₹${servicePrice / 100}")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create `ui/booking/BookingConfirmedScreen.kt`**
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun BookingConfirmedScreen(
+    bookingId: String,
+    onGoHome: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.CheckCircle,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(72.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        Text("Booking Confirmed!", style = MaterialTheme.typography.headlineMedium)
+        Spacer(Modifier.height(8.dp))
+        Text("ID: $bookingId", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(24.dp))
+        CircularProgressIndicator()
+        Spacer(Modifier.height(8.dp))
+        Text("Finding a technician…", style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(32.dp))
+        OutlinedButton(onClick = onGoHome) { Text("Back to Home") }
+    }
+}
+```
+
+- [ ] **Step 3: Create Paparazzi stubs** — `BookingSummaryScreenPaparazziTest.kt` and `BookingConfirmedScreenPaparazziTest.kt`
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.customer.domain.booking.model.BookingSlot
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import org.junit.Rule
+import org.junit.Test
+
+public class BookingSummaryScreenPaparazziTest {
+    @get:Rule public val paparazzi: Paparazzi = Paparazzi(deviceConfig = DeviceConfig.PIXEL_5, theme = "android:Theme.Material3.DayNight.NoActionBar")
+
+    @Test public fun idle_lightTheme() {
+        paparazzi.snapshot { HomeservicesTheme(darkTheme = false) { BookingSummaryScreen(serviceName = "AC Deep Clean", servicePrice = 59900, slot = BookingSlot("2026-05-01", "10:00-12:00"), addressText = "123 Main St, Bengaluru", onPayTapped = {}, isLoading = false) } }
+    }
+
+    @Test public fun loading_lightTheme() {
+        paparazzi.snapshot { HomeservicesTheme(darkTheme = false) { BookingSummaryScreen(serviceName = "AC Deep Clean", servicePrice = 59900, slot = BookingSlot("2026-05-01", "10:00-12:00"), addressText = "123 Main St", onPayTapped = {}, isLoading = true) } }
+    }
+}
+```
+
+```kotlin
+package com.homeservices.customer.ui.booking
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import org.junit.Rule
+import org.junit.Test
+
+public class BookingConfirmedScreenPaparazziTest {
+    @get:Rule public val paparazzi: Paparazzi = Paparazzi(deviceConfig = DeviceConfig.PIXEL_5, theme = "android:Theme.Material3.DayNight.NoActionBar")
+
+    @Test public fun confirmed_lightTheme() {
+        paparazzi.snapshot { HomeservicesTheme(darkTheme = false) { BookingConfirmedScreen(bookingId = "bk-abc123", onGoHome = {}) } }
+    }
+
+    @Test public fun confirmed_darkTheme() {
+        paparazzi.snapshot { HomeservicesTheme(darkTheme = true) { BookingConfirmedScreen(bookingId = "bk-abc123", onGoHome = {}) } }
+    }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/BookingSummaryScreen.kt \
+        customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/BookingConfirmedScreen.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/BookingSummaryScreenPaparazziTest.kt \
+        customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/BookingConfirmedScreenPaparazziTest.kt
+git commit -m "feat(E03-S03b/WS-C): BookingSummaryScreen + BookingConfirmedScreen + Paparazzi stubs"
+```
+
+---
+
+### Task C6: Navigation wiring + MainActivity + enable Book Now CTA
+
+- [ ] **Step 1: Create `navigation/BookingRoutes.kt`**
+
+```kotlin
+package com.homeservices.customer.navigation
+
+import java.net.URLEncoder
+
+internal object BookingRoutes {
+    const val SLOT_PICKER = "booking/{serviceId}/{categoryId}/{serviceName}/{servicePrice}"
+    const val CONFIRMED  = "booking_confirmed/{bookingId}"
+
+    fun slotPicker(serviceId: String, categoryId: String, serviceName: String, servicePrice: Int): String {
+        val encodedName = URLEncoder.encode(serviceName, "UTF-8")
+        return "booking/$serviceId/$categoryId/$encodedName/$servicePrice"
+    }
+
+    fun confirmed(bookingId: String) = "booking_confirmed/$bookingId"
+}
+```
+
+- [ ] **Step 2: Modify `navigation/MainGraph.kt`** — add booking graph, enable `onBookNow`
+
+Replace `onBookNow = { /* E03-S03 */ }` in the `ServiceDetailScreen` composable:
+```kotlin
+onBookNow = {
+    val s = vm.uiState.value
+    if (s is ServiceDetailUiState.Success) {
+        navController.navigate(
+            BookingRoutes.slotPicker(serviceId, s.service.categoryId, s.service.name, s.service.basePrice)
+        )
+    }
+},
+```
+
+Add to `mainGraph` navigation block after the existing catalogue composables:
+
+```kotlin
+composable(
+    route = BookingRoutes.SLOT_PICKER,
+    arguments = listOf(
+        navArgument("serviceId") { type = NavType.StringType },
+        navArgument("categoryId") { type = NavType.StringType },
+        navArgument("serviceName") { type = NavType.StringType },
+        navArgument("servicePrice") { type = NavType.IntType },
+    ),
+) { backStack ->
+    val serviceId   = backStack.arguments?.getString("serviceId") ?: return@composable
+    val categoryId  = backStack.arguments?.getString("categoryId") ?: return@composable
+    val serviceName = backStack.arguments?.getString("serviceName")?.let { java.net.URLDecoder.decode(it, "UTF-8") } ?: ""
+    val servicePrice = backStack.arguments?.getInt("servicePrice") ?: 0
+    val vm: BookingViewModel = hiltViewModel()
+    val uiState by vm.uiState.collectAsStateWithLifecycle()
+    val activity = LocalContext.current as Activity
+    LaunchedEffect(uiState) {
+        if (uiState is BookingUiState.Confirmed) {
+            navController.navigate(BookingRoutes.confirmed((uiState as BookingUiState.Confirmed).bookingId)) {
+                popUpTo(BookingRoutes.SLOT_PICKER) { inclusive = true }
+            }
+        }
+    }
+    when (val s = uiState) {
+        is BookingUiState.SelectingSlot   -> SlotPickerScreen(onSlotSelected = vm::onSlotSelected)
+        is BookingUiState.EnteringAddress -> AddressScreen(onAddressSelected = vm::onAddressSelected)
+        is BookingUiState.ReviewingSummary -> BookingSummaryScreen(
+            serviceName  = serviceName, servicePrice = servicePrice,
+            slot         = s.slot, addressText = s.addressText,
+            onPayTapped  = { vm.onPayTapped(activity, serviceId, categoryId, "") },
+            isLoading    = false,
+        )
+        is BookingUiState.AwaitingPayment -> BookingSummaryScreen(
+            serviceName = serviceName, servicePrice = servicePrice,
+            slot = s.bookingResult.let { BookingSlot(date = "", window = "") },
+            addressText = "", onPayTapped = {}, isLoading = true,
+        )
+        is BookingUiState.Error -> {
+            LaunchedEffect(s) {
+                snackbarHostState.showSnackbar(s.message)
+            }
+        }
+        else -> Unit
+    }
+}
+composable(
+    route = BookingRoutes.CONFIRMED,
+    arguments = listOf(navArgument("bookingId") { type = NavType.StringType }),
+) { backStack ->
+    val bookingId = backStack.arguments?.getString("bookingId") ?: ""
+    BookingConfirmedScreen(
+        bookingId = bookingId,
+        onGoHome  = { navController.navigate(CatalogueRoutes.HOME) { popUpTo(0) { inclusive = true } } },
+    )
+}
+```
+
+> **Note:** `snackbarHostState` must be added to `mainGraph` signature. Add `val snackbarHostState: SnackbarHostState` parameter and wire from `AppNavigation`'s `Scaffold`.
+
+- [ ] **Step 3: Modify `MainActivity.kt`** — implement `PaymentResultWithDataListener`
+
+```kotlin
+// Change class declaration:
+@AndroidEntryPoint
+class MainActivity : FragmentActivity(), PaymentResultWithDataListener {
+
+// Add:
+@Inject lateinit var paymentResultBus: PaymentResultBus
+
+// Add overrides:
+override fun onPaymentSuccess(razorpayPaymentId: String?, data: PaymentData?) {
+    paymentResultBus.post(
+        PaymentResult.Success(
+            paymentId = razorpayPaymentId ?: "",
+            orderId   = data?.orderId ?: "",
+            signature = data?.signature ?: "",
+        ),
+    )
+}
+
+override fun onPaymentError(code: Int, description: String?, data: PaymentData?) {
+    paymentResultBus.post(PaymentResult.Failure(code = code, description = description ?: "Payment cancelled"))
+}
+```
+
+Imports to add: `com.razorpay.PaymentResultWithDataListener`, `com.razorpay.PaymentData`, `com.homeservices.customer.data.booking.PaymentResultBus`, `com.homeservices.customer.domain.booking.model.PaymentResult`.
+
+- [ ] **Step 4: Verify compilation**
+
+```bash
+./gradlew assembleDebug 2>&1 | tail -15
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Run full unit test suite**
+
+```bash
+./gradlew testDebugUnitTest 2>&1 | tail -10
+```
+Expected: no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/ \
+        customer-app/app/src/main/kotlin/com/homeservices/customer/MainActivity.kt
+git commit -m "feat(E03-S03b/WS-C): booking navigation wiring + MainActivity payment listener + Book Now CTA enabled"
+```
+
+---
+
+## WS-D: Admin web — validate bookings container
+
+### Task D1: Verify admin orders query targets `bookings` container
+
+- [ ] **Step 1: Check E09-S02 container reference**
+
+```bash
+grep -r "bookings\|container\|orders" admin-web/src/ --include="*.ts" --include="*.tsx" | grep -v node_modules | head -20
+```
+
+- [ ] **Step 2: If the query references a different container name**, update the string to `'bookings'`. If it already matches, no change needed.
+
+- [ ] **Step 3: Commit only if changed**
+
+```bash
+git add admin-web/
+git commit -m "fix(E03-S03b/WS-D): align admin orders query to bookings Cosmos container"
+```
+
+---
+
+## WS-E: Pre-Codex smoke gate + Paparazzi cleanup
+
+### Task E1: Smoke gate + push + trigger Paparazzi CI record
+
+- [ ] **Step 1: Delete local Paparazzi goldens** (Paparazzi cross-OS invariant — never commit Windows-recorded goldens)
+
+```bash
+git rm -r customer-app/app/src/test/snapshots/images/ 2>/dev/null || true
+```
+
+- [ ] **Step 2: Run Android smoke gate**
+
+```bash
+bash tools/pre-codex-smoke.sh customer-app
+```
+Non-zero exit = stop and fix before proceeding.
+
+- [ ] **Step 3: Run API smoke gate**
+
+```bash
+bash tools/pre-codex-smoke-api.sh
+```
+Non-zero exit = stop and fix.
+
+- [ ] **Step 4: Commit cleanup + push PR**
+
+```bash
+git add -A
+git commit -m "chore(E03-S03b): delete local Paparazzi goldens pre-push"
+git push -u origin feature/E03-S03-booking-creation
+```
+
+- [ ] **Step 5: Run Codex review**
+
+```bash
+codex review --base main
+```
+
+- [ ] **Step 6: After PR merges — trigger Paparazzi golden record on CI**
+
+```bash
+gh workflow run paparazzi-record.yml \
+  --ref main \
+  -f gradle_root=customer-app \
+  -f gradle_task=":app:recordPaparazziDebug"
+```
+Then: `gh run watch` → pull CI-committed goldens → verify `./gradlew verifyPaparazziDebug` passes locally.

--- a/technician-app/gradle/libs.versions.toml
+++ b/technician-app/gradle/libs.versions.toml
@@ -34,6 +34,11 @@ okhttp = "4.12.0"
 moshi = "1.15.1"
 coil = "2.7.0"
 
+# Payments + Maps
+razorpay       = "1.6.40"
+googlePlaces   = "3.5.0"
+playServicesMaps = "19.0.0"
+
 # KYC-specific (Custom Tabs for DigiLocker redirect)
 androidxBrowser = "1.8.0"
 
@@ -103,6 +108,11 @@ okhttp-logging       = { module = "com.squareup.okhttp3:logging-interceptor",   
 moshi-kotlin         = { module = "com.squareup.moshi:moshi-kotlin",               version.ref = "moshi" }
 moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen",       version.ref = "moshi" }
 coil-compose         = { module = "io.coil-kt:coil-compose",                       version.ref = "coil" }
+
+# Payments + Maps
+razorpay-checkout  = { module = "com.razorpay:checkout",                                  version.ref = "razorpay" }
+google-places      = { module = "com.google.android.libraries.places:places",            version.ref = "googlePlaces" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps",             version.ref = "playServicesMaps" }
 
 # Test
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }


### PR DESCRIPTION
## Summary
- **API**: `POST /v1/bookings` (create + Razorpay order), `POST /v1/bookings/:id/confirm` (HMAC-verify + status update), `requireCustomer` Firebase ID-token middleware, booking Cosmos container + Zod schemas
- **Android**: `CreateBookingUseCase`, `ConfirmBookingUseCase`, `BookingRepository`, `BookingApiService` (Retrofit), `BookingModule` (Hilt DI), `PaymentResultBus`
- 185 API tests passing; both Android smoke gates clean

## Test plan
- [ ] API: `POST /v1/bookings` returns 201 with bookingId + razorpayOrderId + amount
- [ ] API: `POST /v1/bookings/:id/confirm` returns 200 with SEARCHING status on valid HMAC
- [ ] API: returns 401 when Bearer token absent/invalid
- [ ] Android: CreateBookingUseCase + ConfirmBookingUseCase unit tests green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)