### PR TITLE
feat(api): E05-S04 — accept/decline job-offer API with _etag optimistic concurrency

### DIFF
--- a/admin-web/app/(dashboard)/catalogue/[categoryId]/page.tsx
+++ b/admin-web/app/(dashboard)/catalogue/[categoryId]/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic';
 import { cookies } from 'next/headers';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { Route } from 'next';
 import type { components } from '@/api/generated/schema';
 
 type AdminServiceCategory = components['schemas']['AdminServiceCategory'];
@@ -81,7 +82,7 @@ export default async function CategoryDetailPage({ params }: PageProps) {
           </p>
         </div>
         <Link
-          href={`/catalogue/${categoryId}/edit`}
+          href={`/catalogue/${categoryId}/edit` as Route}
           style={{
             padding: 'var(--space-2) var(--space-4)',
             fontSize: 'var(--text-sm)',

--- a/admin-web/pnpm-lock.yaml
+++ b/admin-web/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@growthbook/growthbook-react':
         specifier: ^1
         version: 1.6.5(react@19.2.5)
+      '@hello-pangea/dnd':
+        specifier: ^18.0.1
+        version: 18.0.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@sentry/nextjs':
         specifier: ^8
         version: 8.55.1(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(next@15.5.15(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.106.2(esbuild@0.25.12))
@@ -863,6 +866,12 @@ packages:
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@hello-pangea/dnd@18.0.1':
+    resolution: {integrity: sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2999,6 +3008,9 @@ packages:
   csp_evaluator@1.1.1:
     resolution: {integrity: sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw==}
 
+  css-box-model@1.2.1:
+    resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -4748,6 +4760,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  raf-schd@4.0.3:
+    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -6478,6 +6493,18 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.5
       yargs: 17.7.2
+
+  '@hello-pangea/dnd@18.0.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      css-box-model: 1.2.1
+      raf-schd: 4.0.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
+      redux: 5.0.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8842,6 +8869,10 @@ snapshots:
 
   csp_evaluator@1.1.1: {}
 
+  css-box-model@1.2.1:
+    dependencies:
+      tiny-invariant: 1.3.3
+
   css.escape@1.5.1: {}
 
   cssstyle@4.6.0:
@@ -10863,6 +10894,8 @@ snapshots:
   query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
+
+  raf-schd@4.0.3: {}
 
   range-parser@1.2.1: {}
 

--- a/admin-web/src/components/dashboard/Rail.tsx
+++ b/admin-web/src/components/dashboard/Rail.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
+import type { Route } from 'next';
 
 interface NavItem {
   label: string;
@@ -70,7 +71,7 @@ export function Rail() {
           return (
             <Link
               key={item.href}
-              href={item.href}
+              href={item.href as Route}
               aria-label={item.label}
               aria-current={isActive ? 'page' : undefined}
               title={item.label}
@@ -119,7 +120,7 @@ export function Rail() {
           return (
             <Link
               key={item.href}
-              href={item.href}
+              href={item.href as Route}
               aria-label={item.label}
               aria-current={isActive ? 'page' : undefined}
               title={item.label}

--- a/api/src/cosmos/booking-event-repository.ts
+++ b/api/src/cosmos/booking-event-repository.ts
@@ -1,0 +1,14 @@
+import { randomUUID } from 'node:crypto';
+import { getBookingEventsContainer } from './client.js';
+import type { BookingEventDoc } from '../schemas/booking-event.js';
+
+export const bookingEventRepo = {
+  async append(event: Omit<BookingEventDoc, 'id' | 'ts'>): Promise<void> {
+    const doc: BookingEventDoc = {
+      ...event,
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+    };
+    await getBookingEventsContainer().items.create<BookingEventDoc>(doc);
+  },
+};

--- a/api/src/cosmos/dispatch-attempt-repository.ts
+++ b/api/src/cosmos/dispatch-attempt-repository.ts
@@ -1,0 +1,48 @@
+import type { Resource } from '@azure/cosmos';
+import { getDispatchAttemptsContainer } from './client.js';
+import type { DispatchAttemptDoc } from '../schemas/dispatch-attempt.js';
+
+export const dispatchAttemptRepo = {
+  async getByBookingId(bookingId: string): Promise<DispatchAttemptDoc | null> {
+    const { resources } = await getDispatchAttemptsContainer()
+      .items
+      .query<DispatchAttemptDoc>({
+        query: 'SELECT * FROM c WHERE c.bookingId = @bookingId',
+        parameters: [{ name: '@bookingId', value: bookingId }],
+      })
+      .fetchAll();
+    return resources[0] ?? null;
+  },
+
+  async acceptAttempt(id: string, bookingId: string): Promise<DispatchAttemptDoc | null> {
+    const container = getDispatchAttemptsContainer();
+    const { resource } = await container.item(id, bookingId).read<DispatchAttemptDoc & Resource>();
+    if (!resource) return null;
+    if (resource.status !== 'PENDING') return null;
+    if (new Date(resource.expiresAt) <= new Date()) return null;
+
+    const updated: DispatchAttemptDoc = {
+      id: resource.id,
+      bookingId: resource.bookingId,
+      technicianIds: resource.technicianIds,
+      sentAt: resource.sentAt,
+      expiresAt: resource.expiresAt,
+      status: 'ACCEPTED',
+    };
+
+    try {
+      const { resource: replaced } = await container.item(id, bookingId).replace<DispatchAttemptDoc>(
+        updated,
+        { accessCondition: { type: 'IfMatch', condition: resource._etag } },
+      );
+      return replaced ?? null;
+    } catch (err: unknown) {
+      if (isCosmosConflict(err)) return null;
+      throw err;
+    }
+  },
+};
+
+function isCosmosConflict(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 412;
+}

--- a/api/src/functions/job-offers.ts
+++ b/api/src/functions/job-offers.ts
@@ -1,0 +1,123 @@
+import { app, type HttpRequest, type HttpResponseInit, type InvocationContext, type Timer } from '@azure/functions';
+import { getMessaging } from 'firebase-admin/messaging';
+import type { Resource } from '@azure/cosmos';
+import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
+import { dispatchAttemptRepo } from '../cosmos/dispatch-attempt-repository.js';
+import { bookingEventRepo } from '../cosmos/booking-event-repository.js';
+import { updateBookingFields } from '../cosmos/booking-repository.js';
+import { getDispatchAttemptsContainer } from '../cosmos/client.js';
+import type { DispatchAttemptDoc } from '../schemas/dispatch-attempt.js';
+
+export async function acceptJobOfferHandler(
+  req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> {
+  let technicianId: string;
+  try {
+    const { uid } = await verifyTechnicianToken(req);
+    technicianId = uid;
+  } catch {
+    return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } };
+  }
+
+  const bookingId = (req as unknown as { params: { bookingId: string } }).params.bookingId;
+
+  const attempt = await dispatchAttemptRepo.getByBookingId(bookingId);
+  if (!attempt) {
+    return { status: 404, jsonBody: { code: 'OFFER_NOT_FOUND' } };
+  }
+  if (attempt.status !== 'PENDING' || new Date(attempt.expiresAt) <= new Date()) {
+    return { status: 410, jsonBody: { code: 'OFFER_EXPIRED' } };
+  }
+  if (!attempt.technicianIds.includes(technicianId)) {
+    return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+  }
+
+  const accepted = await dispatchAttemptRepo.acceptAttempt(attempt.id, bookingId);
+  if (!accepted) {
+    return { status: 409, jsonBody: { code: 'OFFER_ALREADY_TAKEN' } };
+  }
+
+  await updateBookingFields(bookingId, { status: 'ASSIGNED', technicianId });
+  await bookingEventRepo.append({ event: 'TECH_ACCEPTED', technicianId, bookingId });
+
+  const losingTechs = attempt.technicianIds.filter(id => id !== technicianId);
+  void notifyLosingTechs(losingTechs, bookingId);
+
+  return { status: 200, jsonBody: { bookingId, status: 'ASSIGNED' } };
+}
+
+export async function declineJobOfferHandler(
+  req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> {
+  let technicianId: string;
+  try {
+    const { uid } = await verifyTechnicianToken(req);
+    technicianId = uid;
+  } catch {
+    return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } };
+  }
+
+  const bookingId = (req as unknown as { params: { bookingId: string } }).params.bookingId;
+
+  await bookingEventRepo.append({ event: 'TECH_DECLINED', technicianId, bookingId });
+
+  return { status: 200, jsonBody: { bookingId, status: 'DECLINED' } };
+}
+
+async function notifyLosingTechs(techIds: string[], bookingId: string): Promise<void> {
+  const messaging = getMessaging();
+  await Promise.allSettled(
+    techIds.map(techId =>
+      messaging.send({
+        topic: `tech_${techId}`,
+        data: { type: 'OFFER_CANCELLED', bookingId },
+      })
+    )
+  );
+}
+
+async function expireStaleOffers(_timer: Timer, _ctx: InvocationContext): Promise<void> {
+  const container = getDispatchAttemptsContainer();
+  const { resources } = await container.items
+    .query<DispatchAttemptDoc & Resource>({
+      query: `SELECT * FROM c WHERE c.status = 'PENDING' AND c.expiresAt < @now`,
+      parameters: [{ name: '@now', value: new Date().toISOString() }],
+    })
+    .fetchAll();
+
+  await Promise.allSettled(
+    resources.map(async attempt => {
+      try {
+        await container.item(attempt.id, attempt.bookingId).replace(
+          { ...attempt, status: 'EXPIRED' },
+          { accessCondition: { type: 'IfMatch', condition: attempt._etag } },
+        );
+        await updateBookingFields(attempt.bookingId, { status: 'UNFULFILLED' });
+        await bookingEventRepo.append({ event: 'OFFER_EXPIRED', bookingId: attempt.bookingId });
+      } catch {
+        // 412 PreconditionFailed = concurrent process already updated this attempt; skip it
+      }
+    })
+  );
+}
+
+app.http('acceptJobOffer', {
+  route: 'v1/technicians/job-offers/{bookingId}/accept',
+  methods: ['PATCH'],
+  authLevel: 'anonymous',
+  handler: acceptJobOfferHandler,
+});
+
+app.http('declineJobOffer', {
+  route: 'v1/technicians/job-offers/{bookingId}/decline',
+  methods: ['PATCH'],
+  authLevel: 'anonymous',
+  handler: declineJobOfferHandler,
+});
+
+app.timer('expireStaleOffers', {
+  schedule: '*/30 * * * * *',
+  handler: expireStaleOffers,
+});

--- a/api/tests/bookings/accept-decline.test.ts
+++ b/api/tests/bookings/accept-decline.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpRequest, InvocationContext } from '@azure/functions';
+
+vi.mock('../../src/middleware/verifyTechnicianToken.js', () => ({
+  verifyTechnicianToken: vi.fn(),
+}));
+
+vi.mock('../../src/cosmos/dispatch-attempt-repository.js', () => ({
+  dispatchAttemptRepo: {
+    getByBookingId: vi.fn(),
+    acceptAttempt: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/cosmos/booking-event-repository.js', () => ({
+  bookingEventRepo: {
+    append: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: {
+    getById: vi.fn(),
+  },
+  updateBookingFields: vi.fn(),
+}));
+
+vi.mock('firebase-admin/messaging', () => ({
+  getMessaging: vi.fn().mockReturnValue({
+    send: vi.fn().mockResolvedValue('message-id'),
+  }),
+}));
+
+function makeReq(bookingId: string, suffix: string): HttpRequest {
+  const req = new HttpRequest({
+    url: `http://localhost/api/v1/technicians/job-offers/${bookingId}/${suffix}`,
+    method: 'PATCH',
+    headers: { authorization: 'Bearer test-token' },
+  });
+  Object.assign(req, { params: { bookingId } });
+  return req;
+}
+
+const pendingAttempt = () => ({
+  id: 'da-1',
+  bookingId: 'bk-1',
+  technicianIds: ['tech-1', 'tech-2'],
+  sentAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  status: 'PENDING' as const,
+});
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+describe('PATCH /v1/technicians/job-offers/:bookingId/accept', () => {
+  let acceptHandler: typeof import('../../src/functions/job-offers.js').acceptJobOfferHandler;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import('../../src/functions/job-offers.js');
+    acceptHandler = mod.acceptJobOfferHandler;
+  });
+
+  it('returns 200 ASSIGNED on first caller', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { dispatchAttemptRepo } = await import('../../src/cosmos/dispatch-attempt-repository.js');
+    const { updateBookingFields } = await import('../../src/cosmos/booking-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (dispatchAttemptRepo.getByBookingId as MockFn).mockResolvedValue(pendingAttempt());
+    (dispatchAttemptRepo.acceptAttempt as MockFn).mockResolvedValue({ id: 'da-1', bookingId: 'bk-1', technicianIds: ['tech-1', 'tech-2'], sentAt: '', expiresAt: '', status: 'ACCEPTED' as const });
+    (updateBookingFields as MockFn).mockResolvedValue({ id: 'bk-1', customerId: 'c1', serviceId: 's1', categoryId: 'cat1', slotDate: '2026-01-01', slotWindow: '09:00-11:00', addressText: 'Addr', addressLatLng: { lat: 0, lng: 0 }, status: 'ASSIGNED', paymentOrderId: 'o1', paymentId: null, paymentSignature: null, amount: 100, createdAt: '', technicianId: 'tech-1' });
+
+    const res = await acceptHandler(makeReq('bk-1', 'accept'), new InvocationContext());
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { status: string }).status).toBe('ASSIGNED');
+  });
+
+  it('returns 409 when _etag race lost (acceptAttempt returns null)', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { dispatchAttemptRepo } = await import('../../src/cosmos/dispatch-attempt-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (dispatchAttemptRepo.getByBookingId as MockFn).mockResolvedValue(pendingAttempt());
+    (dispatchAttemptRepo.acceptAttempt as MockFn).mockResolvedValue(null);
+
+    const res = await acceptHandler(makeReq('bk-1', 'accept'), new InvocationContext());
+    expect(res.status).toBe(409);
+    expect((res.jsonBody as { code: string }).code).toBe('OFFER_ALREADY_TAKEN');
+  });
+
+  it('returns 410 when offer expiresAt has already passed', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { dispatchAttemptRepo } = await import('../../src/cosmos/dispatch-attempt-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (dispatchAttemptRepo.getByBookingId as MockFn).mockResolvedValue({
+      id: 'da-1',
+      bookingId: 'bk-1',
+      technicianIds: ['tech-1', 'tech-2'],
+      sentAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() - 1_000).toISOString(),
+      status: 'PENDING' as const,
+    });
+
+    const res = await acceptHandler(makeReq('bk-1', 'accept'), new InvocationContext());
+    expect(res.status).toBe(410);
+    expect((res.jsonBody as { code: string }).code).toBe('OFFER_EXPIRED');
+  });
+
+  it('returns 403 when technicianId not in attempt.technicianIds', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { dispatchAttemptRepo } = await import('../../src/cosmos/dispatch-attempt-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (dispatchAttemptRepo.getByBookingId as MockFn).mockResolvedValue({
+      id: 'da-1',
+      bookingId: 'bk-1',
+      technicianIds: ['tech-99', 'tech-88'],
+      sentAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      status: 'PENDING' as const,
+    });
+
+    const res = await acceptHandler(makeReq('bk-1', 'accept'), new InvocationContext());
+    expect(res.status).toBe(403);
+    expect((res.jsonBody as { code: string }).code).toBe('FORBIDDEN');
+  });
+
+  it('returns 410 when attempt status is not PENDING', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { dispatchAttemptRepo } = await import('../../src/cosmos/dispatch-attempt-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (dispatchAttemptRepo.getByBookingId as MockFn).mockResolvedValue({
+      id: 'da-1',
+      bookingId: 'bk-1',
+      technicianIds: ['tech-1'],
+      sentAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      status: 'ACCEPTED' as const,
+    });
+
+    const res = await acceptHandler(makeReq('bk-1', 'accept'), new InvocationContext());
+    expect(res.status).toBe(410);
+  });
+});
+
+describe('PATCH /v1/technicians/job-offers/:bookingId/decline', () => {
+  let declineHandler: typeof import('../../src/functions/job-offers.js').declineJobOfferHandler;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import('../../src/functions/job-offers.js');
+    declineHandler = mod.declineJobOfferHandler;
+  });
+
+  it('returns 200 DECLINED and does not modify booking or dispatch attempt', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { updateBookingFields } = await import('../../src/cosmos/booking-repository.js');
+    const { dispatchAttemptRepo } = await import('../../src/cosmos/dispatch-attempt-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+
+    const res = await declineHandler(makeReq('bk-1', 'decline'), new InvocationContext());
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { status: string }).status).toBe('DECLINED');
+    expect((updateBookingFields as MockFn).mock.calls).toHaveLength(0);
+    expect((dispatchAttemptRepo.acceptAttempt as MockFn).mock.calls).toHaveLength(0);
+  });
+
+  it('appends TECH_DECLINED event with no ranking field', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { bookingEventRepo } = await import('../../src/cosmos/booking-event-repository.js');
+
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+
+    await declineHandler(makeReq('bk-1', 'decline'), new InvocationContext());
+    const appendCalls = (bookingEventRepo.append as MockFn).mock.calls;
+    expect(appendCalls).toHaveLength(1);
+    const callArg: Record<string, unknown> = appendCalls[0]![0] as Record<string, unknown>;
+    expect(callArg['event']).toBe('TECH_DECLINED');
+    expect(callArg['bookingId']).toBe('bk-1');
+    expect(callArg).not.toHaveProperty('ranking');
+    expect(callArg).not.toHaveProperty('score');
+    expect(callArg).not.toHaveProperty('dispatchScore');
+  });
+});


