### PR TITLE
feat(e10-s01): Karnataka right-to-refuse — four-layer decline-history isolation

### DIFF
--- a/.github/workflows/api-ship.yml
+++ b/.github/workflows/api-ship.yml
@@ -63,5 +63,12 @@ jobs:
       - name: semgrep SAST
         uses: returntocorp/semgrep-action@v1
         with:
-          config: p/typescript p/owasp-top-ten p/nodejs p/secrets
+          # `uses:` steps don't honor the job's `working-directory: api` default,
+          # so the local config path is repo-relative.
+          config: |
+            p/typescript
+            p/owasp-top-ten
+            p/nodejs
+            p/secrets
+            api/.semgrep.yml
 

--- a/api/.semgrep.yml
+++ b/api/.semgrep.yml
@@ -1,0 +1,39 @@
+# Karnataka Platform Workers Act 2025 — FR-9.1 data-layer enforcement.
+#
+# Companion enforcement layers:
+#   - api/tests/integration/dispatcher-data-isolation.test.ts (runtime test gate)
+#   - docs/dispatch-algorithm.md (public algorithm transparency doc)
+#   - docs/adr/0011-karnataka-decline-history-isolation.md (ADR)
+#
+# These rules fail CI if a developer accidentally introduces decline-derived
+# features into the dispatcher read path. Discipline alone is not auditable;
+# CI enforcement is. `acceptRate` is forbidden because it is mathematically
+# `1 - declineRate` — decline-derived even when positively framed.
+#
+# Path resolution: semgrep-action runs from repo root (uses: steps don't
+# honor api-ship.yml's `working-directory: api`), so paths are repo-relative.
+rules:
+  - id: karnataka-no-decline-in-dispatcher
+    pattern-either:
+      - pattern: declineCount
+      - pattern: declineHistory
+      - pattern: declineRatio
+      - pattern: pastDeclines
+      - pattern: rejectionCount
+      - pattern: rejectionHistory
+      - pattern: acceptRate
+      - pattern: acceptanceRate
+    paths:
+      include:
+        - "api/src/services/dispatcher.service.ts"
+        - "api/src/cosmos/technician-repository.ts"
+        - "api/src/cosmos/dispatch-attempt-repository.ts"
+        - "api/src/schemas/technician.ts"
+        - "api/src/schemas/dispatch-attempt.ts"
+    message: |
+      Decline history must not influence dispatch ranking
+      (Karnataka Platform Workers Act 2025, FR-9.1, NFR-C-1).
+      Reverse this change or revise docs/adr/0011-karnataka-decline-history-isolation.md
+      with explicit owner approval.
+    languages: [typescript]
+    severity: ERROR

--- a/api/.semgrep.yml
+++ b/api/.semgrep.yml
@@ -19,10 +19,27 @@ rules:
       - pattern: declineHistory
       - pattern: declineRatio
       - pattern: pastDeclines
+      - pattern: declined_in_last
       - pattern: rejectionCount
       - pattern: rejectionHistory
       - pattern: acceptRate
       - pattern: acceptanceRate
+      - pattern: $X["declineCount"]
+      - pattern: $X['declineCount']
+      - pattern: $X["declineHistory"]
+      - pattern: $X['declineHistory']
+      - pattern: $X["declineRatio"]
+      - pattern: $X['declineRatio']
+      - pattern: $X["pastDeclines"]
+      - pattern: $X['pastDeclines']
+      - pattern: $X["declined_in_last"]
+      - pattern: $X['declined_in_last']
+      - pattern: $X["rejectionCount"]
+      - pattern: $X['rejectionCount']
+      - pattern: $X["acceptRate"]
+      - pattern: $X['acceptRate']
+      - pattern: $X["acceptanceRate"]
+      - pattern: $X['acceptanceRate']
     paths:
       include:
         - "api/src/services/dispatcher.service.ts"

