### PR TITLE
feat(technician-app): E05-S03 — FCM job offer full-screen card with countdown

### DIFF
--- a/technician-app/app/build.gradle.kts
+++ b/technician-app/app/build.gradle.kts
@@ -181,6 +181,8 @@ kover {
                     "*.navigation.*",
                     // Hilt DI module — @Provides methods are framework wiring
                     "*.data.auth.di.*",
+                    // Hilt DI module for job offer feature — @Provides methods are framework wiring
+                    "*.data.jobOffer.di.*",
                     // Stub onboarding screen — placeholder Compose composable, no logic
                     "*.ui.onboarding.*",
                     // BiometricGateUseCase.requestAuth requires FragmentActivity + BiometricPrompt
@@ -213,6 +215,17 @@ kover {
                     // reachable branches via mockk in KycRepositoryImplTest.
                     "*.KycApiService",
                     "*.KycApiService\$*",
+                    // HomeservicesFcmService — @AndroidEntryPoint service with field injection;
+                    // onMessageReceived requires a live FCM connection, not unit-testable
+                    "*.HomeservicesFcmService",
+                    "*.HomeservicesFcmService\$*",
+                    // JobOfferScreen composable file generates *Kt JVM wrapper with framework branches
+                    "*.JobOfferScreenKt",
+                    "*.JobOfferScreenKt\$*",
+                    // JobOfferApiService is an internal Retrofit interface — its methods are invoked
+                    // by the Retrofit runtime (not unit-testable)
+                    "*.JobOfferApiService",
+                    "*.JobOfferApiService\$*",
                 )
             }
         }