### PR DESCRIPTION
## Summary

- **dispatchAttemptRepo.acceptAttempt()** uses Cosmos `_etag` + `If-Match` conditional replace so exactly one technician wins simultaneous race; returns `null` on 412 PreconditionFailed (mapped to 409 at the HTTP layer)
- **bookingEventRepo.append()** is append-only — no update/delete methods exist; partition key is `bookingId`
- **PATCH /v1/technicians/job-offers/{bookingId}/accept** — 410 on expired/non-PENDING, 403 if not in `technicianIds`, 409 on lost _etag race; on win: assigns booking + emits `TECH_ACCEPTED` event + FCM `OFFER_CANCELLED` to losing techs (topic-based, `Promise.allSettled`)
- **PATCH /v1/technicians/job-offers/{bookingId}/decline** — tombstone only; does NOT touch `DispatchAttemptDoc` or booking status (pure audit trail, never fed to dispatcher ranking)
- **Timer trigger** (`*/30 * * * * *`) queries stale PENDING attempts, conditionally replaces to EXPIRED, marks booking `UNFULFILLED`, emits `OFFER_EXPIRED` event

## Test plan

- [x] `accept: 200 ASSIGNED` on first caller
- [x] `accept: 409 OFFER_ALREADY_TAKEN` when `acceptAttempt` returns null (_etag conflict)
- [x] `accept: 410 OFFER_EXPIRED` when `expiresAt` has passed
- [x] `accept: 410` when attempt status is not PENDING
- [x] `accept: 403 FORBIDDEN` when technicianId not in `attempt.technicianIds`
- [x] `decline: 200 DECLINED`, booking unchanged, `acceptAttempt` not called
- [x] `decline: TECH_DECLINED` event appended with no ranking/score field
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` — all green (360 tests)
- [x] `bash tools/pre-codex-smoke-api.sh` — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)