--- a/api/tests/integration/dispatcher-data-isolation.test.ts
+++ b/api/tests/integration/dispatcher-data-isolation.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Karnataka Platform Workers Act 2025 — Data-layer isolation gate (FR-9.1, NFR-C-1).
+ *
+ * The dispatcher's read path (service + cosmos repos + schemas) must NEVER
+ * reference decline-derived fields. This test scans the source files and the
+ * Zod schema shapes to enforce the invariant at CI time, beyond the runtime
+ * ranking-invariance test in dispatcher-up-ranking.test.ts.
+ *
+ * Companion enforcement layers:
+ *   - api/.semgrep.yml — same rule at lint time.
+ *   - docs/dispatch-algorithm.md — public-facing transparency doc.
+ *   - docs/adr/0011-karnataka-decline-history-isolation.md — decision record.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TechnicianProfileSchema } from '../../src/schemas/technician.js';
+import {
+  DispatchAttemptStatusSchema,
+  DispatchAttemptDocSchema,
+} from '../../src/schemas/dispatch-attempt.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const API_ROOT = resolve(here, '..', '..');
+
+// Decline-derived identifiers forbidden in the dispatcher read path.
+// `acceptRate` is mathematically equivalent to `1 - declineRate` and is
+// therefore decline-derived even though positively framed.
+const FORBIDDEN_TOKENS = [
+  'declineCount',
+  'declineHistory',
+  'declineRatio',
+  'declined_in_last',
+  'rejectionCount',
+  'rejectionHistory',
+  'pastDeclines',
+  'acceptRate',
+  'acceptanceRate',
+] as const;
+
+const DISPATCHER_FILES = [
+  'src/services/dispatcher.service.ts',
+  'src/cosmos/technician-repository.ts',
+  'src/cosmos/dispatch-attempt-repository.ts',
+  'src/schemas/technician.ts',
+  'src/schemas/dispatch-attempt.ts',
+] as const;
+
+function readApiFile(rel: string): string {
+  return readFileSync(resolve(API_ROOT, rel), 'utf8');
+}
+
+describe('Karnataka FR-9.1 — Data-layer isolation', () => {
+  it.each(DISPATCHER_FILES)(
+    '%s contains no decline-derived identifiers',
+    (file) => {
+      const content = readApiFile(file).toLowerCase();
+      for (const token of FORBIDDEN_TOKENS) {
+        expect(
+          content.includes(token.toLowerCase()),
+          `${token} appears in ${file} — Karnataka FR-9.1 violation`,
+        ).toBe(false);
+      }
+    },
+  );
+
+  it('TechnicianProfileSchema shape exposes no decline- or rejection-prefixed field', () => {
+    const keys = Object.keys(TechnicianProfileSchema.shape).map((k) => k.toLowerCase());
+    for (const k of keys) {
+      expect(
+        k.startsWith('decline'),
+        `TechnicianProfileSchema field "${k}" starts with "decline"`,
+      ).toBe(false);
+      expect(
+        k.startsWith('rejection'),
+        `TechnicianProfileSchema field "${k}" starts with "rejection"`,
+      ).toBe(false);
+    }
+  });
+
+  it('DispatchAttemptStatusSchema enumerates exactly PENDING|ACCEPTED|EXPIRED', () => {
+    // No 'DECLINED' / 'REJECTED' — those would imply per-tech decline tracking.
+    // A tech who fails to accept within 30s causes the attempt to EXPIRE for
+    // them, which is an attempt-level state, not a per-tech decline record.
+    const values = [...DispatchAttemptStatusSchema.options].sort();
+    expect(values).toEqual(['ACCEPTED', 'EXPIRED', 'PENDING']);
+  });
+
+  it('DispatchAttemptDocSchema shape has no decline-aggregation fields', () => {
+    const keys = Object.keys(DispatchAttemptDocSchema.shape).map((k) => k.toLowerCase());
+    for (const k of keys) {
+      expect(
+        k.startsWith('decline'),
+        `DispatchAttemptDocSchema field "${k}" starts with "decline"`,
+      ).toBe(false);
+      expect(
+        k.includes('rejection'),
+        `DispatchAttemptDocSchema field "${k}" contains "rejection"`,
+      ).toBe(false);
+    }
+  });
+});

--- a/api/tests/integration/dispatcher-up-ranking.test.ts
+++ b/api/tests/integration/dispatcher-up-ranking.test.ts
@@ -82,4 +82,31 @@ describe('Dispatch ranking — invariant to decline history (Ayodhya pilot)', ()
     expect(profile).not.toHaveProperty('declineHistory');
     expect(profile).not.toHaveProperty('declines');
   });