--- a/technician-app/app/build.gradle.kts
+++ b/technician-app/app/build.gradle.kts
@@ -252,6 +252,7 @@ dependencies {
     // Firebase (BOM manages all Firebase library versions)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.messaging)
 
     // Coroutines — play-services extensions (.await() on Task<T>)
     implementation(libs.kotlinx.coroutines.play.services)

--- a/technician-app/app/src/main/AndroidManifest.xml
+++ b/technician-app/app/src/main/AndroidManifest.xml
@@ -38,6 +38,14 @@
                     android:pathPrefix="/aadhaar-callback" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".data.fcm.HomeservicesFcmService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -1,0 +1,46 @@
+package com.homeservices.technician.data.fcm
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.homeservices.technician.data.jobOffer.JobOfferEventBus
+import com.homeservices.technician.domain.jobOffer.model.JobOffer
+import dagger.hilt.android.AndroidEntryPoint
+import java.time.Instant
+import javax.inject.Inject
+
+@AndroidEntryPoint
+public class HomeservicesFcmService : FirebaseMessagingService() {
+    @Inject
+    public lateinit var eventBus: JobOfferEventBus
+
+    override fun onMessageReceived(message: RemoteMessage): Unit {
+        val data = message.data
+        if (data["type"] != "JOB_OFFER") return
+
+        val offer = parseJobOffer(data) ?: return
+        eventBus.tryEmit(offer)
+    }
+
+    override fun onNewToken(token: String): Unit {
+        // Token refresh — FcmTokenSyncUseCase is called by the auth flow after login.
+        // On token refresh the next app launch will re-sync via SaveSessionUseCase.
+    }
+
+    private fun parseJobOffer(data: Map<String, String>): JobOffer? =
+        try {
+            val expiresAtMs = Instant.parse(data["expiresAt"] ?: return null).toEpochMilli()
+            JobOffer(
+                bookingId = data["bookingId"] ?: return null,
+                serviceId = data["serviceId"] ?: return null,
+                serviceName = data["serviceName"] ?: return null,
+                addressText = data["addressText"] ?: return null,
+                slotDate = data["slotDate"] ?: return null,
+                slotWindow = data["slotWindow"] ?: return null,
+                amountPaise = data["amount"]?.toLongOrNull() ?: return null,
+                distanceKm = data["distanceKm"]?.toDoubleOrNull() ?: return null,
+                expiresAtMs = expiresAtMs,
+            )
+        } catch (_: Exception) {
+            null
+        }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -3,15 +3,26 @@ package com.homeservices.technician.data.fcm
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.homeservices.technician.data.jobOffer.JobOfferEventBus
+import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.Instant
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 public class HomeservicesFcmService : FirebaseMessagingService() {
     @Inject
     public lateinit var eventBus: JobOfferEventBus
+
+    @Inject
+    public lateinit var fcmTokenSyncUseCase: FcmTokenSyncUseCase
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onMessageReceived(message: RemoteMessage): Unit {
         val data = message.data
@@ -22,8 +33,14 @@ public class HomeservicesFcmService : FirebaseMessagingService() {
     }
 
     override fun onNewToken(token: String): Unit {
-        // Token refresh — FcmTokenSyncUseCase is called by the auth flow after login.
-        // On token refresh the next app launch will re-sync via SaveSessionUseCase.
+        serviceScope.launch {
+            fcmTokenSyncUseCase.invokeWithFcmToken(token)
+        }
+    }
+
+    public override fun onDestroy(): Unit {
+        super.onDestroy()
+        serviceScope.cancel()
     }
 
     private fun parseJobOffer(data: Map<String, String>): JobOffer? =

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -6,13 +6,13 @@ import com.homeservices.technician.data.jobOffer.JobOfferEventBus
 import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.Instant
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.time.Instant
+import javax.inject.Inject
 
 @AndroidEntryPoint
 public class HomeservicesFcmService : FirebaseMessagingService() {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -43,8 +43,8 @@ public class HomeservicesFcmService : FirebaseMessagingService() {
         serviceScope.cancel()
     }
 
-    private fun parseJobOffer(data: Map<String, String>): JobOffer? =
-        try {
+    private fun parseJobOffer(data: Map<String, String>): JobOffer? {
+        return try {
             val expiresAtMs = Instant.parse(data["expiresAt"] ?: return null).toEpochMilli()
             JobOffer(
                 bookingId = data["bookingId"] ?: return null,
@@ -60,4 +60,5 @@ public class HomeservicesFcmService : FirebaseMessagingService() {
         } catch (_: Exception) {
             null
         }
+    }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferApiService.kt
@@ -26,4 +26,6 @@ internal interface JobOfferApiService {
     ): Response<Unit>
 }
 
-internal data class FcmTokenRequest(val fcmToken: String)
+internal data class FcmTokenRequest(
+    val fcmToken: String,
+)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferApiService.kt
@@ -1,0 +1,29 @@
+package com.homeservices.technician.data.jobOffer
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+
+internal interface JobOfferApiService {
+    @PATCH("v1/technicians/job-offers/{bookingId}/accept")
+    suspend fun acceptOffer(
+        @Header("Authorization") authHeader: String,
+        @Path("bookingId") bookingId: String,
+    ): Response<Unit>
+
+    @PATCH("v1/technicians/job-offers/{bookingId}/decline")
+    suspend fun declineOffer(
+        @Header("Authorization") authHeader: String,
+        @Path("bookingId") bookingId: String,
+    ): Response<Unit>
+
+    @PATCH("v1/technicians/fcm-token")
+    suspend fun syncFcmToken(
+        @Header("Authorization") authHeader: String,
+        @Body body: FcmTokenRequest,
+    ): Response<Unit>
+}
+
+internal data class FcmTokenRequest(val fcmToken: String)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferEventBus.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferEventBus.kt
@@ -1,0 +1,21 @@
+package com.homeservices.technician.data.jobOffer
+
+import com.homeservices.technician.domain.jobOffer.model.JobOffer
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+public class JobOfferEventBus @Inject constructor() {
+    private val _events: MutableSharedFlow<JobOffer> = MutableSharedFlow(
+        replay = 0,
+        extraBufferCapacity = 1,
+    )
+    public val events: SharedFlow<JobOffer> = _events.asSharedFlow()
+
+    public fun tryEmit(offer: JobOffer): Unit {
+        _events.tryEmit(offer)
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferEventBus.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferEventBus.kt
@@ -8,14 +8,17 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-public class JobOfferEventBus @Inject constructor() {
-    private val _events: MutableSharedFlow<JobOffer> = MutableSharedFlow(
-        replay = 0,
-        extraBufferCapacity = 1,
-    )
-    public val events: SharedFlow<JobOffer> = _events.asSharedFlow()
+public class JobOfferEventBus
+    @Inject
+    constructor() {
+        private val _events: MutableSharedFlow<JobOffer> =
+            MutableSharedFlow(
+                replay = 0,
+                extraBufferCapacity = 1,
+            )
+        public val events: SharedFlow<JobOffer> = _events.asSharedFlow()
 
-    public fun tryEmit(offer: JobOffer): Unit {
-        _events.tryEmit(offer)
+        public fun tryEmit(offer: JobOffer): Unit {
+            _events.tryEmit(offer)
+        }
     }
-}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/di/JobOfferModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/di/JobOfferModule.kt
@@ -1,0 +1,33 @@
+package com.homeservices.technician.data.jobOffer.di
+
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+public object JobOfferModule {
+    @Provides
+    @Singleton
+    internal fun provideJobOfferApiService(): JobOfferApiService {
+        val logging =
+            HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
+        val client = OkHttpClient.Builder().addInterceptor(logging).build()
+        return Retrofit
+            .Builder()
+            .baseUrl("https://homeservices-api.azurewebsites.net/api/")
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+            .create(JobOfferApiService::class.java)
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-public class AcceptJobOfferUseCase @Inject constructor(
+public class AcceptJobOfferUseCase @Inject internal constructor(
     private val api: JobOfferApiService,
     private val firebaseAuth: FirebaseAuth,
 ) {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
@@ -8,18 +8,24 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-public class AcceptJobOfferUseCase @Inject internal constructor(
-    private val api: JobOfferApiService,
-    private val firebaseAuth: FirebaseAuth,
-) {
-    public suspend operator fun invoke(bookingId: String): JobOfferResult {
-        val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token
-            ?: throw IllegalStateException("No authenticated user for job offer acceptance")
-        val response = api.acceptOffer("Bearer $token", bookingId)
-        return when {
-            response.isSuccessful -> JobOfferResult.Accepted(bookingId)
-            response.code() == 410 -> JobOfferResult.Expired(bookingId)
-            else -> throw RuntimeException("Accept offer failed: HTTP ${response.code()}")
+public class AcceptJobOfferUseCase
+    @Inject
+    internal constructor(
+        private val api: JobOfferApiService,
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        public suspend operator fun invoke(bookingId: String): JobOfferResult {
+            val token =
+                firebaseAuth.currentUser
+                    ?.getIdToken(false)
+                    ?.await()
+                    ?.token
+                    ?: throw IllegalStateException("No authenticated user for job offer acceptance")
+            val response = api.acceptOffer("Bearer $token", bookingId)
+            return when {
+                response.isSuccessful -> JobOfferResult.Accepted(bookingId)
+                response.code() == 410 -> JobOfferResult.Expired(bookingId)
+                else -> throw RuntimeException("Accept offer failed: HTTP ${response.code()}")
+            }
         }
     }
-}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
@@ -13,7 +13,8 @@ public class AcceptJobOfferUseCase @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
 ) {
     public suspend operator fun invoke(bookingId: String): JobOfferResult {
-        val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
+        val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token
+            ?: throw IllegalStateException("No authenticated user for job offer acceptance")
         val response = api.acceptOffer("Bearer $token", bookingId)
         return when {
             response.isSuccessful -> JobOfferResult.Accepted(bookingId)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
@@ -1,0 +1,24 @@
+package com.homeservices.technician.domain.jobOffer
+
+import com.google.firebase.auth.FirebaseAuth
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+public class AcceptJobOfferUseCase @Inject constructor(
+    private val api: JobOfferApiService,
+    private val firebaseAuth: FirebaseAuth,
+) {
+    public suspend operator fun invoke(bookingId: String): JobOfferResult {
+        val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
+        val response = api.acceptOffer("Bearer $token", bookingId)
+        return when {
+            response.isSuccessful -> JobOfferResult.Accepted(bookingId)
+            response.code() == 410 -> JobOfferResult.Expired(bookingId)
+            else -> throw RuntimeException("Accept offer failed: HTTP ${response.code()}")
+        }
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
@@ -1,0 +1,29 @@
+package com.homeservices.technician.domain.jobOffer
+
+import com.google.firebase.auth.FirebaseAuth
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// Per Karnataka FR-9.1: decline is logged server-side to booking_events but
+// NEVER fed back to ranking. Decline counts MUST NEVER appear in any UI label,
+// sort order, or analytics event.
+@Singleton
+public class DeclineJobOfferUseCase @Inject constructor(
+    private val api: JobOfferApiService,
+    private val firebaseAuth: FirebaseAuth,
+) {
+    public suspend operator fun invoke(bookingId: String): JobOfferResult {
+        val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
+        return try {
+            api.declineOffer("Bearer $token", bookingId)
+            // Response code is intentionally ignored — user intention to decline is the source of truth
+            JobOfferResult.Declined(bookingId)
+        } catch (_: Exception) {
+            // Network error on decline — user intention is known; return Declined anyway
+            JobOfferResult.Declined(bookingId)
+        }
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
@@ -4,6 +4,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.homeservices.technician.data.jobOffer.JobOfferApiService
 import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
 import kotlinx.coroutines.tasks.await
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,7 +22,7 @@ public class DeclineJobOfferUseCase @Inject constructor(
             api.declineOffer("Bearer $token", bookingId)
             // Response code is intentionally ignored — user intention to decline is the source of truth
             JobOfferResult.Declined(bookingId)
-        } catch (_: Exception) {
+        } catch (_: IOException) {
             // Network error on decline — user intention is known; return Declined anyway
             JobOfferResult.Declined(bookingId)
         }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
@@ -12,19 +12,26 @@ import javax.inject.Singleton
 // NEVER fed back to ranking. Decline counts MUST NEVER appear in any UI label,
 // sort order, or analytics event.
 @Singleton
-public class DeclineJobOfferUseCase @Inject internal constructor(
-    private val api: JobOfferApiService,
-    private val firebaseAuth: FirebaseAuth,
-) {
-    public suspend operator fun invoke(bookingId: String): JobOfferResult {
-        val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
-        return try {
-            api.declineOffer("Bearer $token", bookingId)
-            // Response code is intentionally ignored — user intention to decline is the source of truth
-            JobOfferResult.Declined(bookingId)
-        } catch (_: IOException) {
-            // Network error on decline — user intention is known; return Declined anyway
-            JobOfferResult.Declined(bookingId)
+public class DeclineJobOfferUseCase
+    @Inject
+    internal constructor(
+        private val api: JobOfferApiService,
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        public suspend operator fun invoke(bookingId: String): JobOfferResult {
+            val token =
+                firebaseAuth.currentUser
+                    ?.getIdToken(false)
+                    ?.await()
+                    ?.token
+                    .orEmpty()
+            return try {
+                api.declineOffer("Bearer $token", bookingId)
+                // Response code is intentionally ignored — user intention to decline is the source of truth
+                JobOfferResult.Declined(bookingId)
+            } catch (_: IOException) {
+                // Network error on decline — user intention is known; return Declined anyway
+                JobOfferResult.Declined(bookingId)
+            }
         }
     }
-}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 // NEVER fed back to ranking. Decline counts MUST NEVER appear in any UI label,
 // sort order, or analytics event.
 @Singleton
-public class DeclineJobOfferUseCase @Inject constructor(
+public class DeclineJobOfferUseCase @Inject internal constructor(
     private val api: JobOfferApiService,
     private val firebaseAuth: FirebaseAuth,
 ) {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-public class FcmTokenSyncUseCase @Inject constructor(
+public class FcmTokenSyncUseCase @Inject internal constructor(
     private val api: JobOfferApiService,
     private val firebaseAuth: FirebaseAuth,
 ) {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -1,0 +1,38 @@
+package com.homeservices.technician.domain.jobOffer
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.messaging.FirebaseMessaging
+import com.homeservices.technician.data.jobOffer.FcmTokenRequest
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+public class FcmTokenSyncUseCase @Inject constructor(
+    private val api: JobOfferApiService,
+    private val firebaseAuth: FirebaseAuth,
+) {
+    /** Called from app startup / login flow. Fetches the FCM token internally. */
+    public suspend operator fun invoke(): Unit {
+        try {
+            val fcmToken = FirebaseMessaging.getInstance().token.await()
+            invokeWithFcmToken(fcmToken)
+        } catch (_: Exception) {
+            // Token sync is best-effort; failures are non-fatal
+        }
+    }
+
+    /**
+     * Testable entry point — accepts a pre-fetched FCM token.
+     * Unit tests use this overload to avoid static FirebaseMessaging access.
+     */
+    public suspend fun invokeWithFcmToken(fcmToken: String): Unit {
+        try {
+            val idToken = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
+            api.syncFcmToken("Bearer $idToken", FcmTokenRequest(fcmToken))
+        } catch (_: Exception) {
+            // Token sync is best-effort; failures are non-fatal
+        }
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import com.homeservices.technician.data.jobOffer.FcmTokenRequest
 import com.homeservices.technician.data.jobOffer.JobOfferApiService
 import kotlinx.coroutines.tasks.await
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,7 +19,7 @@ public class FcmTokenSyncUseCase @Inject constructor(
         try {
             val fcmToken = FirebaseMessaging.getInstance().token.await()
             invokeWithFcmToken(fcmToken)
-        } catch (_: Exception) {
+        } catch (_: IOException) {
             // Token sync is best-effort; failures are non-fatal
         }
     }
@@ -31,7 +32,7 @@ public class FcmTokenSyncUseCase @Inject constructor(
         try {
             val idToken = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
             api.syncFcmToken("Bearer $idToken", FcmTokenRequest(fcmToken))
-        } catch (_: Exception) {
+        } catch (_: IOException) {
             // Token sync is best-effort; failures are non-fatal
         }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -10,30 +10,37 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-public class FcmTokenSyncUseCase @Inject internal constructor(
-    private val api: JobOfferApiService,
-    private val firebaseAuth: FirebaseAuth,
-) {
-    /** Called from app startup / login flow. Fetches the FCM token internally. */
-    public suspend operator fun invoke(): Unit {
-        try {
-            val fcmToken = FirebaseMessaging.getInstance().token.await()
-            invokeWithFcmToken(fcmToken)
-        } catch (_: IOException) {
-            // Token sync is best-effort; failures are non-fatal
+public class FcmTokenSyncUseCase
+    @Inject
+    internal constructor(
+        private val api: JobOfferApiService,
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        /** Called from app startup / login flow. Fetches the FCM token internally. */
+        public suspend operator fun invoke(): Unit {
+            try {
+                val fcmToken = FirebaseMessaging.getInstance().token.await()
+                invokeWithFcmToken(fcmToken)
+            } catch (_: IOException) {
+                // Token sync is best-effort; failures are non-fatal
+            }
         }
-    }
 
-    /**
-     * Testable entry point — accepts a pre-fetched FCM token.
-     * Unit tests use this overload to avoid static FirebaseMessaging access.
-     */
-    public suspend fun invokeWithFcmToken(fcmToken: String): Unit {
-        try {
-            val idToken = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
-            api.syncFcmToken("Bearer $idToken", FcmTokenRequest(fcmToken))
-        } catch (_: IOException) {
-            // Token sync is best-effort; failures are non-fatal
+        /**
+         * Testable entry point — accepts a pre-fetched FCM token.
+         * Unit tests use this overload to avoid static FirebaseMessaging access.
+         */
+        public suspend fun invokeWithFcmToken(fcmToken: String): Unit {
+            try {
+                val idToken =
+                    firebaseAuth.currentUser
+                        ?.getIdToken(false)
+                        ?.await()
+                        ?.token
+                        .orEmpty()
+                api.syncFcmToken("Bearer $idToken", FcmTokenRequest(fcmToken))
+            } catch (_: IOException) {
+                // Token sync is best-effort; failures are non-fatal
+            }
         }
     }
-}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOffer.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOffer.kt
@@ -1,0 +1,13 @@
+package com.homeservices.technician.domain.jobOffer.model
+
+public data class JobOffer(
+    val bookingId: String,
+    val serviceId: String,
+    val serviceName: String,
+    val addressText: String,
+    val slotDate: String,
+    val slotWindow: String,
+    val amountPaise: Long,
+    val distanceKm: Double,
+    val expiresAtMs: Long,
+)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt
@@ -1,7 +1,15 @@
 package com.homeservices.technician.domain.jobOffer.model
 
 public sealed class JobOfferResult {
-    public data class Accepted(val bookingId: String) : JobOfferResult()
-    public data class Declined(val bookingId: String) : JobOfferResult()
-    public data class Expired(val bookingId: String) : JobOfferResult()
+    public data class Accepted(
+        val bookingId: String,
+    ) : JobOfferResult()
+
+    public data class Declined(
+        val bookingId: String,
+    ) : JobOfferResult()
+
+    public data class Expired(
+        val bookingId: String,
+    ) : JobOfferResult()
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt
@@ -1,0 +1,7 @@
+package com.homeservices.technician.domain.jobOffer.model
+
+public sealed class JobOfferResult {
+    public data class Accepted(val bookingId: String) : JobOfferResult()
+    public data class Declined(val bookingId: String) : JobOfferResult()
+    public data class Expired(val bookingId: String) : JobOfferResult()
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/AppNavigation.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/AppNavigation.kt
@@ -1,24 +1,32 @@
 package com.homeservices.technician.navigation
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.homeservices.technician.data.auth.SessionManager
 import com.homeservices.technician.domain.auth.model.AuthState
+import com.homeservices.technician.ui.jobOffer.JobOfferScreen
+import com.homeservices.technician.ui.jobOffer.JobOfferUiState
+import com.homeservices.technician.ui.jobOffer.JobOfferViewModel
 
 @Composable
 internal fun AppNavigation(
     sessionManager: SessionManager,
     activity: FragmentActivity,
     modifier: Modifier = Modifier,
-) {
+): Unit {
     val navController = rememberNavController()
     val authState by sessionManager.authState.collectAsStateWithLifecycle()
+    val jobOfferViewModel: JobOfferViewModel = hiltViewModel()
+    val jobOfferState by jobOfferViewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(authState) {
         when (authState) {
@@ -35,12 +43,19 @@ internal fun AppNavigation(
         }
     }
 
-    NavHost(
-        navController = navController,
-        startDestination = "auth",
-        modifier = modifier,
-    ) {
-        authGraph(navController, activity)
-        onboardingGraph(navController)
+    Box(modifier = modifier) {
+        NavHost(
+            navController = navController,
+            startDestination = "auth",
+        ) {
+            authGraph(navController, activity)
+            onboardingGraph(navController)
+        }
+        if (jobOfferState !is JobOfferUiState.Idle) {
+            JobOfferScreen(
+                modifier = Modifier.fillMaxSize(),
+                viewModel = jobOfferViewModel,
+            )
+        }
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
@@ -87,15 +87,21 @@ internal fun JobOfferScreenContent(
                     onDecline = onDecline,
                 )
             }
-            is JobOfferUiState.Accepted -> JobOfferResultContent(
-                message = stringResource(R.string.job_offer_accepted), isSuccess = true
-            )
-            is JobOfferUiState.Declined -> JobOfferResultContent(
-                message = stringResource(R.string.job_offer_declined), isSuccess = false
-            )
-            is JobOfferUiState.Expired -> JobOfferResultContent(
-                message = stringResource(R.string.job_offer_expired), isSuccess = false
-            )
+            is JobOfferUiState.Accepted ->
+                JobOfferResultContent(
+                    message = stringResource(R.string.job_offer_accepted),
+                    isSuccess = true,
+                )
+            is JobOfferUiState.Declined ->
+                JobOfferResultContent(
+                    message = stringResource(R.string.job_offer_declined),
+                    isSuccess = false,
+                )
+            is JobOfferUiState.Expired ->
+                JobOfferResultContent(
+                    message = stringResource(R.string.job_offer_expired),
+                    isSuccess = false,
+                )
         }
     }
 }
@@ -109,20 +115,22 @@ private fun JobOfferContent(
     modifier: Modifier = Modifier,
 ): Unit {
     val isLastFiveSeconds = remainingSeconds <= 5
-    val countdownColor = if (isLastFiveSeconds) {
-        MaterialTheme.colorScheme.error
-    } else {
-        MaterialTheme.colorScheme.primary
-    }
+    val countdownColor =
+        if (isLastFiveSeconds) {
+            MaterialTheme.colorScheme.error
+        } else {
+            MaterialTheme.colorScheme.primary
+        }
     val progress by animateFloatAsState(
         targetValue = (remainingSeconds / 30f).coerceIn(0f, 1f),
         label = "countdown",
     )
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(24.dp),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .padding(24.dp),
         verticalArrangement = Arrangement.SpaceBetween,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -184,20 +192,23 @@ private fun JobOfferContent(
         ) {
             Button(
                 onClick = onAccept,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFF2E7D32),
-                ),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF2E7D32),
+                    ),
             ) {
                 Text("Accept", style = MaterialTheme.typography.titleMedium)
             }
             OutlinedButton(
                 onClick = onDecline,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
             ) {
                 Text("Decline", style = MaterialTheme.typography.titleMedium)
             }
@@ -218,11 +229,12 @@ private fun JobOfferResultContent(
         Text(
             text = message,
             style = MaterialTheme.typography.headlineSmall,
-            color = if (isSuccess) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            },
+            color =
+                if (isSuccess) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
             textAlign = TextAlign.Center,
         )
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
@@ -97,7 +97,7 @@ private fun JobOfferContent(
     onDecline: () -> Unit,
     modifier: Modifier = Modifier,
 ): Unit {
-    val isLastFiveSeconds = remainingSeconds in 0..4
+    val isLastFiveSeconds = remainingSeconds <= 5
     val countdownColor = if (isLastFiveSeconds) {
         MaterialTheme.colorScheme.error
     } else {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
@@ -1,0 +1,218 @@
+package com.homeservices.technician.ui.jobOffer
+
+import android.os.VibrationEffect
+import android.os.Vibrator
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homeservices.technician.domain.jobOffer.model.JobOffer
+
+@Composable
+internal fun JobOfferScreen(
+    modifier: Modifier = Modifier,
+    viewModel: JobOfferViewModel = hiltViewModel(),
+): Unit {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState) {
+        val state = uiState
+        if (state is JobOfferUiState.Offering && state.remainingSeconds in 1..5) {
+            try {
+                @Suppress("DEPRECATION")
+                val vibrator = context.getSystemService<Vibrator>()
+                vibrator?.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK))
+            } catch (_: Exception) {
+                // Haptic not available on emulator/test — guard silently
+            }
+        }
+    }
+
+    JobOfferScreenContent(
+        uiState = uiState,
+        onAccept = viewModel::accept,
+        onDecline = viewModel::decline,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun JobOfferScreenContent(
+    uiState: JobOfferUiState,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    modifier: Modifier = Modifier,
+): Unit {
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        when (uiState) {
+            is JobOfferUiState.Idle -> Unit
+            is JobOfferUiState.Offering -> {
+                JobOfferContent(
+                    offer = uiState.offer,
+                    remainingSeconds = uiState.remainingSeconds,
+                    onAccept = onAccept,
+                    onDecline = onDecline,
+                )
+            }
+            is JobOfferUiState.Accepted -> JobOfferResultContent(message = "Offer Accepted!", isSuccess = true)
+            is JobOfferUiState.Declined -> JobOfferResultContent(message = "Offer Declined", isSuccess = false)
+            is JobOfferUiState.Expired -> JobOfferResultContent(message = "Offer Expired", isSuccess = false)
+        }
+    }
+}
+
+@Composable
+private fun JobOfferContent(
+    offer: JobOffer,
+    remainingSeconds: Int,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    modifier: Modifier = Modifier,
+): Unit {
+    val isLastFiveSeconds = remainingSeconds in 0..4
+    val countdownColor = if (isLastFiveSeconds) {
+        MaterialTheme.colorScheme.error
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    val progress by animateFloatAsState(
+        targetValue = (remainingSeconds / 30f).coerceIn(0f, 1f),
+        label = "countdown",
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Header: countdown ring
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.padding(top = 32.dp),
+        ) {
+            CircularProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.size(96.dp),
+                color = countdownColor,
+                strokeWidth = 6.dp,
+            )
+            Text(
+                text = "$remainingSeconds",
+                style = MaterialTheme.typography.headlineMedium,
+                color = countdownColor,
+            )
+        }
+
+        // Job details
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = offer.serviceName,
+                style = MaterialTheme.typography.headlineSmall,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = offer.addressText,
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${offer.slotDate}  ${offer.slotWindow}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "%.1f km away".format(offer.distanceKm),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "Earnings: ₹${offer.amountPaise / 100}",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        // Accept / Decline buttons
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Button(
+                onClick = onAccept,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF2E7D32),
+                ),
+            ) {
+                Text("Accept", style = MaterialTheme.typography.titleMedium)
+            }
+            OutlinedButton(
+                onClick = onDecline,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+            ) {
+                Text("Decline", style = MaterialTheme.typography.titleMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun JobOfferResultContent(
+    message: String,
+    isSuccess: Boolean,
+    modifier: Modifier = Modifier,
+): Unit {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.headlineSmall,
+            color = if (isSuccess) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt
@@ -1,5 +1,6 @@
 package com.homeservices.technician.ui.jobOffer
 
+import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.compose.animation.core.animateFloatAsState
@@ -25,11 +26,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homeservices.technician.R
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
 
 @Composable
@@ -43,12 +46,14 @@ internal fun JobOfferScreen(
     LaunchedEffect(uiState) {
         val state = uiState
         if (state is JobOfferUiState.Offering && state.remainingSeconds in 1..5) {
-            try {
-                @Suppress("DEPRECATION")
-                val vibrator = context.getSystemService<Vibrator>()
-                vibrator?.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK))
-            } catch (_: Exception) {
-                // Haptic not available on emulator/test — guard silently
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                try {
+                    val vibrator = context.getSystemService<Vibrator>()
+                    @Suppress("DEPRECATION")
+                    vibrator?.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK))
+                } catch (_: Exception) {
+                    // Haptic not available on emulator/test — guard silently
+                }
             }
         }
     }
@@ -82,9 +87,15 @@ internal fun JobOfferScreenContent(
                     onDecline = onDecline,
                 )
             }
-            is JobOfferUiState.Accepted -> JobOfferResultContent(message = "Offer Accepted!", isSuccess = true)
-            is JobOfferUiState.Declined -> JobOfferResultContent(message = "Offer Declined", isSuccess = false)
-            is JobOfferUiState.Expired -> JobOfferResultContent(message = "Offer Expired", isSuccess = false)
+            is JobOfferUiState.Accepted -> JobOfferResultContent(
+                message = stringResource(R.string.job_offer_accepted), isSuccess = true
+            )
+            is JobOfferUiState.Declined -> JobOfferResultContent(
+                message = stringResource(R.string.job_offer_declined), isSuccess = false
+            )
+            is JobOfferUiState.Expired -> JobOfferResultContent(
+                message = stringResource(R.string.job_offer_expired), isSuccess = false
+            )
         }
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferUiState.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferUiState.kt
@@ -1,0 +1,18 @@
+package com.homeservices.technician.ui.jobOffer
+
+import com.homeservices.technician.domain.jobOffer.model.JobOffer
+
+public sealed class JobOfferUiState {
+    public data object Idle : JobOfferUiState()
+
+    public data class Offering(
+        val offer: JobOffer,
+        val remainingSeconds: Int,
+    ) : JobOfferUiState()
+
+    public data object Accepted : JobOfferUiState()
+
+    public data object Declined : JobOfferUiState()
+
+    public data object Expired : JobOfferUiState()
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -16,82 +16,86 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-internal class JobOfferViewModel @Inject constructor(
-    private val eventBus: JobOfferEventBus,
-    private val acceptUseCase: AcceptJobOfferUseCase,
-    private val declineUseCase: DeclineJobOfferUseCase,
-) : ViewModel() {
+internal class JobOfferViewModel
+    @Inject
+    constructor(
+        private val eventBus: JobOfferEventBus,
+        private val acceptUseCase: AcceptJobOfferUseCase,
+        private val declineUseCase: DeclineJobOfferUseCase,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<JobOfferUiState>(JobOfferUiState.Idle)
+        public val uiState: StateFlow<JobOfferUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow<JobOfferUiState>(JobOfferUiState.Idle)
-    public val uiState: StateFlow<JobOfferUiState> = _uiState.asStateFlow()
+        private var countdownJob: Job? = null
 
-    private var countdownJob: Job? = null
-
-    init {
-        viewModelScope.launch {
-            eventBus.events.collect { offer ->
-                countdownJob?.cancel()
-                val remainingMs = offer.expiresAtMs - System.currentTimeMillis()
-                if (remainingMs <= 0) {
-                    _uiState.value = JobOfferUiState.Expired
-                    scheduleReset(2_000L)
-                    return@collect
-                }
-                val initialSeconds = (remainingMs / 1000).toInt().coerceAtLeast(0)
-                _uiState.value = JobOfferUiState.Offering(offer, initialSeconds)
-                countdownJob = viewModelScope.launch {
-                    var seconds = initialSeconds
-                    while (seconds > 0) {
-                        delay(1_000L)
-                        seconds--
-                        val current = _uiState.value
-                        if (current is JobOfferUiState.Offering) {
-                            _uiState.value = current.copy(remainingSeconds = seconds)
-                        } else {
-                            break
-                        }
-                    }
-                    if (_uiState.value is JobOfferUiState.Offering) {
+        init {
+            viewModelScope.launch {
+                eventBus.events.collect { offer ->
+                    countdownJob?.cancel()
+                    val remainingMs = offer.expiresAtMs - System.currentTimeMillis()
+                    if (remainingMs <= 0) {
                         _uiState.value = JobOfferUiState.Expired
                         scheduleReset(2_000L)
+                        return@collect
                     }
+                    val initialSeconds = (remainingMs / 1000).toInt().coerceAtLeast(0)
+                    _uiState.value = JobOfferUiState.Offering(offer, initialSeconds)
+                    countdownJob =
+                        viewModelScope.launch {
+                            var seconds = initialSeconds
+                            while (seconds > 0) {
+                                delay(1_000L)
+                                seconds--
+                                val current = _uiState.value
+                                if (current is JobOfferUiState.Offering) {
+                                    _uiState.value = current.copy(remainingSeconds = seconds)
+                                } else {
+                                    break
+                                }
+                            }
+                            if (_uiState.value is JobOfferUiState.Offering) {
+                                _uiState.value = JobOfferUiState.Expired
+                                scheduleReset(2_000L)
+                            }
+                        }
                 }
             }
         }
-    }
 
-    public fun accept(): Unit {
-        val current = _uiState.value as? JobOfferUiState.Offering ?: return
-        countdownJob?.cancel()
-        viewModelScope.launch {
-            val result = try {
-                acceptUseCase(current.offer.bookingId)
-            } catch (_: Exception) {
-                JobOfferResult.Expired(current.offer.bookingId)
+        public fun accept(): Unit {
+            val current = _uiState.value as? JobOfferUiState.Offering ?: return
+            countdownJob?.cancel()
+            viewModelScope.launch {
+                val result =
+                    try {
+                        acceptUseCase(current.offer.bookingId)
+                    } catch (_: Exception) {
+                        JobOfferResult.Expired(current.offer.bookingId)
+                    }
+                _uiState.value =
+                    when (result) {
+                        is JobOfferResult.Accepted -> JobOfferUiState.Accepted
+                        is JobOfferResult.Expired -> JobOfferUiState.Expired
+                        is JobOfferResult.Declined -> JobOfferUiState.Declined
+                    }
+                scheduleReset(2_000L)
             }
-            _uiState.value = when (result) {
-                is JobOfferResult.Accepted -> JobOfferUiState.Accepted
-                is JobOfferResult.Expired -> JobOfferUiState.Expired
-                is JobOfferResult.Declined -> JobOfferUiState.Declined
+        }
+
+        public fun decline(): Unit {
+            val current = _uiState.value as? JobOfferUiState.Offering ?: return
+            countdownJob?.cancel()
+            viewModelScope.launch {
+                declineUseCase(current.offer.bookingId)
+                _uiState.value = JobOfferUiState.Declined
+                scheduleReset(2_000L)
             }
-            scheduleReset(2_000L)
         }
-    }
 
-    public fun decline(): Unit {
-        val current = _uiState.value as? JobOfferUiState.Offering ?: return
-        countdownJob?.cancel()
-        viewModelScope.launch {
-            declineUseCase(current.offer.bookingId)
-            _uiState.value = JobOfferUiState.Declined
-            scheduleReset(2_000L)
+        private fun scheduleReset(delayMs: Long): Unit {
+            viewModelScope.launch {
+                delay(delayMs)
+                _uiState.value = JobOfferUiState.Idle
+            }
         }
     }
-
-    private fun scheduleReset(delayMs: Long): Unit {
-        viewModelScope.launch {
-            delay(delayMs)
-            _uiState.value = JobOfferUiState.Idle
-        }
-    }
-}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -1,0 +1,86 @@
+package com.homeservices.technician.ui.jobOffer
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homeservices.technician.data.jobOffer.JobOfferEventBus
+import com.homeservices.technician.domain.jobOffer.AcceptJobOfferUseCase
+import com.homeservices.technician.domain.jobOffer.DeclineJobOfferUseCase
+import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class JobOfferViewModel @Inject constructor(
+    private val eventBus: JobOfferEventBus,
+    private val acceptUseCase: AcceptJobOfferUseCase,
+    private val declineUseCase: DeclineJobOfferUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<JobOfferUiState>(JobOfferUiState.Idle)
+    public val uiState: StateFlow<JobOfferUiState> = _uiState.asStateFlow()
+
+    private var countdownJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            eventBus.events.collect { offer ->
+                countdownJob?.cancel()
+                val remainingMs = offer.expiresAtMs - System.currentTimeMillis()
+                if (remainingMs <= 0) {
+                    _uiState.value = JobOfferUiState.Expired
+                    return@collect
+                }
+                val initialSeconds = (remainingMs / 1000).toInt().coerceAtLeast(0)
+                _uiState.value = JobOfferUiState.Offering(offer, initialSeconds)
+                countdownJob = viewModelScope.launch {
+                    var seconds = initialSeconds
+                    while (seconds > 0) {
+                        delay(1_000L)
+                        seconds--
+                        val current = _uiState.value
+                        if (current is JobOfferUiState.Offering) {
+                            _uiState.value = current.copy(remainingSeconds = seconds)
+                        } else {
+                            break
+                        }
+                    }
+                    if (_uiState.value is JobOfferUiState.Offering) {
+                        _uiState.value = JobOfferUiState.Expired
+                    }
+                }
+            }
+        }
+    }
+
+    public fun accept(): Unit {
+        val current = _uiState.value as? JobOfferUiState.Offering ?: return
+        countdownJob?.cancel()
+        viewModelScope.launch {
+            val result = try {
+                acceptUseCase(current.offer.bookingId)
+            } catch (_: Exception) {
+                JobOfferResult.Expired(current.offer.bookingId)
+            }
+            _uiState.value = when (result) {
+                is JobOfferResult.Accepted -> JobOfferUiState.Accepted
+                is JobOfferResult.Expired -> JobOfferUiState.Expired
+                is JobOfferResult.Declined -> JobOfferUiState.Declined
+            }
+        }
+    }
+
+    public fun decline(): Unit {
+        val current = _uiState.value as? JobOfferUiState.Offering ?: return
+        countdownJob?.cancel()
+        viewModelScope.launch {
+            declineUseCase(current.offer.bookingId)
+            _uiState.value = JobOfferUiState.Declined
+        }
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -34,6 +34,7 @@ internal class JobOfferViewModel @Inject constructor(
                 val remainingMs = offer.expiresAtMs - System.currentTimeMillis()
                 if (remainingMs <= 0) {
                     _uiState.value = JobOfferUiState.Expired
+                    scheduleReset(2_000L)
                     return@collect
                 }
                 val initialSeconds = (remainingMs / 1000).toInt().coerceAtLeast(0)
@@ -52,6 +53,7 @@ internal class JobOfferViewModel @Inject constructor(
                     }
                     if (_uiState.value is JobOfferUiState.Offering) {
                         _uiState.value = JobOfferUiState.Expired
+                        scheduleReset(2_000L)
                     }
                 }
             }
@@ -72,6 +74,7 @@ internal class JobOfferViewModel @Inject constructor(
                 is JobOfferResult.Expired -> JobOfferUiState.Expired
                 is JobOfferResult.Declined -> JobOfferUiState.Declined
             }
+            scheduleReset(2_000L)
         }
     }
 
@@ -81,6 +84,14 @@ internal class JobOfferViewModel @Inject constructor(
         viewModelScope.launch {
             declineUseCase(current.offer.bookingId)
             _uiState.value = JobOfferUiState.Declined
+            scheduleReset(2_000L)
+        }
+    }
+
+    private fun scheduleReset(delayMs: Long): Unit {
+        viewModelScope.launch {
+            delay(delayMs)
+            _uiState.value = JobOfferUiState.Idle
         }
     }
 }

--- a/technician-app/app/src/main/res/values/strings.xml
+++ b/technician-app/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">homeservices technician</string>
+    <string name="job_offer_accepted">Offer Accepted!</string>
+    <string name="job_offer_declined">Offer Declined</string>
+    <string name="job_offer_expired">Offer Expired</string>
 </resources>

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 import java.io.IOException
 
@@ -56,7 +57,7 @@ public class AcceptJobOfferUseCaseTest {
         runTest {
             stubFirebaseToken("test-id-token")
             coEvery { api.acceptOffer("Bearer test-id-token", "booking-expired") } returns
-                Response.error(410, okhttp3.ResponseBody.create(null, ""))
+                Response.error(410, "".toResponseBody(null))
 
             val result = useCase("booking-expired")
 
@@ -68,7 +69,7 @@ public class AcceptJobOfferUseCaseTest {
         runTest {
             stubFirebaseToken("test-id-token")
             coEvery { api.acceptOffer("Bearer test-id-token", "booking-500") } returns
-                Response.error(500, okhttp3.ResponseBody.create(null, ""))
+                Response.error(500, "".toResponseBody(null))
 
             assertThrows<RuntimeException> { useCase("booking-500") }
         }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -9,15 +9,15 @@ import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 import java.io.IOException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class AcceptJobOfferUseCaseTest {
@@ -34,9 +34,7 @@ public class AcceptJobOfferUseCaseTest {
 
     private fun stubFirebaseToken(token: String): Unit {
         val tokenResult = mockk<GetTokenResult> { every { this@mockk.token } returns token }
-        val user = mockk<FirebaseUser> {
-            every { getIdToken(false) } returns Tasks.forResult(tokenResult)
-        }
+        val user = mockk<FirebaseUser> { every { getIdToken(false) } returns Tasks.forResult(tokenResult) }
         every { firebaseAuth.currentUser } returns user
     }
 

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -1,0 +1,84 @@
+package com.homeservices.technician.domain.jobOffer
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class AcceptJobOfferUseCaseTest {
+    private lateinit var api: JobOfferApiService
+    private lateinit var firebaseAuth: FirebaseAuth
+    private lateinit var useCase: AcceptJobOfferUseCase
+
+    @BeforeEach
+    public fun setUp(): Unit {
+        api = mockk()
+        firebaseAuth = mockk()
+        useCase = AcceptJobOfferUseCase(api, firebaseAuth)
+    }
+
+    private fun stubFirebaseToken(token: String): Unit {
+        val tokenResult = mockk<GetTokenResult> { every { this@mockk.token } returns token }
+        val user = mockk<FirebaseUser> {
+            every { getIdToken(false) } returns Tasks.forResult(tokenResult)
+        }
+        every { firebaseAuth.currentUser } returns user
+    }
+
+    @Test
+    public fun `invoke returns Accepted on HTTP 200`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.acceptOffer("Bearer test-id-token", "booking-123") } returns
+                Response.success(Unit)
+
+            val result = useCase("booking-123")
+
+            assertThat(result).isEqualTo(JobOfferResult.Accepted("booking-123"))
+        }
+
+    @Test
+    public fun `invoke returns Expired on HTTP 410`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.acceptOffer("Bearer test-id-token", "booking-expired") } returns
+                Response.error(410, okhttp3.ResponseBody.create(null, ""))
+
+            val result = useCase("booking-expired")
+
+            assertThat(result).isEqualTo(JobOfferResult.Expired("booking-expired"))
+        }
+
+    @Test
+    public fun `invoke throws RuntimeException on unexpected HTTP error`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.acceptOffer("Bearer test-id-token", "booking-500") } returns
+                Response.error(500, okhttp3.ResponseBody.create(null, ""))
+
+            assertThrows<RuntimeException> { useCase("booking-500") }
+        }
+
+    @Test
+    public fun `invoke propagates IOException on network error`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.acceptOffer(any(), any()) } throws IOException("Connection reset")
+
+            assertThrows<IOException> { useCase("booking-net-err") }
+        }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -9,6 +9,8 @@ import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -16,8 +18,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import retrofit2.Response
 import java.io.IOException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class AcceptJobOfferUseCaseTest {

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 import java.io.IOException
 
@@ -57,7 +58,7 @@ public class DeclineJobOfferUseCaseTest {
         runTest {
             stubFirebaseToken("test-id-token")
             coEvery { api.declineOffer("Bearer test-id-token", "booking-http-err") } returns
-                Response.error(503, okhttp3.ResponseBody.create(null, ""))
+                Response.error(503, "".toResponseBody(null))
 
             val result = useCase("booking-http-err")
 

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
@@ -9,14 +9,14 @@ import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.Response
 import java.io.IOException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 
 // Per Karnataka FR-9.1: decline counts MUST NEVER appear in any UI label, sort order,
 // or analytics event. These tests verify only that Declined is returned, never the count.

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
@@ -9,14 +9,14 @@ import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 import java.io.IOException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 
 // Per Karnataka FR-9.1: decline counts MUST NEVER appear in any UI label, sort order,
 // or analytics event. These tests verify only that Declined is returned, never the count.
@@ -35,9 +35,7 @@ public class DeclineJobOfferUseCaseTest {
 
     private fun stubFirebaseToken(token: String): Unit {
         val tokenResult = mockk<GetTokenResult> { every { this@mockk.token } returns token }
-        val user = mockk<FirebaseUser> {
-            every { getIdToken(false) } returns Tasks.forResult(tokenResult)
-        }
+        val user = mockk<FirebaseUser> { every { getIdToken(false) } returns Tasks.forResult(tokenResult) }
         every { firebaseAuth.currentUser } returns user
     }
 

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.homeservices.technician.domain.jobOffer
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+import java.io.IOException
+
+// Per Karnataka FR-9.1: decline counts MUST NEVER appear in any UI label, sort order,
+// or analytics event. These tests verify only that Declined is returned, never the count.
+@OptIn(ExperimentalCoroutinesApi::class)
+public class DeclineJobOfferUseCaseTest {
+    private lateinit var api: JobOfferApiService
+    private lateinit var firebaseAuth: FirebaseAuth
+    private lateinit var useCase: DeclineJobOfferUseCase
+
+    @BeforeEach
+    public fun setUp(): Unit {
+        api = mockk()
+        firebaseAuth = mockk()
+        useCase = DeclineJobOfferUseCase(api, firebaseAuth)
+    }
+
+    private fun stubFirebaseToken(token: String): Unit {
+        val tokenResult = mockk<GetTokenResult> { every { this@mockk.token } returns token }
+        val user = mockk<FirebaseUser> {
+            every { getIdToken(false) } returns Tasks.forResult(tokenResult)
+        }
+        every { firebaseAuth.currentUser } returns user
+    }
+
+    @Test
+    public fun `invoke returns Declined on HTTP 200`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.declineOffer("Bearer test-id-token", "booking-123") } returns
+                Response.success(Unit)
+
+            val result = useCase("booking-123")
+
+            assertThat(result).isEqualTo(JobOfferResult.Declined("booking-123"))
+        }
+
+    @Test
+    public fun `invoke returns Declined on HTTP error (user intention is the source of truth)`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.declineOffer("Bearer test-id-token", "booking-http-err") } returns
+                Response.error(503, okhttp3.ResponseBody.create(null, ""))
+
+            val result = useCase("booking-http-err")
+
+            assertThat(result).isEqualTo(JobOfferResult.Declined("booking-http-err"))
+        }
+
+    @Test
+    public fun `invoke returns Declined when network throws IOException`(): Unit =
+        runTest {
+            stubFirebaseToken("test-id-token")
+            coEvery { api.declineOffer(any(), any()) } throws IOException("No network")
+
+            val result = useCase("booking-net-err")
+
+            assertThat(result).isEqualTo(JobOfferResult.Declined("booking-net-err"))
+        }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
@@ -1,0 +1,66 @@
+package com.homeservices.technician.domain.jobOffer
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import com.homeservices.technician.data.jobOffer.FcmTokenRequest
+import com.homeservices.technician.data.jobOffer.JobOfferApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class FcmTokenSyncUseCaseTest {
+    private lateinit var api: JobOfferApiService
+    private lateinit var firebaseAuth: FirebaseAuth
+    private lateinit var useCase: FcmTokenSyncUseCase
+
+    @BeforeEach
+    public fun setUp(): Unit {
+        api = mockk()
+        firebaseAuth = mockk()
+        useCase = FcmTokenSyncUseCase(api, firebaseAuth)
+    }
+
+    private fun stubFirebaseToken(idToken: String): Unit {
+        val tokenResult = mockk<GetTokenResult> { every { this@mockk.token } returns idToken }
+        val user = mockk<FirebaseUser> {
+            every { getIdToken(false) } returns Tasks.forResult(tokenResult)
+        }
+        every { firebaseAuth.currentUser } returns user
+    }
+
+    @Test
+    public fun `invoke calls api with correct token and auth header`(): Unit =
+        runTest {
+            stubFirebaseToken("id-token-xyz")
+            coEvery {
+                api.syncFcmToken("Bearer id-token-xyz", FcmTokenRequest("fcm-device-token"))
+            } returns Response.success(Unit)
+
+            useCase.invokeWithFcmToken("fcm-device-token")
+
+            coVerify(exactly = 1) {
+                api.syncFcmToken("Bearer id-token-xyz", FcmTokenRequest("fcm-device-token"))
+            }
+        }
+
+    @Test
+    public fun `invoke handles network error gracefully (no exception escapes)`(): Unit =
+        runTest {
+            stubFirebaseToken("id-token-xyz")
+            coEvery { api.syncFcmToken(any(), any()) } throws IOException("Network unavailable")
+
+            assertThatCode { runTest { useCase.invokeWithFcmToken("fcm-device-token") } }
+                .doesNotThrowAnyException()
+        }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
@@ -10,13 +10,13 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.Response
 import java.io.IOException
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class FcmTokenSyncUseCaseTest {

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
@@ -12,7 +12,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.Response
@@ -58,7 +57,6 @@ public class FcmTokenSyncUseCaseTest {
             stubFirebaseToken("id-token-xyz")
             coEvery { api.syncFcmToken(any(), any()) } throws IOException("Network unavailable")
 
-            assertThatCode { runTest { useCase.invokeWithFcmToken("fcm-device-token") } }
-                .doesNotThrowAnyException()
+            useCase.invokeWithFcmToken("fcm-device-token") // IOException is swallowed — no throw
         }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCaseTest.kt
@@ -10,13 +10,13 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import retrofit2.Response
 import java.io.IOException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class FcmTokenSyncUseCaseTest {
@@ -33,9 +33,7 @@ public class FcmTokenSyncUseCaseTest {
 
     private fun stubFirebaseToken(idToken: String): Unit {
         val tokenResult = mockk<GetTokenResult> { every { this@mockk.token } returns idToken }
-        val user = mockk<FirebaseUser> {
-            every { getIdToken(false) } returns Tasks.forResult(tokenResult)
-        }
+        val user = mockk<FirebaseUser> { every { getIdToken(false) } returns Tasks.forResult(tokenResult) }
         every { firebaseAuth.currentUser } returns user
     }
 

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreenPaparazziTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreenPaparazziTest.kt
@@ -1,0 +1,87 @@
+package com.homeservices.technician.ui.jobOffer
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import com.homeservices.technician.domain.jobOffer.model.JobOffer
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+
+public class JobOfferScreenPaparazziTest {
+    @get:Rule
+    public val paparazzi: Paparazzi =
+        Paparazzi(
+            deviceConfig = DeviceConfig.PIXEL_5,
+            theme = "android:Theme.Material3.DayNight.NoActionBar",
+        )
+
+    private fun anOffer(): JobOffer =
+        JobOffer(
+            bookingId = "booking-123",
+            serviceId = "svc-1",
+            serviceName = "AC Repair",
+            addressText = "12 Main Street, Bengaluru",
+            slotDate = "2026-05-01",
+            slotWindow = "10:00–12:00",
+            amountPaise = 50000L,
+            distanceKm = 2.5,
+            expiresAtMs = System.currentTimeMillis() + 30_000L,
+        )
+
+    @Test
+    @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
+    public fun JobOfferScreen_offerArrived_lightTheme(): Unit {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                JobOfferScreenContent(
+                    uiState = JobOfferUiState.Offering(offer = anOffer(), remainingSeconds = 28),
+                    onAccept = {},
+                    onDecline = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
+    public fun JobOfferScreen_offerArrived_darkTheme(): Unit {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = true) {
+                JobOfferScreenContent(
+                    uiState = JobOfferUiState.Offering(offer = anOffer(), remainingSeconds = 28),
+                    onAccept = {},
+                    onDecline = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
+    public fun JobOfferScreen_lastFiveSeconds(): Unit {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                JobOfferScreenContent(
+                    uiState = JobOfferUiState.Offering(offer = anOffer(), remainingSeconds = 4),
+                    onAccept = {},
+                    onDecline = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
+    public fun JobOfferScreen_expired(): Unit {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                JobOfferScreenContent(
+                    uiState = JobOfferUiState.Expired,
+                    onAccept = {},
+                    onDecline = {},
+                )
+            }
+        }
+    }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreenPaparazziTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreenPaparazziTest.kt
@@ -31,7 +31,7 @@ public class JobOfferScreenPaparazziTest {
 
     @Test
     @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
-    public fun JobOfferScreen_offerArrived_lightTheme(): Unit {
+    public fun jobOfferScreen_offerArrived_lightTheme(): Unit {
         paparazzi.snapshot {
             HomeservicesTheme(darkTheme = false) {
                 JobOfferScreenContent(
@@ -45,7 +45,7 @@ public class JobOfferScreenPaparazziTest {
 
     @Test
     @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
-    public fun JobOfferScreen_offerArrived_darkTheme(): Unit {
+    public fun jobOfferScreen_offerArrived_darkTheme(): Unit {
         paparazzi.snapshot {
             HomeservicesTheme(darkTheme = true) {
                 JobOfferScreenContent(
@@ -59,7 +59,7 @@ public class JobOfferScreenPaparazziTest {
 
     @Test
     @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
-    public fun JobOfferScreen_lastFiveSeconds(): Unit {
+    public fun jobOfferScreen_lastFiveSeconds(): Unit {
         paparazzi.snapshot {
             HomeservicesTheme(darkTheme = false) {
                 JobOfferScreenContent(
@@ -73,7 +73,7 @@ public class JobOfferScreenPaparazziTest {
 
     @Test
     @Ignore("goldens recorded on CI — see docs/patterns/paparazzi-cross-os-goldens.md")
-    public fun JobOfferScreen_expired(): Unit {
+    public fun jobOfferScreen_expired(): Unit {
         paparazzi.snapshot {
             HomeservicesTheme(darkTheme = false) {
                 JobOfferScreenContent(

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModelTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModelTest.kt
@@ -94,6 +94,17 @@ public class JobOfferViewModelTest {
         }
 
     @Test
+    public fun `accept transitions to Expired when use case reports booking already taken`(): Unit =
+        runTest {
+            offerFlow.emit(aJobOffer(expiresAtMs = System.currentTimeMillis() + 30_000L))
+            coEvery { acceptUseCase(any()) } returns JobOfferResult.Expired("booking-123")
+
+            viewModel.accept()
+
+            assertThat(viewModel.uiState.value).isEqualTo(JobOfferUiState.Expired)
+        }
+
+    @Test
     public fun `decline transitions to Declined state`(): Unit =
         runTest {
             val offer = aJobOffer()
@@ -130,9 +141,8 @@ public class JobOfferViewModelTest {
             advanceTimeBy(5_000L)
 
             val laterState = viewModel.uiState.value
-            if (laterState is JobOfferUiState.Offering) {
-                assertThat(laterState.remainingSeconds).isLessThan(initialSeconds)
-            }
-            // If state transitioned away, that's also acceptable — offer may have expired.
+            assertThat(laterState).isInstanceOf(JobOfferUiState.Offering::class.java)
+            val offeringState = laterState as JobOfferUiState.Offering
+            assertThat(offeringState.remainingSeconds).isLessThan(initialSeconds)
         }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModelTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModelTest.kt
@@ -1,0 +1,138 @@
+package com.homeservices.technician.ui.jobOffer
+
+import com.homeservices.technician.data.jobOffer.JobOfferEventBus
+import com.homeservices.technician.domain.jobOffer.AcceptJobOfferUseCase
+import com.homeservices.technician.domain.jobOffer.DeclineJobOfferUseCase
+import com.homeservices.technician.domain.jobOffer.model.JobOffer
+import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class JobOfferViewModelTest {
+    private lateinit var acceptUseCase: AcceptJobOfferUseCase
+    private lateinit var declineUseCase: DeclineJobOfferUseCase
+    private lateinit var eventBus: JobOfferEventBus
+    private lateinit var viewModel: JobOfferViewModel
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val offerFlow = MutableSharedFlow<JobOffer>(extraBufferCapacity = 1)
+
+    private fun aJobOffer(expiresAtMs: Long = System.currentTimeMillis() + 30_000L): JobOffer =
+        JobOffer(
+            bookingId = "booking-123",
+            serviceId = "svc-1",
+            serviceName = "AC Repair",
+            addressText = "12 Main Street, Bengaluru",
+            slotDate = "2026-05-01",
+            slotWindow = "10:00–12:00",
+            amountPaise = 50000L,
+            distanceKm = 2.5,
+            expiresAtMs = expiresAtMs,
+        )
+
+    @BeforeEach
+    public fun setUp(): Unit {
+        Dispatchers.setMain(testDispatcher)
+        acceptUseCase = mockk(relaxed = true)
+        declineUseCase = mockk(relaxed = true)
+        eventBus = mockk(relaxed = true)
+        every { eventBus.events } returns offerFlow
+        viewModel = JobOfferViewModel(eventBus, acceptUseCase, declineUseCase)
+    }
+
+    @AfterEach
+    public fun tearDown(): Unit {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    public fun `initial uiState is Idle`(): Unit =
+        runTest {
+            assertThat(viewModel.uiState.value).isEqualTo(JobOfferUiState.Idle)
+        }
+
+    @Test
+    public fun `offer arrives via bus — uiState becomes Offering with correct data and remaining seconds`(): Unit =
+        runTest {
+            val offer = aJobOffer(expiresAtMs = System.currentTimeMillis() + 30_000L)
+
+            offerFlow.emit(offer)
+
+            val state = viewModel.uiState.value
+            assertThat(state).isInstanceOf(JobOfferUiState.Offering::class.java)
+            val offering = state as JobOfferUiState.Offering
+            assertThat(offering.offer).isEqualTo(offer)
+            assertThat(offering.remainingSeconds).isGreaterThan(0)
+        }
+
+    @Test
+    public fun `accept transitions to Accepted state`(): Unit =
+        runTest {
+            val offer = aJobOffer()
+            offerFlow.emit(offer)
+            assertThat(viewModel.uiState.value).isInstanceOf(JobOfferUiState.Offering::class.java)
+
+            coEvery { acceptUseCase(offer.bookingId) } returns JobOfferResult.Accepted(offer.bookingId)
+
+            viewModel.accept()
+
+            assertThat(viewModel.uiState.value).isEqualTo(JobOfferUiState.Accepted)
+        }
+
+    @Test
+    public fun `decline transitions to Declined state`(): Unit =
+        runTest {
+            val offer = aJobOffer()
+            offerFlow.emit(offer)
+            assertThat(viewModel.uiState.value).isInstanceOf(JobOfferUiState.Offering::class.java)
+
+            coEvery { declineUseCase(offer.bookingId) } returns JobOfferResult.Declined(offer.bookingId)
+
+            viewModel.decline()
+
+            assertThat(viewModel.uiState.value).isEqualTo(JobOfferUiState.Declined)
+        }
+
+    @Test
+    public fun `offer expires when remainingSeconds reaches zero`(): Unit =
+        runTest {
+            val expiredOffer = aJobOffer(expiresAtMs = System.currentTimeMillis() - 1_000L)
+
+            offerFlow.emit(expiredOffer)
+
+            assertThat(viewModel.uiState.value).isEqualTo(JobOfferUiState.Expired)
+        }
+
+    @Test
+    public fun `countdown reduces remainingSeconds over time`(): Unit =
+        runTest {
+            val offer = aJobOffer(expiresAtMs = System.currentTimeMillis() + 30_000L)
+            offerFlow.emit(offer)
+
+            val initialState = viewModel.uiState.value as? JobOfferUiState.Offering
+            assertThat(initialState).isNotNull
+            val initialSeconds = initialState!!.remainingSeconds
+
+            advanceTimeBy(5_000L)
+
+            val laterState = viewModel.uiState.value
+            if (laterState is JobOfferUiState.Offering) {
+                assertThat(laterState.remainingSeconds).isLessThan(initialSeconds)
+            }
+            // If state transitioned away, that's also acceptable — offer may have expired.
+        }
+}

--- a/technician-app/gradle/libs.versions.toml
+++ b/technician-app/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-com
 # Firebase (BOM-pinned — firebase-auth-ktx / firebase-storage have no explicit version)
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging-ktx" }
 firebase-storage = { module = "com.google.firebase:firebase-storage" }
 
 # Observability


### PR DESCRIPTION
## Summary

- **FCM integration:** `HomeservicesFcmService` intercepts `JOB_OFFER` data messages, parses payload into `JobOffer` domain model, and emits to `JobOfferEventBus` (singleton SharedFlow)
- **Use cases:** `AcceptJobOfferUseCase` (PATCH accept + 410→Expired), `DeclineJobOfferUseCase` (always returns Declined — FR-9.1: decline counts never fed to ranking), `FcmTokenSyncUseCase` (syncs token on login and on `onNewToken`)
- **UI:** Full-screen overlay composable (`JobOfferScreen`) with service name, address, slot, distance, earnings (₹ from paise), 30-second countdown ring (red ≤5s), large Accept (green) + Decline (outline) buttons, haptic tick for last 5 seconds (API 29+ guarded), auto-dismiss after 2s on terminal state

## Work streams

| Stream | Commits | Contents |
|--------|---------|----------|
| WS-E init | 1 | libs.versions.toml sync + firebase-messaging-ktx |
| WS-A | 1 | `JobOffer` + `JobOfferResult` domain models |
| WS-B | 3 | FCM service + 3 use cases (TDD red→green→review fixes) |
| WS-C | 1 | `JobOfferModule` Hilt DI + kover exclusions |
| WS-D | 3 | `JobOfferViewModel` + `JobOfferScreen` overlay + Paparazzi stubs (TDD red→green→review fixes) |
| Smoke fixes | 7 | Compiler errors, ktlint, nested runTest, rebase onto main |

## Test plan

- [x] Smoke gate passed: `assembleDebug` → `ktlintCheck` → `testDebugUnitTest` (128 tests, 0 failures) → `koverVerify` (≥80% coverage)
- [ ] Paparazzi goldens: trigger `paparazzi-record.yml` workflow_dispatch after merge (Windows cannot record — cross-OS font drift)
- [ ] Manual device test: send FCM `JOB_OFFER` data message → verify overlay appears, countdown runs, haptic fires in last 5s, Accept/Decline work

## Constraints satisfied

- FR-9.1 (Karnataka): decline counts never appear in UI, sort, or analytics — enforced by code comment + test assertions
- ₹0 infra: FCM is free tier (unlimited)
- Paparazzi goldens: 4 `@Ignore`d tests, CI records via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)