+
+  it('phantom decline field on input is ignored — output ordering unchanged', () => {
+    /**
+     * Adversarial check (Karnataka FR-9.1, E10-S01): if a future refactor
+     * accidentally introduces a decline-derived field on TechnicianProfile,
+     * rankTechnicians must continue to ignore it. A phantom `declineCount` is
+     * tacked on via an unsafe cast to simulate that scenario.
+     */
+    const cleanA = makeTech('tech-A', 0.02, { rating: 4.0 });
+    const cleanB = makeTech('tech-B', 0.10, { rating: 4.0 });
+    const cleanC = makeTech('tech-C', 0.50, { rating: 4.0 });
+
+    const phantomA = { ...cleanA, declineCount: 999 } as unknown as TechnicianProfile;
+    const phantomB = { ...cleanB, declineCount: 0 } as unknown as TechnicianProfile;
+    const phantomC = { ...cleanC, declineCount: 0 } as unknown as TechnicianProfile;
+
+    const cleanRanking = rankTechnicians([cleanC, cleanB, cleanA], BOOKING_LAT, BOOKING_LNG)
+      .map((t) => t.id);
+    const phantomRanking = rankTechnicians(
+      [phantomC, phantomB, phantomA],
+      BOOKING_LAT,
+      BOOKING_LNG,
+    ).map((t) => t.id);
+
+    expect(phantomRanking).toEqual(cleanRanking);
+    expect(phantomRanking).toEqual(['tech-A', 'tech-B', 'tech-C']);
+  });
 });

--- a/docs/adr/0011-karnataka-decline-history-isolation.md
+++ b/docs/adr/0011-karnataka-decline-history-isolation.md
@@ -1,0 +1,93 @@
+# ADR-0011: Karnataka decline-history isolation enforced at four layers
+
+- **Status:** accepted
+- **Date:** 2026-04-26
+- **Deciders:** Alok Tiwari
+- **Supersedes:** the compliance section (§"Compliance enforcement") of ADR-0006, which contemplated `acceptance_rate_30d` as a candidate filter and ranking input. The implementation in `api/src/services/dispatcher.service.ts` never adopted that field, and this ADR ratifies the stricter actual behavior.
+
+## Context
+
+The **Karnataka Platform Based Gig Workers (Social Security and Welfare) Act 2025** came into force in May 2025 with implementing rules notified in November 2025. FR-9.1 of our PRD and NFR-C-1 of our architecture both reflect its core obligation: **technician declines must not be used, directly or indirectly, in algorithmic decisions that affect a technician's earnings**. The Central Social Security Code 2025 (Chapter IX) reinforces this for platform workers nationally.
+
+The Karnataka Labour Department may **audit the platform's dispatch algorithm with one week's notice**. The acceptable audit response is not "we trust developers not to add decline-derived features"; it is a demonstrable, multi-layer technical isolation that no individual code change can circumvent.
+
+ADR-0006 already named this constraint, but its "Compliance enforcement" section relied on (a) the absence of decline fields on the technician read-model and (b) a planned integration test. Since ADR-0006 was written:
+
+- The implementation diverged in the strict direction — even `acceptance_rate_30d` (which ADR-0006 proposed) was never added, because it is mathematically `1 − declineRate` and therefore decline-derived.
+- E08-S04 added a block-list filter to the dispatcher path, increasing the surface area of code that must remain compliant.
+- The actual `dispatcher-up-ranking.test.ts` test passes, but it does not on its own assert *which* fields the function is allowed to read — it only asserts ranking invariance for a single phantom field. A motivated developer could add an `acceptRate` term and the existing test could still pass given specific inputs.
+
+E10-S01 closes that gap.
+
+## Decision
+
+Enforce decline-history isolation at **four independent layers**:
+
+### a. Schema layer
+
+`TechnicianProfile` (`api/src/schemas/technician.ts`) and `DispatchAttemptDoc` (`api/src/schemas/dispatch-attempt.ts`) define **no decline-derived fields**. The dispatch attempt status set is exactly `'PENDING' | 'ACCEPTED' | 'EXPIRED'` — a tech who fails to accept within 30 s causes the attempt to **EXPIRE** for them; the system records no per-tech decline event for ranking purposes.
+
+### b. Source-code lint layer (Semgrep)
+
+`api/.semgrep.yml` defines rule `karnataka-no-decline-in-dispatcher` which fails with severity `ERROR` on any occurrence of `declineCount`, `declineHistory`, `declineRatio`, `pastDeclines`, `rejectionCount`, `rejectionHistory`, `acceptRate`, or `acceptanceRate` in:
+
+- `api/src/services/dispatcher.service.ts`
+- `api/src/cosmos/technician-repository.ts`
+- `api/src/cosmos/dispatch-attempt-repository.ts`
+- `api/src/schemas/technician.ts`
+- `api/src/schemas/dispatch-attempt.ts`
+
+`api-ship.yml` loads `api/.semgrep.yml` alongside the public Semgrep rule packs.
+
+### c. Runtime test layer (Vitest)
+
+Two tests in the API integration suite enforce the invariant on every CI run:
+
+- `api/tests/integration/dispatcher-up-ranking.test.ts` — asserts `rankTechnicians` is invariant to phantom decline fields and stable across all input permutations.
+- `api/tests/integration/dispatcher-data-isolation.test.ts` — file-scans the dispatcher source files for forbidden tokens and inspects the Zod schema `.shape` to assert no decline- or rejection-prefixed field exists.
+
+### d. Process layer
+
+This ADR + explicit owner approval are required to relax the invariant. Any future ranking improvement that genuinely benefits from decline-derived data must:
+
+1. Open an ADR superseding this one.
+2. Receive explicit written owner approval (per `CLAUDE.md` "Forbidden" section).
+3. Demonstrate a separate code path that is structurally unable to feed `dispatcher.service.ts` (separate file, separate import graph) for analytics/dashboard use cases.
+
+## Consequences
+
+**Positive:**
+- The compliance posture is auditable in source — a Karnataka Labour Department auditor can be handed `docs/dispatch-algorithm.md` plus the four enforcement files and verify the property end-to-end.
+- The four layers are independent: schema removal alone is insufficient, lint alone is insufficient, runtime test alone is insufficient. All four would have to be subverted for a violation to ship.
+- Future ranking improvements based on **non-decline** signals (`completedJobCount`, distance, rating) are explicitly allowed without revising this ADR.
+
+**Negative:**
+- Adds a Semgrep configuration dependency to the API CI pipeline (~5 s extra step).
+- Adds two integration tests to the API suite (~20 ms total).
+- Future legitimate analytics features that need decline data must live in a separate code path with no import line-of-sight to `dispatcher.service.ts` — this constrains module organization.
+
+**Neutral:**
+- The forbidden-token list is finite and may need to grow if future code introduces synonyms (e.g., `noShowRate`). The lint rule and the data-isolation test should be extended together when that happens.
+
+## Alternatives considered
+
+- **Source-code review only.** Rejected — not auditable, depends on reviewer vigilance, fails the "one week's notice" audit standard.
+- **Runtime test only (existing `dispatcher-up-ranking.test.ts`).** Rejected — invariance for one phantom field does not prove the function reads no decline-derived field at all. A developer could add `acceptRate` and craft test inputs that still pass.
+- **Schema-only enforcement.** Rejected — the field could be added to the schema later, or read from a sibling collection (`booking_events`) without a schema change to `TechnicianProfile`.
+- **Centralizing all dispatch features in a single allowlist module.** Considered for future work; the four-layer approach is the minimum viable enforcement for the launch gate. A typed allowlist could supplement (not replace) these layers in a later refactor.
+
+## References
+
+- `docs/prd.md` — FR-9.1, NFR-C-1
+- `docs/adr/0006-dispatch-algorithm.md` — original dispatch architecture (this ADR tightens its compliance section)
+- `docs/dispatch-algorithm.md` — public-facing algorithm transparency document
+- `api/src/services/dispatcher.service.ts`
+- `api/src/cosmos/technician-repository.ts`
+- `api/src/schemas/technician.ts`
+- `api/src/schemas/dispatch-attempt.ts`
+- `api/.semgrep.yml`
+- `api/tests/integration/dispatcher-up-ranking.test.ts`
+- `api/tests/integration/dispatcher-data-isolation.test.ts`
+- Karnataka Platform Based Gig Workers (Social Security and Welfare) Act 2025 (in force May 2025; rules notified Nov 2025)
+- Central Social Security Code 2025, Chapter IX — Platform Workers
+- DLA Piper analysis: *"Karnataka's new platform-based gig worker protection"* (Apr 2025)

--- a/docs/dispatch-algorithm.md
+++ b/docs/dispatch-algorithm.md
@@ -1,0 +1,106 @@
+# Dispatch Algorithm — Public Transparency Document
+
+**Owner:** Alok Tiwari
+**Last reviewed:** 2026-04-26
+**Authority:** Karnataka Platform Based Gig Workers (Social Security and Welfare) Act 2025, FR-9.1, NFR-C-1.
+**Companion artifacts:** `docs/adr/0006-dispatch-algorithm.md`, `docs/adr/0011-karnataka-decline-history-isolation.md`, `api/src/services/dispatcher.service.ts`, `api/.semgrep.yml`, `api/tests/integration/dispatcher-up-ranking.test.ts`, `api/tests/integration/dispatcher-data-isolation.test.ts`.
+
+## 1. Purpose
+
+The Karnataka Act of 2025 grants platform technicians the **right to refuse** offered tasks without consequence. The Karnataka Labour Department may audit the platform's dispatch algorithm with **one week's notice** to confirm compliance.
+
+This document is the artifact handed to such an auditor. It describes — with no abstraction — every input the dispatcher uses to rank technicians for a booking offer, and lists features deliberately **not** used.
+
+## 2. Algorithm Overview
+
+`rankTechnicians(candidates, bookingLat, bookingLng)` is a pure function in `api/src/services/dispatcher.service.ts`. It is invoked by `dispatchBookingToTechs` after Cosmos has returned a candidate set within the active dispatch radius (10 km, expanding to 15 km on no-show redispatch).
+
+The top-3 ranked technicians receive a 30-second FCM job offer simultaneously. The first to accept wins; the others receive a "no longer available" message. This document covers the **ranking** step only.
+
+## 3. Input features actually used by `rankTechnicians`
+
+| Feature | Source field | Role |
+|---|---|---|
+| Distance to booking | `tech.location.coordinates` (haversine to `bookingLat`/`bookingLng`) | **Primary sort key** (ascending) |
+| Tech rating | `tech.rating` (range 0–5, optional) | **Secondary sort key, tie-break only** (descending) |
+
+That is the complete list. No other field on `TechnicianProfile` is read by the ranking function.
+
+## 4. Implicit prerequisite filters (not ranking inputs)
+
+These are applied by the Cosmos query in `getTechniciansWithinRadius` **before** ranking, so they never participate in scoring:
+
+- `tech.skills` — must contain the booking's `serviceId`
+- `tech.kycStatus` — must equal `'APPROVED'`
+- `tech.isOnline` — must be `true`
+- `tech.isAvailable` — must be `true`
+- Geographic bounding-box predicate `ST_WITHIN`
+
+Plus a service-side circle filter on the haversine distance (square → circle), and exclusion of the no-show technician on redispatch.
+
+## 5. Input features deliberately NOT used
+
+The following are **forbidden by design** and **enforced at four layers** (see §7):
+
+- Decline count (any window)
+- Decline ratio
+- Declines in the last N days/hours
+- **Acceptance rate** (mathematically equivalent to `1 − declineRate`, hence decline-derived even when positively framed)
+- Response time / time-to-accept
+- Online hours per week
+- Geographic preference history
+- Per-customer relationship history (the `rating` field is platform-wide, not per-customer)
+
+`completedJobCount` exists on the schema for settlement and onboarding purposes but is currently **not** read by `rankTechnicians`. ADR-0011 explicitly carves out that future ranking improvements built on `completedJobCount` (or other non-decline signals) do **not** require revising ADR-0011 — only decline-derived features do.
+
+## 6. Pseudocode (transcribed verbatim from `dispatcher.service.ts`)
+
+```ts
+export function rankTechnicians(
+  techs: TechnicianProfile[],
+  bookingLat: number,
+  bookingLng: number,
+): TechnicianProfile[] {
+  return techs
+    .map((t) => ({
+      tech: t,
+      // GeoJSON coordinates: [longitude, latitude]
+      distanceKm: haversine(
+        bookingLat, bookingLng,
+        t.location.coordinates[1], t.location.coordinates[0],
+      ),
+    }))
+    .sort((a, b) => {
+      // Primary: distance, ascending
+      if (a.distanceKm !== b.distanceKm) return a.distanceKm - b.distanceKm;
+      // Secondary tie-break: rating, descending. Decline history MUST NEVER appear here.
+      return (b.tech.rating ?? 0) - (a.tech.rating ?? 0);
+    })
+    .map((x) => x.tech);
+}
+```
+
+## 7. Enforcement layers
+
+The compliance invariant is enforced at four independent layers so that any single oversight is caught:
+
+1. **Schema layer.** `TechnicianProfileSchema` and `DispatchAttemptDocSchema` (`api/src/schemas/`) define no decline-derived fields. The dispatcher cannot read what does not exist.
+2. **Source-code lint layer.** `api/.semgrep.yml` rule `karnataka-no-decline-in-dispatcher` blocks merges that introduce `declineCount`, `declineHistory`, `declineRatio`, `pastDeclines`, `rejectionCount`, `rejectionHistory`, or `acceptRate` into the dispatcher read-path source files.
+3. **Runtime test layer.** Two CI-enforced tests:
+   - `dispatcher-up-ranking.test.ts` — asserts ranking is invariant to phantom decline fields and stable across all input permutations.
+   - `dispatcher-data-isolation.test.ts` — file-scans the dispatcher source for forbidden tokens and inspects schema shapes.
+4. **Process layer.** ADR-0011 requires explicit owner approval to relax this invariant.
+
+## 8. Audit response procedure
+
+On request from the Karnataka Labour Department:
+
+1. **Within 24 hours:** send this document (`docs/dispatch-algorithm.md`) and `docs/adr/0011-karnataka-decline-history-isolation.md` at the SHA of the most recent production release.
+2. **Within 1 week:** extract `api/src/services/dispatcher.service.ts`, `api/src/cosmos/technician-repository.ts`, `api/src/schemas/technician.ts`, and the two test files at the same SHA, and append to the audit response.
+3. **On request:** demonstrate the CI failure mode by adding `pastDeclines` to `dispatcher.service.ts` in a sandbox branch — both the Semgrep rule and the data-isolation test will fail before merge.
+
+## 9. Document maintenance
+
+- Reviewed at every minor release of the API package.
+- Any change to `rankTechnicians` requires updating §3 and §6 of this document **in the same commit**.
+- Owner contact: Alok Tiwari (per project root `CLAUDE.md`).


### PR DESCRIPTION
## Summary

Adds **four-layer enforcement** of the Karnataka Platform Workers Act 2025 (FR-9.1) right-to-refuse invariant around the existing-correct dispatcher. **No source changes** to `dispatcher.service.ts`, `technician-repository.ts`, `dispatch-attempt-repository.ts`, or any schema — this story adds enforcement around code that already complies.

- **Schema layer:** `TechnicianProfile` and `DispatchAttemptDoc` already have no decline-derived fields. Documented as the first defense.
- **Source-code lint layer:** `api/.semgrep.yml` rule `karnataka-no-decline-in-dispatcher` blocks 8 forbidden identifiers in 5 dispatcher read-path files (`declineCount`, `declineHistory`, `declineRatio`, `pastDeclines`, `rejectionCount`, `rejectionHistory`, `acceptRate`, `acceptanceRate`). Loaded by `api-ship.yml` semgrep step.
- **Runtime test layer:** New `dispatcher-data-isolation.test.ts` (8 tests) scans dispatcher source for forbidden tokens + introspects Zod `.shape`. Extended `dispatcher-up-ranking.test.ts` (+1 test) asserts `rankTechnicians` ignores phantom `declineCount` injected via unsafe cast.
- **Process layer:** `docs/adr/0011-karnataka-decline-history-isolation.md` requires explicit owner approval to relax — supersedes ADR-0006 §"Compliance enforcement".

Plus `docs/dispatch-algorithm.md` (106 lines) — public-facing transparency doc handed to a Karnataka Labour Department auditor on request, containing the verbatim ranking pseudocode, exhaustive list of used/forbidden features, and 1-week audit response procedure.

## Branch base note

This PR is based on `main`, but the local branch was cut from `chore/paparazzi-golden-batch-record` (which is where E08-S01 / E08-S03 / E08-S04 stack). Because this story only touches files that are not in that stack (workflow + new test files + new docs + new Semgrep config), the diff against `main` is clean. See `docs/runbooks/codex-merge-train-2026-04-28.md` for the broader merge train order.

## Test plan

- [x] `pnpm -C api test` — 580/580 pass (8 new + 1 extended + 571 existing)
- [x] `pnpm -C api typecheck` — clean
- [x] `pnpm -C api lint` — 0 warnings
- [x] `bash tools/pre-codex-smoke-api.sh` — exit 0
- [x] Substitute review (`superpowers:code-reviewer`) — no P1 issues
- [ ] **DO NOT MERGE.** Codex review deferred to 2026-04-28 17:37 IST (weekly quota reset). Per the merge train runbook, this PR is #6 in the queue.
- [ ] Manual sanity check (post-Codex): `semgrep --config api/.semgrep.yml api/` returns zero findings; temporarily injecting `pastDeclines` into `dispatcher.service.ts` causes both the Semgrep rule and `dispatcher-data-isolation.test.ts` to fail; revert.

## Acceptance criteria

All seven AC from the E10-S01 spec are met (data-layer scan, phantom-field invariance, status-set enumeration, Semgrep rule, transparency doc, ADR-0011, dispatcher source unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)