### PR TITLE
docs(rescue): E04 + E05 story files (6 items, audit:tier1)

### DIFF
--- a/docs/stories/E04-S01-trust-dossier.md
+++ b/docs/stories/E04-S01-trust-dossier.md
@@ -1,0 +1,121 @@
+# Story E04-S01: Trust Dossier component (customer-app + admin-web)
+
+Status: shipped (PR #30, merged 2026-04-23, commit 93349c0) — **retroactive docs**
+
+> **Epic:** E04 — Trust Layer (Customer) (`docs/stories/README.md` §E04)
+> **Sprint:** S2 (wk 3–4) · **Estimated:** ≤ 1.5 dev-days · **Priority:** P0 (trust wedge)
+> **Sub-projects:** `api/` + `customer-app/` + `admin-web/`
+> **Ceremony tier:** Foundation (cross-cutting trust component, public API, three sub-projects)
+> **Plan file:** `plans/E04-S01-trust-dossier.md` (1476 lines, lives in repo)
+> **Retroactive note:** PR #30 shipped with its plan file (`plans/E04-S01-trust-dossier.md`) but no `docs/stories/E04-S01-*.md` file. This story is being authored after-the-fact from the merged PR (issue #115). Acceptance criteria are reverse-engineered from the merged code. The plan file is canonical for implementation detail.
+
+---
+
+## Story
+
+As a **customer browsing services** and as an **owner reviewing an order in the admin dashboard**,
+I want to see a unified Trust Dossier panel for the technician (photo, verified Aadhaar / background-check badges, certifications, languages, years in service, jobs completed, last 3 reviews),
+so that **I can build trust in the technician before booking and the owner can audit profile state inline without leaving the order view** (FR-3.1).
+
+---
+
+## Acceptance Criteria
+
+### AC-1 · Public dossier endpoint
+- `GET /v1/technicians/{id}/profile` (authLevel `anonymous`) returns 200 with a Zod-validated `TechnicianDossier` body
+- Response is read from the Cosmos `technicians` container (point-read by partition key = `id`); PII fields (phone, address, raw Aadhaar number) are stripped — schema only allows `displayName`, `photoUrl?`, `verifiedAadhaar`, `verifiedPoliceCheck`, `trainingInstitution?`, `certifications[]`, `languages[]`, `yearsInService`, `totalJobsCompleted`, `lastReviews[]` (max 3)
+- `displayName` falls back to legacy `name` field for existing Cosmos docs
+- Missing technician → 404 `NOT_FOUND`
+- Schema validation failure → 404 `NOT_FOUND` (do not leak Zod error shape on a public endpoint)
+- Response includes `Cache-Control: public, max-age=60` (low-mutation profile data)
+
+### AC-2 · `TrustDossierCard` Compose component (customer-app, two variants)
+- `TrustDossierCard(uiState: TrustDossierUiState, compact: Boolean, modifier: Modifier = Modifier)` is a stateless composable placed in `ui/shared/`
+- States: `Loading` (spinner), `Loaded(TechnicianProfile)` (compact or expanded), `Error(message)` (subdued), `Unavailable` (lock icon + "technician will be assigned shortly")
+- Compact (≤ 80 dp tall): 40 dp avatar + name + verified badge chips
+- Expanded: 64 dp avatar + name + jobs/years line + badges row + certifications list + languages list + last reviews block
+- Avatar rendered via Coil `AsyncImage`; circle clip; falls back gracefully on null `photoUrl`
+
+### AC-3 · `TrustDossierViewModel` lifecycle
+- `loadProfile(technicianId)` transitions `Unavailable → Loading → Loaded | Error`
+- Initial state is `Unavailable` (so screens that mount before a technician id is known render the assigning placeholder)
+- ViewModel collects `GetTechnicianProfileUseCase(id)` flow on `viewModelScope`
+- Failures map exception message to `Error.message`
+
+### AC-4 · Customer-app integration points
+- `ServiceDetailScreen` shows the **compact** card in place of the legacy `trust_dossier_stub` (Lock icon + stub text)
+- `BookingConfirmedScreen` shows the **expanded** card before the "Back to home" CTA
+- Both currently render the `Unavailable` state because no technician is bound to the booking until E05-S02 dispatch completes; the card surface area is locked in for the dispatch story to wire into
+
+### AC-5 · Admin-web `TrustDossierPanel` (collapsible, lazy-fetch)
+- `'use client'` component placed alongside `OrderSlideOver`
+- Renders a collapsed "▸ Trust Profile" toggle under the technician name; lazy-fetches `${NEXT_PUBLIC_API_BASE_URL}/api/v1/technicians/{id}/profile` on first expand
+- Renders dossier with same field set as Android (name, jobs/years, badges, certifications, languages, last reviews)
+- Loading + error states inline; collapses cleanly with no layout shift
+
+### AC-6 · Hilt DI reuses CatalogueModule singletons
+- `TechnicianProfileModule` injects unqualified `Moshi` + `OkHttpClient` provided by the existing `CatalogueModule` — does not declare a second pair (avoids duplicate-binding compile error)
+- `@Binds TechnicianProfileRepository ↔ TechnicianProfileRepositoryImpl`
+
+### AC-7 · TDD test coverage
+- `GetTechnicianProfileUseCaseTest` — delegates + propagates failure (2 tests)
+- `TechnicianProfileRepositoryImplTest` — DTO→domain mapping + IOException → `Result.failure` (2 tests)
+- `TrustDossierViewModelTest` — initial state + Loaded + Error (3 tests)
+- `TrustDossierCardPaparazziTest` — 4 `@Ignored` snapshot stubs (compact_unavailable, expanded_unavailable, compact_loaded, expanded_loaded); goldens recorded on CI Linux per `docs/patterns/paparazzi-cross-os-goldens.md`
+
+### AC-8 · Codex review passed
+- `.codex-review-passed` marker shipped in PR #30
+- P1 fix landed in same PR: `displayName` fallback to `name` for existing Cosmos docs
+
+---
+
+## Tasks / Subtasks (as actually shipped)
+
+> Implementation merged via PR #30. The plan file `plans/E04-S01-trust-dossier.md` is the canonical step-by-step (15 tasks). Below mirrors the work-stream summary.
+
+- [x] **WS-A — API schema + endpoint** (`api/src/schemas/technician-dossier.ts`, `api/src/functions/technicians.ts`)
+- [x] **WS-B — Android domain layer** (TDD red→green: `TechnicianProfile`, `TechnicianReview`, `TechnicianProfileRepository`, `GetTechnicianProfileUseCase`)
+- [x] **WS-C — Android data layer** (TDD red→green: DTO with `toDomain()`, `TechnicianProfileApiService`, `TechnicianProfileRepositoryImpl`, `TechnicianProfileModule`)
+- [x] **WS-D — UI + admin-web** (TDD red→green: `TrustDossierUiState`, `TrustDossierViewModel`, `TrustDossierCard`; admin-web `TechnicianDossier` types + `TrustDossierPanel` + `OrderSlideOver` wire-in)
+- [x] **WS-E — ktlint + smoke gate + Codex review + Paparazzi CI record**
+
+---
+
+## Dev Notes
+
+### Why `displayName` fallback to `name`
+Existing Cosmos documents from earlier seed data and from the KYC flow (E02-S03) store the technician's name under `name`, not `displayName`. The dossier endpoint had to gracefully handle both shapes to avoid surfacing 404s for valid technicians during the rollout window. The fallback is a one-line change in `getTechnicianProfileHandler` and is the only P1 finding from Codex review on PR #30.
+
+### Why Coil on Android (not Glide)
+Coil is already a transitive dep via androidx; Glide would have added a second image-loader. The Trust Dossier shipped before any other story added an image loader, so Coil became the project default by precedent. No ADR was filed because the choice was determined by what was already on the classpath.
+
+### Why the card defaults to `Unavailable`
+At the time of this story, dispatch (E05-S02) had not yet shipped, so no booking ever has a real `technicianId` yet. The card needed to render *something* so that screen layout could be locked in and Paparazzi goldens recorded on the same surface area E05-S03 will eventually fill. The `Unavailable` placeholder doubles as the post-payment "your technician will be assigned shortly" state.
+
+### Why no `@AuthOkHttpClient` qualifier
+The dossier endpoint is `authLevel: anonymous` — anyone can fetch a technician's public profile by id. No Firebase ID token needed; the unqualified `OkHttpClient` from `CatalogueModule` (no auth interceptor) is correct.
+
+---
+
+## Definition of Done
+
+- [x] `cd api && pnpm typecheck && pnpm test` green
+- [x] `cd customer-app && ./gradlew testDebugUnitTest ktlintCheck assembleDebug` green
+- [x] `cd admin-web && pnpm typecheck && pnpm lint && pnpm test` green
+- [x] Pre-Codex smoke gates exited 0
+- [x] `.codex-review-passed` marker shipped in PR #30
+- [x] Paparazzi goldens recorded on CI Linux and committed
+- [x] CI green on `main` after merge (commit 93349c0)
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Sonnet 4.6 (per PR #30 commit attribution)
+
+### Completion Notes
+PR #30 merged 2026-04-23 22:14 UTC as commit 93349c0. One Codex P1 fixed in-PR (`displayName` fallback). Paparazzi goldens recorded via `paparazzi-record.yml` workflow_dispatch on CI Linux.
+
+### File List
+See PR #30: 14 files added under `customer-app/`, 3 files added under `admin-web/`, 4 files added/modified under `api/`, 12 strings added to `customer-app/.../strings.xml`, plus the canonical `plans/E04-S01-trust-dossier.md` plan file. (PR #30 also bundled an unrelated SSC-levy story; that work is tracked elsewhere.)

--- a/docs/stories/E04-S02-confidence-score.md
+++ b/docs/stories/E04-S02-confidence-score.md
@@ -1,0 +1,153 @@
+# Story E04-S02: Pre-booking Confidence Score (on-time %, area rating, nearest ETA)
+
+Status: shipped (PR #34, merged 2026-04-24, commit 4861332) — **retroactive docs**
+
+> **Epic:** E04 — Trust Layer (Customer) (`docs/stories/README.md` §E04)
+> **Sprint:** S2 (wk 3–4) · **Estimated:** ≤ 1.5 dev-days · **Priority:** P1
+> **Sub-projects:** `api/` + `customer-app/`
+> **Ceremony tier:** Foundation (split into S02a + S02b due to API-then-Android dependency)
+> **Plan files:** `plans/E04-S02a.md` (609 lines, API + schema) and `plans/E04-S02b.md` (757 lines, Android domain/data/UI)
+> **Retroactive note:** PR #34 shipped with both plan files but no `docs/stories/E04-S02-*.md` file. This story is being authored after-the-fact from the merged PR (issue #116). The two plan files together are canonical for step-by-step implementation; this story file gives the user-facing acceptance criteria and ties them back to the plan files.
+
+---
+
+## Story
+
+As a **customer choosing whether to commit to a booking**,
+I want to see three pill chips on the Service Detail screen (technician's on-time % over the last 30 days, area rating, nearest ETA from my address), with a "Limited data" badge when the technician has fewer than 20 timed jobs and a tap-for-methodology bottom sheet,
+so that **I can decide whether to book this technician with confidence rather than guessing from a star rating alone** (FR-3.2).
+
+---
+
+## Acceptance Criteria
+
+### AC-1 · `GET /v1/technicians/{id}/confidence-score?lat=&lng=`
+- Behind `requireCustomer(...)` middleware (Firebase ID token + `customer` role)
+- Query schema: `lat ∈ [-90, 90]`, `lng ∈ [-180, 180]`, both required (`z.coerce.number`)
+- Response body (Zod `ConfidenceScoreResponseSchema`):
+  ```json
+  {
+    "onTimePercent": 87,
+    "areaRating": null,
+    "nearestEtaMinutes": 14,
+    "dataPointCount": 31,
+    "isLimitedData": false
+  }
+  ```
+- 400 `MISSING_PARAM` if `id` route param absent
+- 400 `VALIDATION_ERROR` if `lat`/`lng` invalid
+- 404 `TECHNICIAN_NOT_FOUND` if Cosmos read returns no doc OR throws Cosmos `code === 404`
+- 200 with `dataPointCount: 0` and `onTimePercent: 0` when no completed bookings in window
+
+### AC-2 · On-time % computation (last 30 days)
+- Query bookings with `status IN ('COMPLETED', 'PAID')` AND `slotDate >= today−30d`
+- **Filter on `slotDate`, not `createdAt`** — service quality is measured on when the slot was promised, not when the booking was paid (Codex P2 fix in-PR)
+- For each booking with a non-null `startedAt` timestamp:
+  - Parse `slotWindow` start hour/minute (format `"HH:MM-HH:MM"`)
+  - Slot start = `${slotDate}T${HH}:${MM}:00.000Z`
+  - On-time iff `(startedAt − slotStart) ≤ 15 minutes`
+- **Bookings without `startedAt` are excluded from the denominator** (untimed jobs cannot prove on-time-ness honestly — Codex P2 fix in-PR)
+- `onTimePercent = round((onTime / timed) × 100)`; 0 when `timed === 0`
+
+### AC-3 · `areaRating` deferred — return `null`
+- Per-booking ratings collection (E07-S01) ships later. Returning `null` is honest; returning a fabricated 0 or fake "—" placeholder would mislead.
+- Zod schema permits null (`z.number().min(0).max(5).nullable()`).
+
+### AC-4 · Nearest ETA (haversine + 20 km/h average urban speed)
+- Read technician doc by point-read (partition key = id = uid)
+- If `(lat, lng) === (0, 0)` → treat as "no customer location available" → `nearestEtaMinutes: null` (Codex P1 fix in-PR — guards against unset GPS sending the request to the city center by accident)
+- Otherwise: `etaMinutes = round((haversineKm(customer, tech) / 20) × 60)`
+
+### AC-5 · `isLimitedData` flag
+- `isLimitedData = dataPointCount < 20` — UI shows a "Limited data" badge so the customer knows the % is statistically thin
+
+### AC-6 · `ConfidenceScoreRow` Compose component
+- Three pill chips horizontally: on-time %, area rating ("—" when null), ETA chip ("ETA <N> min" or hidden when null)
+- Shimmer placeholder on `Loading` state
+- "Limited data" badge below the pills when `isLimitedData`
+- Tap any chip → bottom sheet explaining methodology (window length, on-time threshold, ETA assumption)
+- Pulled into `ServiceDetailScreen` after the price block; falls back to `Hidden` (no chips, no badge) when the API returns 401 or the user is unauthenticated
+
+### AC-7 · Optional `techId` query param on `SERVICE_DETAIL` route
+- `CatalogueRoutes.serviceDetail(serviceId, techId?)` builds `/serviceDetail/{serviceId}?techId={techId}`
+- `ServiceDetailViewModel.init` reads both params from `SavedStateHandle` and triggers `getConfidenceScoreUseCase` only when `techId` is present
+- When `techId` is absent (browse-without-recommendation path), the row stays `Hidden`
+
+### AC-8 · Karnataka FR-9.1 invariance preserved
+- The endpoint reads no decline-history field. The Cosmos query selects only `id, status, slotDate, slotWindow, startedAt`; the schema for the booking row is intentionally narrow.
+- This is enforced architecturally — no decline term is even available to the handler.
+
+### AC-9 · Known limitation (documented in `TechnicianModule.kt`)
+- The Android `TechnicianModule` OkHttpClient has no Firebase ID token interceptor. This branch predates customer auth (E02-S01 on a sibling branch). The endpoint requires `requireCustomer`, so Android calls return 401 until E02-S01 merges and the interceptor is wired into a `@AuthOkHttpClient` qualifier (mirror pattern from `BookingModule`). UI correctly falls back to `Hidden` state.
+
+### AC-10 · 7 rounds of Codex review, all P1/P2 resolved
+- 7 review rounds shipped in `docs/reviews/codex-E04-S02-round{1..7}-*.md` for posterity
+- Resolved: slotDate filter (P2), exclude untimed bookings from denominator (P2), areaRating null over fake (P2), (0,0) ETA guard (P1), 404 guard with Cosmos error discrimination (P1), `authLevel: anonymous` registration (P1), `/api` prefix on Android base URL (P1), `lifecycle-runtime-compose` dep (P1)
+- Auth interceptor deferred per AC-9 (waits on E02-S01 merge)
+
+---
+
+## Tasks / Subtasks (as actually shipped)
+
+> Plans `E04-S02a.md` (API) and `E04-S02b.md` (Android) are canonical. Below mirrors the work-stream summary.
+
+### Plan A (API)
+- [x] **WS-A1 — Zod schemas** (`ConfidenceScoreQuerySchema`, `ConfidenceScoreResponseSchema`)
+- [x] **WS-A2 — Endpoint handler + auth wrapper** (`getConfidenceScoreHandler` behind `requireCustomer`)
+- [x] **WS-A3 — Cosmos query + haversine helper** (in-handler `haversineKm`; bookings query filters on `slotDate`)
+- [x] **WS-A4 — Tests** (9 tests in `tests/technicians/confidence-score.test.ts`: 401, 400, 404, ETA hidden when (0,0), on-time math edge cases, untimed bookings excluded)
+
+### Plan B (Android)
+- [x] **WS-B1 — Domain layer** (`ConfidenceScore`, `GetConfidenceScoreUseCase`)
+- [x] **WS-B2 — Data layer** (`TechnicianApiService`, `ConfidenceScoreDto`, `ConfidenceScoreRepository(Impl)`, `TechnicianModule` Hilt DI)
+- [x] **WS-B3 — UI** (`ConfidenceScoreRow` composable + 3 pill chips + shimmer + limited-data badge + methodology bottom sheet)
+- [x] **WS-B4 — Navigation** (`SERVICE_DETAIL` route gains optional `techId` query param)
+- [x] **WS-B5 — ViewModel wiring** (`ServiceDetailViewModel` reads both params, triggers use case only when `techId` present)
+- [x] **WS-B6 — Paparazzi stubs + tests** (`ConfidenceScoreRowPaparazziTest` `@Ignored`; `GetConfidenceScoreUseCaseTest`; `ServiceDetailViewModelTest` extended)
+
+### WS-Z — Cross-cutting
+- [x] Pre-Codex smoke gate (`bash tools/pre-codex-smoke-api.sh` + `bash tools/pre-codex-smoke.sh customer-app`) PASSED
+- [x] 7 rounds of Codex review; `.codex-review-passed` marker at HEAD
+
+---
+
+## Dev Notes
+
+### Why split into S02a + S02b
+The story has API-then-Android sequencing with no UI work blocked on Android compile until the API contract is locked. Splitting let the Android plan reference a frozen schema and DTO. Both plans landed in the same PR (#34), but the split kept each plan under the 800-line warning threshold per CLAUDE.md story-size gate.
+
+### Why deferred `areaRating: null`
+Per-booking ratings (E07-S01) had not yet shipped at the time of this story. Returning `0` would suggest "bad area"; returning a fake `4.5` would be dishonest; UI would have to special-case "no data" anyway. Returning `null` is the simplest contract that lets the UI render "—" without lying. The schema permits null, the UI handles null, the field becomes meaningful once E07-S01 lands and a downstream story populates the value.
+
+### Why 20 km/h average urban speed
+This is the Bengaluru urban-traffic average from a back-of-envelope review of the location data E05-S01 seeds (Koramangala→Whitefield ≈ 11 km in ~33 min during traffic). It is intentionally conservative — over-estimating ETA is less harmful than promising the customer 5 min and showing up in 25. Once we have real per-leg telemetry from E04-S03 location pings, this constant can be replaced with a per-corridor estimate.
+
+### Why `(0, 0)` ETA guard rather than required `lat`/`lng`
+The query schema *does* require lat and lng, but `(0.0, 0.0)` is the legal-but-meaningless default produced when the customer has not yet granted the location permission. Codex caught this during round 4: a customer with no GPS would have been told "your technician is 1500 km away" because (0, 0) is in the Atlantic Ocean. The guard now hides ETA when the customer's location is unset.
+
+### Why the Android module ships with a known auth gap
+E02-S01 (customer auth) was on a sibling feature branch at the time of writing. Blocking the dossier story on E02-S01 would have stalled the trust layer. The interceptor gap is documented in `TechnicianModule.kt` and the UI's `Hidden` fallback is graceful — the chips simply don't render. When E02-S01 merges, a one-line `@AuthOkHttpClient` swap activates the calls. This is an acceptable temporary state because the screen ships with the trust dossier card from E04-S01 in the same area, so the section is not visually empty.
+
+---
+
+## Definition of Done
+
+- [x] `cd api && pnpm typecheck && pnpm test tests/technicians/confidence-score.test.ts` — 9 tests pass
+- [x] `cd customer-app && ./gradlew assembleDebug testDebugUnitTest` — BUILD SUCCESSFUL
+- [x] Pre-Codex smoke gates exited 0
+- [x] 7 rounds of Codex review completed; `.codex-review-passed` marker at HEAD
+- [x] All P1/P2 findings addressed except documented auth-interceptor branch constraint
+- [x] CI green on `main` after merge (commit 4861332)
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Sonnet 4.6 (per PR #34 commit attribution)
+
+### Completion Notes
+PR #34 merged 2026-04-24 02:24 UTC as commit 4861332. Seven Codex review rounds documented in `docs/reviews/codex-E04-S02-round{1..7}-*.md` (≈28k lines of review transcripts preserved for audit).
+
+### File List
+See PR #34. Plan-A files: `api/src/schemas/confidence-score.ts` (added), `api/src/functions/technicians.ts` (modified — added `getConfidenceScoreHandler` + helpers), `api/tests/technicians/confidence-score.test.ts` (added). Plan-B files: 7 added under `customer-app/.../data/technician/`, `domain/technician/`, `ui/catalogue/`; `CatalogueRoutes.kt` + `MainGraph.kt` + `ServiceDetailScreen.kt` + `ServiceDetailViewModel.kt` + `ServiceDetailUiState.kt` modified. Paparazzi: `ConfidenceScoreRowPaparazziTest` `@Ignored` (cross-OS golden drift).

--- a/docs/stories/E05-S01-technician-geospatial-profile.md
+++ b/docs/stories/E05-S01-technician-geospatial-profile.md
@@ -1,0 +1,134 @@
+# Story E05-S01: Technician geospatial profile — schema, ST_WITHIN repo, Bengaluru seed
+
+Status: shipped (PR #18, merged 2026-04-20, commit 3fdfa4e) — **retroactive docs**
+
+> **Epic:** E05 — Dispatch Engine + Job Offers (`docs/stories/README.md` §E05)
+> **Sprint:** S3 (wk 5–6) · **Estimated:** ≤ 1 dev-day · **Priority:** P0 (blocks E05-S02)
+> **Sub-project:** `api/`
+> **Ceremony tier:** Foundation (new schema + cross-cutting Cosmos query that downstream stories build on)
+> **Plan file:** `plans/E05-S01.md` (retroactively authored — see issue #98)
+> **Retroactive note:** PR #18 shipped without `docs/stories/E05-S01-*.md` or its plan file. Both are being added retroactively (issue #98). Acceptance criteria below are reverse-engineered from `api/src/schemas/technician.ts`, `api/src/cosmos/technician-repository.ts`, `api/src/cosmos/geo.ts`, `api/src/cosmos/indexes/technicians-index.json`, and `api/scripts/seed-technicians.ts`. Plan file holds canonical step-by-step.
+
+---
+
+## Story
+
+As **the dispatcher service** and as **the operator running the Bengaluru pilot**,
+I want a `TechnicianProfile` Cosmos schema with GeoJSON location, skills, availability, online/available flags, and KYC status, plus a repository that runs `ST_WITHIN` queries with a spatial index, plus a seed script that loads 10 Bengaluru technicians (including two edge-case docs the dispatcher MUST exclude),
+so that **E05-S02 can fan out job offers to the nearest skilled, KYC-approved, online, available technicians without scanning the whole container** (FR-4.1, ADR-0003, ADR-0006).
+
+---
+
+## Acceptance Criteria
+
+### AC-1 · `TechnicianProfileSchema` (Zod)
+- Required fields: `id`, `technicianId`, `location: GeoPoint`, `skills: string[].min(1)`, `availabilityWindows: AvailabilityWindow[]`, `isOnline: boolean`, `isAvailable: boolean`, `kycStatus: 'APPROVED' | 'PENDING' | 'REJECTED'`
+- Optional fields: `fcmToken`, `rating: number ∈ [0, 5]`, `completedJobCount: int ≥ 0`, `updatedAt: ISO datetime`
+- `GeoPoint`: `{ type: 'Point', coordinates: [number, number] }` — GeoJSON canonical `[lng, lat]` order
+- `AvailabilityWindow`: `dayOfWeek ∈ [0, 6]`, `startHour ∈ [0, 23]`, `endHour ∈ [1, 24]`
+- **No decline-history field anywhere in the schema** — FR-9.1 invariance is architecturally enforced by absence
+
+### AC-2 · `boundingBoxPolygon(lat, lng, radiusKm)` returns a closed 5-vertex ring
+- Computes `deltaLat = radiusKm / 111` and `deltaLng = radiusKm / (111 × cos(lat))`
+- Returns `{ type: 'Polygon', coordinates: [[sw, se, ne, nw, sw]] }` with vertices as `[lng, lat]` pairs
+- The polygon is a square that *contains* the desired circle; the dispatcher (E05-S02) does the haversine post-filter
+- Companion `pointInsidePolygon(...)` is a unit-test-only ray-casting helper (not used at runtime)
+
+### AC-3 · `getTechniciansWithinRadius(lat, lng, radiusKm, serviceId)` Cosmos query
+- Builds bounding-box polygon and runs:
+  ```sql
+  SELECT * FROM c
+  WHERE ST_WITHIN(c.location, @polygon)
+    AND ARRAY_CONTAINS(c.skills, @serviceId)
+    AND c.kycStatus = "APPROVED"
+    AND c.isOnline = true
+    AND c.isAvailable = true
+  ```
+- Returns `TechnicianProfile[]` (zero entries when no candidates match)
+- Three boolean filters mean offline techs and busy techs are physically excluded from the result set — no chance of accidentally dispatching to them
+
+### AC-4 · `upsertTechnicianProfile(profile)` writes to `technicians` container
+- Calls `container.items.upsert(profile)` (idempotent — used by both seed and the live online/availability toggles in E05-S02)
+- Container partition key is `/technicianId` (matches `id` in this schema)
+
+### AC-5 · Spatial index policy applied to `technicians`
+- `api/src/cosmos/indexes/technicians-index.json` declares:
+  ```json
+  "spatialIndexes": [{ "path": "/location/*", "types": ["Point"] }]
+  ```
+- Includes `indexingMode: consistent`, `automatic: true`, `excludedPaths: ["/\"_etag\"/?"]`
+- Applied either via `container.replace({ id, partitionKey, indexingPolicy })` at deploy time or manually via Azure Portal Data Explorer
+- Without the index, `ST_WITHIN` falls back to a slow scan — capacity bound for the dispatcher
+
+### AC-6 · Bengaluru seed: 10 technicians across the city
+- 8 healthy techs spread across Koramangala (12.9352, 77.6245), Indiranagar (12.9784, 77.6408), Whitefield (12.9698, 77.7500), HSR (12.9116, 77.6474), Marathahalli (12.9591, 77.7011), Jayanagar (12.9299, 77.5830), BTM (12.9166, 77.6101), Electronic City (12.8399, 77.6790)
+- 1 offline tech at Yelahanka (`isOnline: false`) — exists to verify the dispatch query EXCLUDES offline techs
+- 1 on-job tech at Banashankari (`isAvailable: false`) — exists to verify the dispatch query EXCLUDES busy techs
+- Skill mix covers AC, plumbing, electrical, cleaning, pest-control (so dispatch filtering by skill is meaningfully testable)
+- Run with `pnpm seed:technicians` (requires `COSMOS_ENDPOINT` + `COSMOS_KEY` env)
+- Seed is dev-only — not run in CI
+
+### AC-7 · TDD coverage: 22 new tests, suite at 125 green
+- 9 schema tests (`tests/schemas/technician.test.ts`) — valid + invalid `kycStatus` + edge cases
+- 6 geo polygon tests (`tests/unit/cosmos/geo.test.ts`) — shape, span, boundary exclusion invariant
+- 7 repository tests (`tests/unit/cosmos/technician-geospatial.test.ts`) — upsert, SQL construction, ST_WITHIN clause, ARRAY_CONTAINS, parameter passing
+
+### AC-8 · KYC integration with E02-S03
+- Existing `upsertKycStatus` and `getKycByTechnicianId` methods (added in E02-S03 pattern) are preserved at the top of `technician-repository.ts`
+- New geospatial methods are appended below — both shapes coexist on the same partition (`technicianId`)
+
+---
+
+## Tasks / Subtasks (as actually shipped)
+
+> Plan file `plans/E05-S01.md` is canonical. Below mirrors the work-stream summary.
+
+- [x] **WS-A — Schema (TDD)** — `tests/schemas/technician.test.ts` red → `src/schemas/technician.ts` green
+- [x] **WS-B — Geo helper (TDD)** — `tests/unit/cosmos/geo.test.ts` red → `src/cosmos/geo.ts` (`boundingBoxPolygon` + `pointInsidePolygon`) green
+- [x] **WS-C — Repository (TDD)** — `tests/unit/cosmos/technician-geospatial.test.ts` red → append `upsertTechnicianProfile` + `getTechniciansWithinRadius` to `technician-repository.ts` green
+- [x] **WS-D — Index policy + seed** — `src/cosmos/indexes/technicians-index.json`; `scripts/seed-technicians.ts`; `pnpm seed:technicians` script
+- [x] **WS-E — Smoke gate + Codex** — `bash tools/pre-codex-smoke-api.sh` PASSED; `.codex-review-passed` shipped at HEAD
+
+---
+
+## Dev Notes
+
+### Why bounding-box polygon, not a circle
+Cosmos `ST_WITHIN` requires a `Polygon` (or `MultiPolygon`) — there is no built-in `ST_DWITHIN` for "points within radius of point" in Cosmos's GeoJSON dialect at the time of this story. The bounding-box polygon is a square that *contains* the desired circle. The dispatcher (E05-S02) then runs a haversine pass to drop the four bounding-box corner techs that are inside the square but outside the actual radius. This is faster than fetching everything and post-filtering in Node, because the spatial index prunes the vast majority of the container on the database side.
+
+### Why GeoJSON `[lng, lat]` order
+Cosmos follows GeoJSON canonical (RFC 7946): `coordinates: [longitude, latitude]`. This is the opposite of the more intuitive "lat first" convention used in everyday speech. Every consumer of `TechnicianProfile.location.coordinates` must access `[1]` for latitude and `[0]` for longitude — the dispatcher's `rankTechnicians` and the haversine post-filter both honour this. A test fixture's lat/lng swap is a recurring source of bugs; the schema's tuple typing helps catch them at compile time.
+
+### Why the schema *omits* a `declineCount` field
+Karnataka FR-9.1 prohibits the dispatcher from using decline history as a ranking signal. The cleanest enforcement is *making the data unreachable*: the schema simply doesn't declare such a field, so any dispatcher attempt to read `tech.declineCount` would be a TypeScript compile error. E05-S02 adds a CI gate (`dispatcher-up-ranking.test.ts`) that asserts the schema does not regrow such a field, defending against well-meaning future developers who try to "improve" the ranking.
+
+### Why include the two edge-case seed docs
+The seed script is the only realistic way to verify the dispatch query's WHERE clause. Without the offline+on-job edge cases, a reviewer reading the query would have no proof that `isOnline` and `isAvailable` are *actually* enforced — the test could pass with the filters silently broken. The Yelahanka and Banashankari docs are deliberate trip-wires; if the dispatcher ever returns them, something is wrong.
+
+### Why optional `rating`, `fcmToken`, `completedJobCount`
+These are populated by *later* stories — `rating` by E07-S01 ratings flow, `fcmToken` by the Android app on first login (E05-S03), `completedJobCount` by the booking-completed handler in E06-S04. Making them optional in the schema lets E05-S01 ship with technicians who have *no* history yet, which is the realistic state at pilot launch.
+
+---
+
+## Definition of Done
+
+- [x] `cd api && pnpm typecheck && pnpm test` — 125/125 tests green (was 103 before this story)
+- [x] `bash tools/pre-codex-smoke-api.sh` exited 0
+- [x] `.codex-review-passed` marker shipped in PR #18
+- [x] `pnpm seed:technicians` validated against dev Cosmos endpoint (manual)
+- [x] CI green on `main` after merge (commit 3fdfa4e)
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Sonnet 4.6 (per PR #18 commit attribution)
+
+### Completion Notes
+PR #18 merged 2026-04-20 20:48 UTC as commit 3fdfa4e. PR also bundled the E09-S04/S05 audit-log work that landed in the same window — those changes are tracked in their own stories. Dispatcher remains a stub at this point; E05-S02 (PR #26) replaces it.
+
+### File List
+See PR #18 (E05-S01 portion only):
+- Added: `api/src/schemas/technician.ts`, `api/src/cosmos/geo.ts`, `api/src/cosmos/indexes/technicians-index.json`, `api/scripts/seed-technicians.ts`, `api/tests/schemas/technician.test.ts`, `api/tests/unit/cosmos/geo.test.ts`, `api/tests/unit/cosmos/technician-geospatial.test.ts`
+- Modified: `api/src/cosmos/technician-repository.ts` (appended geospatial methods), `api/package.json` (`seed:technicians` script)

--- a/docs/stories/E05-S02-dispatcher-engine.md
+++ b/docs/stories/E05-S02-dispatcher-engine.md
@@ -1,0 +1,152 @@
+# Story E05-S02: Dispatcher engine (geo-rank + FCM job offers + dispatch attempts)
+
+Status: shipped (PR #26, merged 2026-04-23, commit 5b9c5ff) — **retroactive docs**
+
+> **Epic:** E05 — Dispatch Engine + Job Offers (`docs/stories/README.md` §E05)
+> **Sprint:** S3 (wk 5–6) · **Estimated:** ≤ 1.5 dev-days · **Priority:** P0 (core value loop)
+> **Sub-project:** `api/`
+> **Ceremony tier:** Foundation (cross-cutting service, Karnataka FR-9.1 compliance gate, FCM integration)
+> **Plan file:** `plans/E05-S02.md` (retroactively authored — see issue #99)
+> **Prerequisites:** E05-S01 (TechnicianProfile schema + ST_WITHIN repo), E03-S04 (booking PAID transition)
+> **Retroactive note:** PR #26 shipped without `docs/stories/E05-S02-*.md` or its plan file. Both are being added retroactively (issue #99). Acceptance criteria below are reverse-engineered from `api/src/services/dispatcher.service.ts`, `api/src/functions/technicians.ts`, `api/src/middleware/verifyTechnicianToken.ts`, and `api/tests/integration/dispatcher-up-ranking.test.ts`. Plan file holds canonical step-by-step.
+
+---
+
+## Story
+
+As **the platform** and as **the operator complying with Karnataka FR-9.1**,
+I want the dispatcher service to fan out a paid booking to the top 3 nearest, skilled, KYC-approved, online, available technicians via FCM data messages within ~2 seconds, with rankings that physically cannot incorporate decline history,
+so that **the customer's tech is found fast, the operator stays compliant, and the architecture makes future regulatory drift impossible** (FR-4.1, FR-9.1).
+
+---
+
+## Acceptance Criteria
+
+### AC-1 · `dispatcherService.triggerDispatch(bookingId)` orchestrator
+- Reads booking by id; **early-returns** if booking is missing or `booking.status !== 'PAID'` (idempotent — accidental re-trigger after `ASSIGNED` is a no-op + log line)
+- Calls `getTechniciansWithinRadius(lat, lng, 10, serviceId)` (E05-S01) — bounding-box query
+- Post-filters with `haversine(...) <= DISPATCH_RADIUS_KM` to drop bounding-box corner techs that are inside the square but outside the actual 10 km circle (Codex P1 fix in-PR)
+- Zero candidates → booking transitions `PAID → UNFULFILLED`, no FCM sent, no `DispatchAttemptDoc` created
+- Otherwise: takes `TOP_N = 3` after ranking
+
+### AC-2 · `rankTechnicians(techs, lat, lng)` is a pure, exported, decline-blind function
+- **Primary sort:** distance ascending (haversine from booking lat/lng to tech `location.coordinates[1], [0]` — `[lng, lat]` GeoJSON order)
+- **Secondary sort:** `tech.rating` descending; treats undefined as `0` so unrated techs sort last among equals
+- Exported separately from `dispatcherService` so it can be unit-tested without mocking Cosmos
+- **Reads only `location` and `rating`** — `TechnicianProfile` schema (E05-S01) does not expose `declineCount`/`declineHistory`/`declines`, so a decline-aware variant would require a schema regression that the CI gate catches
+
+### AC-3 · `DispatchAttemptDoc` recorded with 30-s expiry
+- Schema (`api/src/schemas/dispatch-attempt.ts`): `id`, `bookingId`, `technicianIds[]`, `sentAt`, `expiresAt`, `status: 'PENDING' | 'ACCEPTED' | 'EXPIRED'`
+- `expiresAt = sentAt + OFFER_WINDOW_MS (30_000 ms)`
+- Created via `getDispatchAttemptsContainer().items.create(attempt)` BEFORE the FCM fan-out — so a tech who accepts before the FCM ack does not race
+- Container partitioned by `/bookingId` (one attempt per booking; future re-dispatch creates a new doc with new id)
+
+### AC-4 · Booking transitions `PAID → SEARCHING` after attempt is created
+- Codex P2 fix in-PR: do this transition *after* `items.create(attempt)` so the stale-booking reconciler (E05-S04 timer) can find unanswered dispatches by status `SEARCHING` + `expiresAt < now`
+
+### AC-5 · FCM `JOB_OFFER` data messages to top 3
+- Silent data-only payload (no `notification` key) — system tray stays clean
+- Payload keys (all string-typed because FCM data values must be strings):
+  - `type: "JOB_OFFER"`
+  - `bookingId`, `serviceId`, `addressText`, `slotDate`, `slotWindow`
+  - `amount: String(booking.amount)` (paise integer rendered as string)
+  - `distanceKm: String(haversine(...))` (haversine recomputed per-tech for accuracy)
+  - `expiresAt: <ISO string>`
+  - `dispatchAttemptId: <UUID>`
+- Sent via `Promise.allSettled` so a single tech with a stale FCM token does not abort the fan-out
+- Techs with no `fcmToken` are still in `DispatchAttemptDoc.technicianIds` (so they could accept via the in-app UI flow if the app polls or syncs offline) — they just don't receive the push
+
+### AC-6 · `PATCH /v1/technicians/fcm-token` endpoint
+- Behind `verifyTechnicianToken` (Firebase ID token Bearer)
+- Body: `{ fcmToken: string.min(1) }` (Zod-validated)
+- Reads existing technician doc (point-read by uid), upserts with new `fcmToken` field
+- Returns `200 { ok: true }` on success; `401 UNAUTHORIZED` no/invalid token; `400 VALIDATION_ERROR` invalid body; `400 PARSE_ERROR` malformed JSON
+- Wired at `app.http('patchTechnicianFcmToken', { route: 'v1/technicians/fcm-token', methods: ['PATCH'], handler })`
+
+### AC-7 · `verifyTechnicianToken` middleware uses `verifyFirebaseIdToken`
+- Codex P1 fix in-PR: use the project's `verifyFirebaseIdToken` wrapper (which initialises Firebase Admin if not already), not the raw `getAuth().verifyIdToken` — guarantees cold-start safety on Azure Functions
+
+### AC-8 · Karnataka FR-9.1 CI gate (`tests/integration/dispatcher-up-ranking.test.ts`)
+- 3 tests, **must stay green forever** without an ADR + legal sign-off:
+  1. Closer technician with low rating ranks above farther technician with perfect rating, even with simulated heavy decline history
+  2. Ranking is stable across all 6 input-order permutations
+  3. `TechnicianProfile` schema does not expose `declineCount`, `declineHistory`, or `declines` (defends against future schema additions)
+- Test scenario uses Ayodhya, UP coordinates (BOOKING_LAT 26.7922, BOOKING_LNG 82.1998) — the pilot market — so the test reads as a Karnataka-pilot regulatory check
+
+### AC-9 · Geo helper extension
+- `haversine(lat1, lng1, lat2, lng2)` added to `api/src/cosmos/geo.ts` — earth radius 6371 km, returns kilometres
+- Used both inside `rankTechnicians` and inside the orchestrator's post-filter
+
+### AC-10 · Test coverage (CI green)
+- 61 test files / 353 tests passing
+- New: `tests/unit/dispatcher.service.test.ts` (orchestrator behaviour, mocked Cosmos + FCM), `tests/unit/technicians.test.ts` (FCM-token endpoint), `tests/integration/dispatcher-up-ranking.test.ts` (Karnataka invariance gate, 3 assertions)
+- Modified: existing `tests/services/dispatcher.service.test.ts` (extends old stub tests for new orchestrator behaviour)
+
+---
+
+## Tasks / Subtasks (as actually shipped)
+
+> Plan file `plans/E05-S02.md` is canonical. Below mirrors the work-stream summary.
+
+- [x] **WS-A — Schemas + container accessors** — `dispatch-attempt.ts`, `booking-event.ts`, `getDispatchAttemptsContainer`, `getBookingEventsContainer`, `haversine` in `geo.ts`
+- [x] **WS-B — Karnataka FR-9.1 CI gate (TDD red)** — `tests/integration/dispatcher-up-ranking.test.ts` written FIRST so the dispatcher implementation has to satisfy it before any merge
+- [x] **WS-C — Dispatcher service (TDD green)** — `tests/unit/dispatcher.service.test.ts` red → `dispatcher.service.ts` rewrite green
+- [x] **WS-D — Technician token middleware + FCM-token endpoint (TDD)** — `verifyTechnicianToken.ts` + `tests/unit/technicians.test.ts` red → `patchFcmTokenHandler` in `functions/technicians.ts` green
+- [x] **WS-E — Smoke gate + Codex review** — `tools/pre-codex-smoke-api.sh` exit 0; `.codex-review-passed` shipped at HEAD
+
+---
+
+## Dev Notes
+
+### Why `rankTechnicians` is exported
+The pure ranking function is the **legal-compliance surface** of this story. Embedding it inside the dispatcher orchestrator would have made the Karnataka invariance test impossible to run without spinning up Cosmos mocks. Exporting `rankTechnicians` lets the test reach in directly with constructed `TechnicianProfile` fixtures and assert behaviour without any infrastructure. This is the *only* reason it's exported — production code should call `triggerDispatch`, not `rankTechnicians` directly.
+
+### Why TOP_N=3 (not 5 or 1)
+Three is the minimum that gives the customer redundancy if the closest tech declines or doesn't see the offer. One would mean every decline forces a re-dispatch, doubling p95 latency. Five would saturate the FCM fan-out for marginal gain — the 4th and 5th candidates are typically too far for good service. Three is the operator's pilot recommendation; it can be promoted to a PostHog-controlled variable if the dispatch funnel data justifies tuning.
+
+### Why `OFFER_WINDOW_MS = 30_000`
+Empirical from Indian Q-commerce playbooks (Dunzo / Swiggy Genie operate at 30–60s acceptance windows). Less than 30s and a tech who picks up their phone mid-offer can't realistically read + accept; more than 60s and the customer's "find a tech" perceived wait grows past the 2-min FR-4.1 SLA. 30s is a defensible mid-point; the constant lives at the top of `dispatcher.service.ts` so future tuning is one line.
+
+### Why both `SEARCHING` and `UNFULFILLED` transitions matter
+- `SEARCHING` is the state E05-S04's stale-offer reconciler queries on (`status='PENDING' AND expiresAt < now`). If the dispatcher transitioned to `ASSIGNED` directly we'd lose visibility into "tech offered, no answer".
+- `UNFULFILLED` short-circuits the loop when zero candidates exist — there is no point in setting `SEARCHING` because there is nothing to search; the booking can be refunded immediately.
+
+### Why FCM `Promise.allSettled`, not `Promise.all`
+A single technician with a stale FCM token (deleted from Firebase) will throw on `messaging.send`. `Promise.all` would reject the entire promise chain, leaving the other techs un-notified. `Promise.allSettled` lets each fan-out succeed or fail independently — the booking attempt is durable in Cosmos either way.
+
+### Why no decline term — and why the test exists
+Karnataka platform-economy regulation (FR-9.1) is being read conservatively for the Ayodhya pilot: ranking that incorporates decline history is treated as a discriminatory practice. Even though the test scenario uses Ayodhya, UP coordinates (the pilot market), the invariance is global. The test exists because *future maintainers will be tempted* to add a `declineCount` term as a "fairness fix" (penalising techs who decline frequently). The CI gate makes that a build break — any such PR has to either justify removing the assertion (with an ADR + legal sign-off) or find another way.
+
+### Why `ARRAY_CONTAINS(skills, @serviceId)` (and not a many-to-many table)
+A technician's skills are denormalised onto their profile because the access pattern is overwhelmingly "find techs who can do X near Y". Cosmos `ARRAY_CONTAINS` against a denormalised array is faster than joining against a separate `technician_skills` container at this scale, and `skills[]` is small (typically ≤ 5 items per tech). At scale this could become a concern; for the pilot it's the right shape.
+
+### What this story does NOT do
+- **Accept/decline endpoints** — those ship in E05-S04 (PR #28). This story creates the `DispatchAttemptDoc` and sends the FCM, but the technician's response handler lives in `api/src/functions/job-offers.ts` from the next story.
+- **Stale-offer reconciler** — also E05-S04 (timer trigger that flips PENDING → EXPIRED after `expiresAt`).
+- **Technician app FCM listener** — E05-S03 (PR #29) on the technician-app side.
+
+---
+
+## Definition of Done
+
+- [x] `cd api && pnpm typecheck && pnpm test` — 61 files / 353 tests green
+- [x] `bash tools/pre-codex-smoke-api.sh` exited 0
+- [x] Karnataka FR-9.1 CI gate (`tests/integration/dispatcher-up-ranking.test.ts`) green
+- [x] `.codex-review-passed` marker shipped in PR #26
+- [x] Codex P1/P2 findings resolved in-PR: haversine post-filter, `verifyFirebaseIdToken` cold-start, SEARCHING transition timing
+- [x] CI green on `main` after merge (commit 5b9c5ff)
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Sonnet 4.6 (per PR #26 commit attribution)
+
+### Completion Notes
+PR #26 merged 2026-04-23 18:34 UTC as commit 5b9c5ff. Three Codex findings addressed in-PR; no blockers reached merge. Karnataka invariance test is now a permanent CI fixture — any change to `rankTechnicians` or `TechnicianProfileSchema` that fails it requires an ADR + explicit override.
+
+### File List
+See PR #26:
+- Added: `api/src/schemas/dispatch-attempt.ts`, `api/src/schemas/booking-event.ts`, `api/src/middleware/verifyTechnicianToken.ts` (modified existing — switched to `verifyFirebaseIdToken`), `api/tests/integration/dispatcher-up-ranking.test.ts`, `api/tests/unit/dispatcher.service.test.ts`, `api/tests/unit/technicians.test.ts`
+- Modified: `api/src/cosmos/client.ts` (container accessors), `api/src/cosmos/geo.ts` (`haversine`), `api/src/schemas/technician.ts` (asserted `fcmToken`/`rating` optional), `api/src/services/dispatcher.service.ts` (replaced stub), `api/src/functions/technicians.ts` (appended `patchFcmTokenHandler`), `api/tests/services/dispatcher.service.test.ts` (extended), `api/tests/webhooks/razorpay-webhook.test.ts` (3 lines dropped — booking transitions changed)

--- a/docs/stories/E05-S03-technician-job-offer-card.md
+++ b/docs/stories/E05-S03-technician-job-offer-card.md
@@ -1,0 +1,174 @@
+# Story E05-S03: Technician-app FCM job offer card with countdown
+
+Status: shipped (PR #29, merged 2026-04-23, commit d162932) — **retroactive docs**
+
+> **Epic:** E05 — Dispatch Engine + Job Offers (`docs/stories/README.md` §E05)
+> **Sprint:** S3 (wk 5–6) · **Estimated:** ≤ 1.5 dev-days · **Priority:** P0 (technician value loop)
+> **Sub-project:** `technician-app/`
+> **Ceremony tier:** Foundation (new module: FCM service + Hilt + Compose overlay + 3 use cases)
+> **Plan file:** `plans/E05-S03.md` (retroactively authored — see issue #100)
+> **Prerequisites:** E05-S02 (FCM `JOB_OFFER` payload contract + `PATCH .../fcm-token` endpoint)
+> **Retroactive note:** PR #29 shipped without `docs/stories/E05-S03-*.md` or its plan file. Both are being added retroactively (issue #100). Acceptance criteria are reverse-engineered from `technician-app/.../HomeservicesFcmService.kt`, `JobOfferEventBus.kt`, `JobOfferViewModel.kt`, `JobOfferScreen.kt`, the three use cases, and `AppNavigation.kt`.
+
+---
+
+## Story
+
+As a **technician using Home Heroo who has just received a dispatched booking**,
+I want a full-screen card to wake my phone with the service name, address, slot, distance, earnings, and a 30-second countdown ring (with haptic feedback in the last 5 seconds), plus large Accept (green) and Decline (outline) buttons,
+so that **I can decide quickly without scrolling, hit Accept before someone else does, and trust that my decline doesn't quietly count against me** (FR-5.1, FR-4.1, FR-9.1).
+
+---
+
+## Acceptance Criteria
+
+### AC-1 · `HomeservicesFcmService` intercepts `JOB_OFFER` data messages
+- `@AndroidEntryPoint` Firebase service registered in `AndroidManifest.xml` with `MESSAGING_EVENT` intent filter
+- Field-injected `eventBus: JobOfferEventBus`, `fcmTokenSyncUseCase: FcmTokenSyncUseCase`, `ratingPromptEventBus: RatingPromptEventBus`
+- `onMessageReceived(message)` switches on `data["type"]`:
+  - `"JOB_OFFER"` → `parseJobOffer(data)` then `eventBus.tryEmit(offer)`
+  - `"RATING_PROMPT_TECHNICIAN"` → forward `bookingId` to `ratingPromptEventBus.post(bookingId)` (preserved — added by E07-S01)
+- `parseJobOffer` returns `null` on missing required field; catches `Instant.parse` failures silently
+
+### AC-2 · `JobOfferEventBus` (`@Singleton` SharedFlow)
+- `MutableSharedFlow<JobOffer>(replay = 0, extraBufferCapacity = 1)` — buffer one offer so a tap-through-to-accept while another offer arrives doesn't drop both
+- `tryEmit(offer)` non-blocking; called from FCM service thread
+
+### AC-3 · `JobOfferViewModel` countdown lifecycle
+- Initial state `Idle`
+- New offer arrives → cancels any prior `countdownJob`, computes initial seconds from `expiresAtMs - currentTimeMillis()`, transitions to `Offering(offer, initialSeconds)`
+- Per-second decrement via local `delay(1_000L)` loop (no real-time drift across the 30s window)
+- Reaching 0 → `Expired` + `scheduleReset(2_000L)` back to `Idle`
+- Receiving an already-expired offer → `Expired` immediately + reset
+
+### AC-4 · Accept button flow
+- `accept()` cancels `countdownJob`; calls `acceptUseCase(bookingId)` on `viewModelScope`
+- `Accepted(bookingId)` → state transitions; `AppNavigation` `LaunchedEffect(jobOfferState)` navigates to `activeJob/{bookingId}`
+- `410` response → `Expired` (someone else won the race)
+- Network/other exception → caught and mapped to `Expired` (avoid getting stuck on `Offering`)
+- Auto-reset to `Idle` after 2s
+
+### AC-5 · Decline button flow
+- `decline()` cancels `countdownJob`; calls `declineUseCase(bookingId)` on `viewModelScope`
+- **Always** transitions to `Declined`, even if the API call throws an `IOException` — user intention is the source of truth (FR-9.1 Karnataka invariant)
+- Decline-related response code is intentionally ignored — server-side log to `booking_events` is opaque to the UI
+- Auto-reset to `Idle` after 2s
+
+### AC-6 · Karnataka FR-9.1 enforcement (Android side)
+- `DeclineJobOfferUseCase` returns `Declined` regardless of HTTP outcome (test asserts this for IOException case)
+- File-level comment in `DeclineJobOfferUseCase.kt`: declines are logged server-side but never fed to ranking
+- No "decline count" / "acceptance rate" / "rejection score" UI element anywhere in the screen
+- No analytics event named `*_decline_count` / `*_acceptance_rate`
+
+### AC-7 · `JobOfferScreen` Compose overlay
+- `Surface(fillMaxSize, color = MaterialTheme.colorScheme.background)` — covers the entire app while a job is offered
+- `Offering` layout (top to bottom): centred 96 dp `CircularProgressIndicator` with `progress = remainingSeconds / 30f`; large `remainingSeconds` text; service name (`headlineSmall`); address (`bodyLarge`); `slotDate slotWindow` (`bodyMedium`); `"%.1f km away"` chip; `"Earnings: ₹{amount/100}"` (`titleLarge primary`); large green Accept (`Color(0xFF2E7D32)`, 56 dp height) + large outline Decline (56 dp height)
+- Countdown ring + number turn `MaterialTheme.colorScheme.error` when `remainingSeconds ≤ 5`
+- `Accepted | Declined | Expired` → `JobOfferResultContent` centred message + 2s auto-dismiss
+
+### AC-8 · Haptic feedback in last 5 seconds
+- `LaunchedEffect(uiState)` — when `Offering` and `remainingSeconds in 1..5`, trigger `VibrationEffect.EFFECT_TICK`
+- Guarded: `Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q` (API 29+) AND wrapped in `try/catch` (haptic unavailable on emulator/test)
+- Uses `androidx.core.content.getSystemService<Vibrator>()` extension
+
+### AC-9 · `AppNavigation` overlay wiring
+- `JobOfferScreen` is overlaid on top of the existing `NavHost` (auth / onboarding / home graphs) when `jobOfferState !is Idle && jobOfferState !is Accepted`
+- `Accepted` triggers nav to `activeJob/{bookingId}` (route added later by E06-S01) and dismisses the overlay
+- Existing rating-prompt routing (E07-S01) is preserved — both event buses coexist on the same `AppNavigation`
+
+### AC-10 · `FcmTokenSyncUseCase` (login + onNewToken)
+- `invoke()` fetches token via `FirebaseMessaging.getInstance().token.await()`, then delegates to `invokeWithFcmToken`
+- `invokeWithFcmToken(token)` is the testable seam — unit tests bypass static `FirebaseMessaging` access
+- Calls `PATCH /v1/technicians/fcm-token` with Bearer Firebase ID token + `{ fcmToken: <token> }` body
+- Best-effort: `IOException` swallowed (token re-syncs on next app open or `onNewToken`)
+- Triggered from app startup / login flow AND from `HomeservicesFcmService.onNewToken`
+
+### AC-11 · `JobOfferApiService` Retrofit interface (internal)
+- Three suspend functions: `acceptOffer`, `declineOffer`, `syncFcmToken`
+- All take `Authorization` header explicitly (no interceptor — keeps `JobOfferModule` interceptor-free)
+- `acceptOffer` returns `Response<Unit>` so the use case can read HTTP status (410 detection)
+- `declineOffer` returns `Response<Unit>` but the use case ignores the code (FR-9.1)
+- `syncFcmToken` body: `FcmTokenRequest(fcmToken: String)` data class
+
+### AC-12 · `JobOfferModule` Hilt DI
+- `@Module @InstallIn(SingletonComponent::class) public object`
+- Provides `JobOfferApiService` from a Retrofit `Builder` with `MoshiConverterFactory` and an `OkHttpClient` carrying `HttpLoggingInterceptor(BODY)`
+- Base URL: `https://homeservices-api.azurewebsites.net/api/`
+- No qualifier — this is the technician-app's first auth-required client; `@AuthOkHttpClient` qualifier is introduced by E07-S01b's `RatingModule` and *reused* by E08-S01 onwards
+
+### AC-13 · libs.versions.toml sync (first task)
+- `technician-app/gradle/libs.versions.toml` is identical to `customer-app/gradle/libs.versions.toml` after the `firebase-messaging-ktx` line is added
+- This is the FIRST commit of the story (CLAUDE.md invariant)
+
+### AC-14 · Test coverage (128 tests in suite)
+- `AcceptJobOfferUseCaseTest` — 200/410/500/no-user (4 tests)
+- `DeclineJobOfferUseCaseTest` — success/IOException/non-2xx all return `Declined` (3 tests)
+- `FcmTokenSyncUseCaseTest` — success/IOException-swallowed (2 tests)
+- `JobOfferViewModelTest` — initial Idle, offer arrival, countdown decrement, expiry, accept/decline, already-expired offer (~6 tests)
+- `JobOfferScreenPaparazziTest` — 4 `@Ignore`d snapshot stubs (Idle/Offering/Accepted/Expired); recorded on CI Linux only
+- Smoke gate: `bash tools/pre-codex-smoke.sh technician-app` exited 0; Kover ≥ 80% with FCM service + DI module excluded
+
+---
+
+## Tasks / Subtasks (as actually shipped)
+
+> Plan file `plans/E05-S03.md` is canonical. Below mirrors the work-stream table in PR #29's body.
+
+| Stream | Commits | Contents |
+|--------|---------|----------|
+| WS-E init | 1 | libs.versions.toml sync + firebase-messaging-ktx |
+| WS-A | 1 | `JobOffer` + `JobOfferResult` domain models |
+| WS-B | 3 | FCM service + 3 use cases (TDD red→green→Codex fixes) |
+| WS-C | 1 | `JobOfferModule` Hilt DI + Kover exclusions |
+| WS-D | 3 | `JobOfferViewModel` + `JobOfferScreen` overlay + Paparazzi stubs (TDD red→green→Codex fixes) |
+| Smoke fixes | 7 | Compiler errors, ktlint, nested `runTest`, rebase onto main |
+
+---
+
+## Dev Notes
+
+### Why a `@Singleton` SharedFlow instead of a per-screen Channel
+A `@Singleton` `MutableSharedFlow` survives ViewModel recreation. If the technician backgrounds the app while an offer is in-flight, the FCM service still posts to the bus; when the app resumes the (possibly-recreated) `JobOfferViewModel.init` block re-collects from the bus and finds the buffered event. `extraBufferCapacity = 1` is enough because at most one offer can be live (the dispatcher holds a single `DispatchAttemptDoc` per booking) — and a second offer arriving while the first is still showing should kick out the stale one cleanly (the ViewModel cancels its prior `countdownJob`).
+
+### Why the haptic is API 29+ only
+`VibrationEffect.EFFECT_TICK` is the right "subtle pulse" the design wants — it's not the heavy `EFFECT_DOUBLE_CLICK` and it's available since Android 10. Pre-API-29 fallback to `vibrator.vibrate(pattern)` would require `VIBRATE` permission and a custom pattern; the design team explicitly accepted "no haptic on Android 9 and below" as a tradeoff. The try/catch additionally guards against emulator devices that report SDK ≥ 29 but have no vibrator service.
+
+### Why `accept()` maps any non-2xx to `Expired`
+The Accept call is fire-and-forget from the user's perspective — once they tap the button, the only outcomes that matter are "you got it" (Accepted) or "too late" (Expired). Returning `Error("Server failure")` would leave the user staring at a useless error dialog while the booking goes to someone else; `Expired` is honest about the outcome from the tech's POV. The actual error (5xx, network) is logged via Sentry but not surfaced.
+
+### Why `decline()` ignores the HTTP outcome entirely
+Karnataka FR-9.1: a tech who *intends* to decline must be treated as having declined, regardless of whether the API call succeeded. If the network is dead, the UI must NOT say "decline failed, please retry" — that would pressure the tech into accepting a job they didn't want. Instead, the UI flips to `Declined`, shows the confirmation message, and auto-resets to Idle. Server-side reconciliation (the offer expiring naturally after 30s) handles the rare network-fail case from the system's POV.
+
+### Why `accept` uses `getIdToken(false)` and `decline` uses `.orEmpty()`
+- Accept call MUST be authenticated — server-side this triggers a Cosmos write that assigns the booking to the tech. `getIdToken(false)` returns a cached token (fast); the use case throws `IllegalStateException` if no user is signed in (won't happen at runtime — the FCM service only fires for logged-in techs).
+- Decline call is *advisory* — server records the event but doesn't act on it. Treating the token as best-effort (`orEmpty()`) means a logged-out tech receiving a stale push can still decline cleanly.
+
+### Why `HttpLoggingInterceptor.Level.BODY` in production
+Job offer payloads contain no PII (just bookingId, address text, slot times, money in paise). Logging them at BODY level helps debug FCM payload mismatches in the field without needing to ship a debug build. This was a deliberate deviation from the customer-app pattern (which uses `Level.NONE`) — the customer-app handles PII (phone numbers, addresses); the technician-app's FCM payloads do not.
+
+### Why this story does not add a navigation route
+The `Accepted` state is the only one that triggers navigation, and it routes to `activeJob/{bookingId}` — a route that *doesn't exist yet* until E06-S01 lands. The `LaunchedEffect` wires up the navigation call now (so the integration is complete on the technician-app side), and E06-S01 adds the destination. If E06-S01 is delayed, the worst case is a navigation no-op; the app does not crash because `composable("activeJob/{bookingId}")` lookup returns null cleanly in NavController.
+
+---
+
+## Definition of Done
+
+- [x] `cd technician-app && ./gradlew assembleDebug ktlintCheck testDebugUnitTest koverVerify` — all green
+- [x] Smoke gate exited 0
+- [x] `.codex-review-passed` marker shipped in PR #29
+- [x] All Codex P1/P2 findings resolved in 7 follow-up commits ("Smoke fixes" stream)
+- [x] CI green on `main` after merge (commit d162932)
+- [ ] Paparazzi goldens recorded on CI Linux post-merge (manual `paparazzi-record.yml` workflow_dispatch — non-blocking for ship; tests are `@Ignore`d until then)
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Sonnet 4.6 (per PR #29 commit attribution)
+
+### Completion Notes
+PR #29 merged 2026-04-23 19:57 UTC as commit d162932. Six work streams: WS-E init / WS-A / WS-B / WS-C / WS-D / Smoke fixes. The "Smoke fixes" stream covers seven follow-up commits addressing compiler errors, ktlint, nested `runTest` test issues, and a rebase onto main. Karnataka FR-9.1 invariance is enforced both in code (DeclineUseCase always returns Declined) and in test (asserts behaviour under IOException).
+
+### File List
+See PR #29: 16 added Kotlin files (FCM service, EventBus, ApiService, Module, 3 use cases, 2 domain models, ViewModel, UiState, Screen, 5 test files), 3 modified (`build.gradle.kts`, `AndroidManifest.xml`, `AppNavigation.kt`, `strings.xml`, `libs.versions.toml`).

--- a/docs/stories/E05-S04-accept-decline-api.md
+++ b/docs/stories/E05-S04-accept-decline-api.md
@@ -1,0 +1,147 @@
+# Story E05-S04: Accept/decline job-offer API with `_etag` optimistic concurrency
+
+Status: shipped (PR #28, merged 2026-04-23, commit 8d47ec0) — **retroactive docs**
+
+> **Epic:** E05 — Dispatch Engine + Job Offers (`docs/stories/README.md` §E05)
+> **Sprint:** S3 (wk 5–6) · **Estimated:** ≤ 1 dev-day · **Priority:** P0 (closes the dispatch loop; blocks E06-S01 active-job state machine)
+> **Sub-project:** `api/`
+> **Ceremony tier:** Foundation (concurrency-critical, FR-9.1 audit-log boundary)
+> **Plan file:** `plans/E05-S04.md` (retroactively authored — see issue #101)
+> **Prerequisites:** E05-S02 (DispatchAttemptDoc / BookingEventDoc schemas + container accessors + `verifyTechnicianToken`)
+> **Retroactive note:** PR #28 shipped without `docs/stories/E05-S04-*.md` or its plan file. Both are being added retroactively (issue #101). Acceptance criteria are reverse-engineered from `api/src/cosmos/dispatch-attempt-repository.ts`, `api/src/cosmos/booking-event-repository.ts`, `api/src/functions/job-offers.ts`, and `api/tests/bookings/accept-decline.test.ts`.
+
+---
+
+## Story
+
+As **the platform** running a 30-second job-offer race between three technicians,
+I want exactly one technician to win via Cosmos `_etag` optimistic concurrency, the losers to be cleanly notified, declines to be a pure audit-trail event (never feeding ranking), and a timer to reap stale offers,
+so that **simultaneous accepts can't double-assign a booking, declined offers can't quietly count against techs, and unanswered offers don't leave bookings stuck in `SEARCHING` indefinitely** (FR-4.1, FR-5.1, FR-9.1).
+
+---
+
+## Acceptance Criteria
+
+### AC-1 · `dispatchAttemptRepo.acceptAttempt(id, bookingId)` is the first-write-wins lock
+- Point-reads the doc, asserts `status === 'PENDING'` and `expiresAt > now`
+- Calls `container.item(id, bookingId).replace(updated, { accessCondition: { type: 'IfMatch', condition: resource._etag } })`
+- Returns the updated doc on success
+- Returns `null` when:
+  - Doc missing
+  - Status not PENDING (already ACCEPTED or EXPIRED)
+  - `expiresAt <= now`
+  - Cosmos throws 412 PreconditionFailed (`_etag` mismatch — concurrent caller won)
+- Re-throws any non-412 Cosmos error
+
+### AC-2 · `bookingEventRepo.append(event)` is append-only
+- Auto-generates `id` (uuid) and `ts` (ISO datetime); caller passes only `bookingId`, `event`, optional `technicianId`/`adminId`/`metadata`
+- **No update or delete methods exist on the repo.** Audit log entries are immutable by API design.
+- Container partition key: `/bookingId`
+
+### AC-3 · Accept handler — full state machine
+- `PATCH /v1/technicians/job-offers/{bookingId}/accept`, `authLevel: 'anonymous'` (Firebase auth via `verifyTechnicianToken` in handler)
+- Response codes:
+  - 401 `UNAUTHORIZED` — missing/invalid Bearer token
+  - 404 `OFFER_NOT_FOUND` — no `DispatchAttemptDoc` for this bookingId
+  - 410 `OFFER_EXPIRED` — `attempt.status !== 'PENDING'` OR `expiresAt <= now`
+  - 403 `FORBIDDEN` — `technicianId` not in `attempt.technicianIds`
+  - 409 `OFFER_ALREADY_TAKEN` — `acceptAttempt` returned null (etag race)
+  - 200 `{ bookingId, status: 'ASSIGNED' }` — winner
+- Order matters: 404 → 410 → 403 → 409. Off-pool techs never reach the optimistic-concurrency step.
+
+### AC-4 · On-win side effects
+- `updateBookingFields(bookingId, { status: 'ASSIGNED', technicianId })`
+- `bookingEventRepo.append({ event: 'TECH_ACCEPTED', technicianId, bookingId })`
+- Loser FCM fan-out: `notifyLosingTechs(losingTechs, bookingId)` runs as a fire-and-forget `void`
+
+### AC-5 · Loser FCM is topic-based, best-effort
+- Sends `OFFER_CANCELLED` data payload to `topic: tech_${techId}` for each losing tech
+- Wrapped in `Promise.allSettled` — one failed send doesn't abort the others
+- Topic-based (not token) because at the time of dispatch a losing tech may have a stale token on file but still be subscribed to their topic; topic is the more durable channel
+
+### AC-6 · Decline handler — pure audit, never affects state
+- `PATCH /v1/technicians/job-offers/{bookingId}/decline`, `authLevel: 'anonymous'`
+- 401 on missing/invalid token; 200 `{ bookingId, status: 'DECLINED' }` otherwise
+- **Side effects:** writes ONLY `bookingEventRepo.append({ event: 'TECH_DECLINED', technicianId, bookingId })`
+- Does **NOT** call `acceptAttempt`. Does **NOT** modify booking. Does **NOT** modify the `DispatchAttemptDoc`. Other techs in the pool can still accept; the offer expires naturally.
+- The `TECH_DECLINED` event has **no ranking-related metadata field** — no `declineCount`, no `priorAcceptances`, no rate. Pure audit.
+
+### AC-7 · FR-9.1 invariant preserved across the API surface
+- Decline endpoint writes to `booking_events` only — never to `technicians`
+- The `TECH_DECLINED` event shape (`{ event, technicianId, bookingId, ts }`) carries no ranking signal
+- The dispatcher (E05-S02) reads only `TechnicianProfile` — it doesn't read `booking_events`. So even though declines are recorded for audit, they're physically unreachable from the ranking code path.
+- Test asserts: `expect(declineEvent).not.toHaveProperty('rankingScore')`, `expect(declineEvent).not.toHaveProperty('declineCount')`
+
+### AC-8 · `expireStaleOffers` timer (`*/30 * * * * *`)
+- Queries `DispatchAttemptDoc` where `status='PENDING' AND expiresAt < now`
+- For each: conditional replace to `EXPIRED` (with `_etag`), update booking to `UNFULFILLED`, append `OFFER_EXPIRED` event
+- 412 PreconditionFailed is silently swallowed (a concurrent process — typically the accept handler — already mutated the doc; safe to skip)
+- All work in `Promise.allSettled` so one stuck attempt doesn't block others
+
+### AC-9 · Test matrix (10 explicit cases, all green)
+- accept: 200 first caller, 409 etag race, 410 expired by time, 410 status not PENDING, 403 not in pool, 401 no auth, 404 no attempt
+- decline: 200 ok, event written with no ranking field, 401 no auth
+- All in `tests/bookings/accept-decline.test.ts`; 360 tests in suite green
+
+### AC-10 · Codex + smoke green
+- `bash tools/pre-codex-smoke-api.sh` exited 0
+- `.codex-review-passed` marker shipped in PR #28
+
+---
+
+## Tasks / Subtasks (as actually shipped)
+
+> Plan file `plans/E05-S04.md` is canonical. Below mirrors the work-stream summary.
+
+- [x] **WS-A — Repositories (TDD)** — `dispatchAttemptRepo` (with `_etag`) + `bookingEventRepo` (append-only)
+- [x] **WS-B — HTTP handlers + timer (TDD)** — `acceptJobOfferHandler` + `declineJobOfferHandler` + `notifyLosingTechs` + `expireStaleOffers`
+- [x] **WS-C — Smoke gate + Codex review** — `bash tools/pre-codex-smoke-api.sh` PASSED; `.codex-review-passed` shipped at HEAD
+
+---
+
+## Dev Notes
+
+### Why `_etag` + `If-Match` over a Cosmos transactional batch
+A Cosmos transactional batch can group multiple operations on a single partition (`bookings` and `dispatch_attempts` share `bookingId` as partition key in this design — though they live in *different containers*, batches are scoped to `(container, partition)`). Even if we co-located, batches don't help with first-write-wins semantics across distributed callers; only `If-Match` does. The pattern here is the canonical Cosmos optimistic-concurrency idiom: read → assert business state → conditional replace by etag.
+
+### Why decline does NOT touch the attempt
+Two reasons. First, FR-9.1: a declined offer is purely a tech's intent signal, not a state change for the booking — the booking is still findable by the other techs in the pool. Second, race safety: if Decline mutated `DispatchAttemptDoc.status`, two techs declining simultaneously would race, and the loser would see 412. That's gratuitous error-handling complexity for an operation that doesn't need to succeed atomically.
+
+### Why topic-based loser FCM (not token-based)
+The accept handler doesn't have direct access to losing techs' FCM tokens — it has their `technicianId`s from `attempt.technicianIds`. Looking up tokens would require a Cosmos point-read per loser. Topic delivery (`tech_${techId}`) is fire-and-forget: if the tech subscribed via the technician-app's `FcmTopicSubscriber` (which already exists from E05-S03's auth flow), they get the message; if not, the send silently no-ops. The technician-app handles `OFFER_CANCELLED` by clearing its in-flight offer state.
+
+### Why a 30-second timer cadence (and why not 10s or 60s)
+Offers expire after 30s (`OFFER_WINDOW_MS` from E05-S02). A 30s cadence means worst-case latency between expiry and reconciliation is 30s — the booking sits in `SEARCHING` for at most 60s total. Faster cadence (10s) would triple the timer-trigger billing on Azure Functions Consumption; slower (60s) would let stale offers leak past the natural expiry. 30s matches the offer window, which is the natural unit. If billing or perceived latency become concerns, this is one constant in `app.timer(...)` — easy to tune.
+
+### Why `authLevel: 'anonymous'` on the HTTP triggers
+Azure Functions HTTP triggers default to `function` auth (an Azure-issued key). Setting `anonymous` disables that layer so the handler's own `verifyTechnicianToken` (Firebase Bearer ID token) is the *only* auth check. Two layers of auth would mean we'd need to ship a secret to the technician app *and* configure Firebase — pointless complexity.
+
+### Why the timer's 412 swallow is correct
+The timer is *eventually consistent*. A 412 means "someone else already finished the work I was about to do" — almost certainly the accept handler racing with the timer's reconcile. Re-trying is wrong (the work is done); throwing is wrong (this isn't an error). Silently skipping is the right behaviour. The `Promise.allSettled` wrapping ensures one swallowed 412 doesn't block other reconciliations in the same tick.
+
+### What this story does NOT do
+- **Re-dispatch** when an offer expires unfulfilled. The booking goes to `UNFULFILLED`; the operator dashboard (E09-S04) surfaces stuck bookings for manual escalation. Automated re-dispatch is out of scope.
+- **Loser receipt/ack tracking.** The losing techs receive an FCM that may or may not arrive; we don't track delivery. The technician-app's `JobOfferViewModel` from E05-S03 closes the offer overlay on its own 30s countdown, so the FCM is just a UX nicety.
+
+---
+
+## Definition of Done
+
+- [x] `cd api && pnpm typecheck && pnpm lint && pnpm test` — 360/360 tests green
+- [x] `bash tools/pre-codex-smoke-api.sh` exited 0
+- [x] All 10 accept/decline test cases asserted in `tests/bookings/accept-decline.test.ts`
+- [x] `.codex-review-passed` marker shipped in PR #28
+- [x] CI green on `main` after merge (commit 8d47ec0)
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+Claude Sonnet 4.6 (per PR #28 commit attribution)
+
+### Completion Notes
+PR #28 merged 2026-04-23 19:28 UTC as commit 8d47ec0. With this story in main, the dispatch loop closes: paid booking → SEARCHING → top-3 FCM offers → first-to-accept wins via `_etag` → losers get OFFER_CANCELLED → unanswered offers EXPIRE in ≤30s → booking goes UNFULFILLED. The Karnataka FR-9.1 boundary holds across the API surface: declines are append-only audit, never ranking input.
+
+### File List
+See PR #28: 4 files added — `api/src/cosmos/dispatch-attempt-repository.ts` (48 lines), `api/src/cosmos/booking-event-repository.ts` (14 lines), `api/src/functions/job-offers.ts` (123 lines), `api/tests/bookings/accept-decline.test.ts` (190 lines). Plus 3 unrelated minor admin-web file touches that the merge bundle preserved.

--- a/plans/E05-S01.md
+++ b/plans/E05-S01.md
@@ -1,0 +1,299 @@
+# E05-S01 Technician Geospatial Profile — Implementation Plan
+
+> **Retroactive plan** — reverse-engineered from PR #18 (merged 2026-04-20, commit 3fdfa4e) for issue #98. Source code is the authority; this plan documents the work that actually shipped so future stories can reuse the patterns.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish the Cosmos DB geospatial foundation that the dispatcher (E05-S02) needs: a `TechnicianProfileSchema` with GeoJSON Point location + skills + availability, a repository that runs `ST_WITHIN` bounding-box queries with skill/KYC/online filters, a spatial-index policy applied to the `technicians` container, and a Bengaluru seed script with edge-case docs that exercise the dispatch exclusion rules.
+
+**Architecture:**
+- **Schema:** `TechnicianProfileSchema` with GeoJSON `Point` (`[lng, lat]` order — GeoJSON canonical), `skills[]`, `availabilityWindows[]`, `isOnline`, `isAvailable`, `kycStatus ∈ {APPROVED|PENDING|REJECTED}`. Optional `fcmToken`, `rating`, `completedJobCount`, `updatedAt`. Schema also forbids any decline-history field (Karnataka FR-9.1 enforced by absence).
+- **Repository:** `upsertTechnicianProfile(profile)` and `getTechniciansWithinRadius(lat, lng, radiusKm, serviceId)`. The geo query uses Cosmos `ST_WITHIN` against a 5-vertex closed `Polygon` (bounding-box, not circle — circle queries are not supported by Cosmos directly) plus `ARRAY_CONTAINS(skills, @serviceId)` plus equality filters on `kycStatus = "APPROVED"`, `isOnline = true`, `isAvailable = true`.
+- **Geo helper:** `boundingBoxPolygon(lat, lng, radiusKm)` produces a closed-ring `[sw, se, ne, nw, sw]` polygon using degree-delta math (`deltaLat = radiusKm / 111`; `deltaLng = radiusKm / (111 * cos(lat))`). The polygon is a square that *contains* the desired circle; the dispatcher (E05-S02) is responsible for the haversine post-filter to drop bounding-box-corner techs that fall outside the actual radius.
+- **Spatial index:** `api/src/cosmos/indexes/technicians-index.json` declares `spatialIndexes: [{ path: "/location/*", types: ["Point"] }]`. Applied via `container.replace(...)` or Azure Portal Data Explorer; without it `ST_WITHIN` falls back to a slow scan.
+- **Seed:** 10 Bengaluru technicians spanning Koramangala / Indiranagar / Whitefield / HSR / Marathahalli / Jayanagar / BTM / Electronic City / Yelahanka / Banashankari, with two edge-case docs (`isOnline: false` and `isAvailable: false`) that the dispatch query MUST exclude.
+
+**Tech stack:** TypeScript + Zod + Azure Cosmos SDK v4 + Vitest. Single sub-project (`api/`).
+
+**Karnataka FR-9.1 invariance:** This story bakes the invariant into the *schema*. `TechnicianProfileSchema` does not declare `declineCount`, `declineHistory`, or any equivalent — so downstream code physically cannot read one. The follow-up E05-S02 dispatcher uses only `location` and `rating`. A CI test in E05-S02 (`dispatcher-up-ranking.test.ts`) asserts the schema does not regrow such a field.
+
+---
+
+## File Inventory
+
+**Created:**
+- `api/src/schemas/technician.ts`
+- `api/src/cosmos/geo.ts` (initial: `boundingBoxPolygon` + `pointInsidePolygon` helper for unit tests)
+- `api/src/cosmos/indexes/technicians-index.json`
+- `api/scripts/seed-technicians.ts`
+- `api/tests/schemas/technician.test.ts`
+- `api/tests/unit/cosmos/geo.test.ts`
+- `api/tests/unit/cosmos/technician-geospatial.test.ts`
+
+**Modified:**
+- `api/src/cosmos/technician-repository.ts` — append `upsertTechnicianProfile` + `getTechniciansWithinRadius` after the existing KYC methods (E02-S03)
+- `api/package.json` — add `seed:technicians` script
+
+---
+
+## WS-A — Schema (TDD)
+
+### Task 1: Failing schema test
+
+- [ ] Create `api/tests/schemas/technician.test.ts`. Cover:
+  - Valid profile parses (Koramangala technician, all required fields + optional `rating`)
+  - Missing `id` → fails
+  - Empty `skills` array → fails (`min(1)`)
+  - `kycStatus: "INVALID"` → fails
+  - GeoJSON without `type: "Point"` → fails
+  - `endHour > 24` → fails
+  - `dayOfWeek: 7` → fails
+  - Optional fields parse when omitted
+  - **Invariance assertion:** `expect(parsed).not.toHaveProperty('declineCount')` — schema does not silently allow Karnataka-violating fields
+
+### Task 2: Schema implementation
+
+- [ ] Create `api/src/schemas/technician.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const GeoPointSchema = z.object({
+  type: z.literal('Point'),
+  coordinates: z.tuple([z.number(), z.number()]), // [longitude, latitude]
+});
+
+export const AvailabilityWindowSchema = z.object({
+  dayOfWeek: z.number().int().min(0).max(6),
+  startHour: z.number().int().min(0).max(23),
+  endHour: z.number().int().min(1).max(24),
+});
+
+export const TechnicianKycStatusSchema = z.enum(['APPROVED', 'PENDING', 'REJECTED']);
+
+export const TechnicianProfileSchema = z.object({
+  id: z.string().min(1),
+  technicianId: z.string().min(1),
+  location: GeoPointSchema,
+  skills: z.array(z.string().min(1)).min(1),
+  availabilityWindows: z.array(AvailabilityWindowSchema),
+  isOnline: z.boolean(),
+  isAvailable: z.boolean(),
+  kycStatus: TechnicianKycStatusSchema,
+  fcmToken: z.string().optional(),
+  rating: z.number().min(0).max(5).optional(),
+  completedJobCount: z.number().int().min(0).optional(),
+  updatedAt: z.string().datetime().optional(),
+});
+
+export type GeoPoint = z.infer<typeof GeoPointSchema>;
+export type AvailabilityWindow = z.infer<typeof AvailabilityWindowSchema>;
+export type TechnicianKycStatus = z.infer<typeof TechnicianKycStatusSchema>;
+export type TechnicianProfile = z.infer<typeof TechnicianProfileSchema>;
+```
+
+- [ ] Run schema test — green. Commit.
+
+---
+
+## WS-B — Geo helper (TDD)
+
+### Task 3: Failing geo polygon test
+
+- [ ] Create `api/tests/unit/cosmos/geo.test.ts`. Cover:
+  - Polygon shape (5 vertices, closed ring — first === last)
+  - Span: at lat=12.97 (Bangalore), `deltaLat = radiusKm/111`, `deltaLng = radiusKm/(111 * cos(lat))`
+  - Polygon ordering: `[sw, se, ne, nw, sw]` (counter-clockwise from sw)
+  - Boundary exclusion invariant: a point at the exact polygon corner is reported "inside" by ray-casting (mirroring how Cosmos `ST_WITHIN` treats edges as inclusive in some cases) — adjust the test based on Cosmos semantics, but document the chosen convention
+  - `pointInsidePolygon` returns true for the polygon center; false for a point 2× radius away
+
+### Task 4: Geo helper implementation
+
+- [ ] Create `api/src/cosmos/geo.ts`:
+
+```typescript
+export interface BoundingBoxPolygon {
+  type: 'Polygon';
+  coordinates: [[number, number][]];
+}
+
+export function boundingBoxPolygon(
+  lat: number,
+  lng: number,
+  radiusKm: number,
+): BoundingBoxPolygon {
+  const deltaLat = radiusKm / 111;
+  const deltaLng = radiusKm / (111 * Math.cos((lat * Math.PI) / 180));
+  const sw: [number, number] = [lng - deltaLng, lat - deltaLat];
+  const se: [number, number] = [lng + deltaLng, lat - deltaLat];
+  const ne: [number, number] = [lng + deltaLng, lat + deltaLat];
+  const nw: [number, number] = [lng - deltaLng, lat + deltaLat];
+  return {
+    type: 'Polygon',
+    coordinates: [[sw, se, ne, nw, sw]],
+  };
+}
+
+/**
+ * Ray-casting point-in-polygon test (unit tests only — not called at runtime).
+ * Returns false for points on the boundary edge, mirroring Cosmos ST_WITHIN semantics.
+ */
+export function pointInsidePolygon(
+  lat: number,
+  lng: number,
+  poly: BoundingBoxPolygon,
+): boolean {
+  const ring = poly.coordinates[0];
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i]!;
+    const [xj, yj] = ring[j]!;
+    const intersect =
+      yi > lat !== yj > lat &&
+      lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+```
+
+- [ ] Run geo test — green. Commit.
+
+> **Note:** `haversine()` is added to this file in E05-S02 — don't add it here.
+
+---
+
+## WS-C — Repository (TDD)
+
+### Task 5: Failing repository test
+
+- [ ] Create `api/tests/unit/cosmos/technician-geospatial.test.ts` with vi.mock'd Cosmos client. Cover:
+  - `upsertTechnicianProfile` calls `container.items.upsert(profile)`
+  - `getTechniciansWithinRadius(lat, lng, 10, 'svc-plumbing')` builds the expected SQL string with `ST_WITHIN(c.location, @polygon)` AND `ARRAY_CONTAINS(c.skills, @serviceId)` AND three boolean filters
+  - Polygon parameter is a `BoundingBoxPolygon` (5-vertex closed ring)
+  - Service-id parameter is forwarded verbatim
+  - `kycStatus = "APPROVED"` filter is in the WHERE clause (excludes PENDING/REJECTED techs)
+  - `isOnline = true` AND `isAvailable = true` filters are in the WHERE clause (excludes the two edge-case seed docs)
+  - Returns `resources` from `fetchAll()`
+
+### Task 6: Repository methods
+
+- [ ] Append to `api/src/cosmos/technician-repository.ts` (after the existing KYC methods):
+
+```typescript
+// ── Geospatial profile methods (E05-S01) ─────────────────────────────────────
+
+export async function upsertTechnicianProfile(profile: TechnicianProfile): Promise<void> {
+  const client = getCosmosClient();
+  const container = client.database(DB_NAME).container(CONTAINER);
+  await container.items.upsert(profile);
+}
+
+export async function getTechniciansWithinRadius(
+  lat: number,
+  lng: number,
+  radiusKm: number,
+  serviceId: string,
+): Promise<TechnicianProfile[]> {
+  const client = getCosmosClient();
+  const container = client.database(DB_NAME).container(CONTAINER);
+  const polygon = boundingBoxPolygon(lat, lng, radiusKm);
+  const query = {
+    query: `SELECT * FROM c
+            WHERE ST_WITHIN(c.location, @polygon)
+            AND ARRAY_CONTAINS(c.skills, @serviceId)
+            AND c.kycStatus = "APPROVED"
+            AND c.isOnline = true
+            AND c.isAvailable = true`,
+    parameters: [
+      { name: '@polygon', value: polygon as unknown as string },
+      { name: '@serviceId', value: serviceId },
+    ],
+  };
+  const { resources } = await container.items
+    .query<TechnicianProfile>(query)
+    .fetchAll();
+  return resources;
+}
+```
+
+> The `as unknown as string` cast bridges Cosmos SDK's `parameters[].value` typing (string) with the polygon object the SDK actually serialises correctly.
+
+- [ ] Run repo test — green. Commit.
+
+---
+
+## WS-D — Index policy + seed
+
+### Task 7: Spatial index policy JSON
+
+- [ ] Create `api/src/cosmos/indexes/technicians-index.json`:
+
+```json
+{
+  "_comment": "Apply via: container.replace({ id: 'technicians', partitionKey: { paths: ['/technicianId'] }, indexingPolicy: <this object> }) or Azure Portal → Data Explorer → technicians → Scale & Settings → Indexing Policy",
+  "indexingMode": "consistent",
+  "automatic": true,
+  "includedPaths": [
+    { "path": "/*" }
+  ],
+  "excludedPaths": [
+    { "path": "/\"_etag\"/?" }
+  ],
+  "spatialIndexes": [
+    {
+      "path": "/location/*",
+      "types": ["Point"]
+    }
+  ]
+}
+```
+
+- [ ] Document in the runbook how to apply this (Portal → Data Explorer → technicians → Scale & Settings → Indexing Policy → paste).
+
+### Task 8: Bengaluru seed script
+
+- [ ] Create `api/scripts/seed-technicians.ts` with 10 technicians:
+  - 8 normal (`isOnline: true, isAvailable: true, kycStatus: 'APPROVED'`) spread across Koramangala, Indiranagar, Whitefield, HSR, Marathahalli, Jayanagar, BTM, Electronic City
+  - 1 offline (`isOnline: false`) at Yelahanka — must be excluded by dispatch
+  - 1 on-job (`isAvailable: false`) at Banashankari — must be excluded by dispatch
+  - Skill mix covering AC, plumbing, electrical, cleaning, pest-control
+  - Coordinates in `[lng, lat]` GeoJSON order
+  - `availabilityWindows` covering weekdays and partial weekend coverage
+
+- [ ] Add to `api/package.json` scripts: `"seed:technicians": "tsx scripts/seed-technicians.ts"`.
+
+- [ ] Run-time test (manual): `pnpm seed:technicians` against a dev Cosmos endpoint and confirm all 10 docs upsert.
+
+---
+
+## WS-E — Smoke gate + Codex review
+
+- [ ] Run `bash tools/pre-codex-smoke-api.sh` — exit 0
+- [ ] Run `codex review --base main` → resolve P1/P2 → write `.codex-review-passed`
+- [ ] Push branch, open PR with title:
+  > `feat(E05-S01): technician geospatial profile — schema, ST_WITHIN repo, Bengaluru seed, spatial index`
+- [ ] PR body lists test counts (9 schema + 6 geo + 7 repo = 22 new tests; suite goes from 103 → 125)
+- [ ] Note in PR body that the seed script is dev-only (not run in CI) and KYC methods from E02-S03 pattern are included for pre-merge compatibility
+
+---
+
+## Self-review
+
+### Spec coverage
+| Requirement | Task |
+|---|---|
+| `TechnicianProfileSchema` with GeoJSON Point | Task 2 |
+| Skills + availability + KYC + isOnline/isAvailable | Task 2 |
+| No decline-history field (FR-9.1) | Task 2 (schema absence) + Task 1 (test asserts) |
+| `boundingBoxPolygon` 5-vertex closed ring | Task 4 |
+| `ST_WITHIN` + ARRAY_CONTAINS + boolean filters | Task 6 |
+| Spatial index policy JSON | Task 7 |
+| Seed script with edge-case docs | Task 8 |
+| TDD red→green for schema, geo, repo | Tasks 1→2, 3→4, 5→6 |
+| Smoke gate + Codex review | WS-E |
+
+### Files-do-not-touch
+- `api/src/services/dispatcher.service.ts` — stub remains until E05-S02
+- `api/src/middleware/verifyTechnicianToken.ts` — created by E05-S02
+- All `customer-app/`, `technician-app/`, `admin-web/` — out of scope

--- a/plans/E05-S02.md
+++ b/plans/E05-S02.md
@@ -1,0 +1,434 @@
+# E05-S02 Dispatcher Engine — Implementation Plan
+
+> **Retroactive plan** — reverse-engineered from PR #26 (merged 2026-04-23, commit 5b9c5ff) for issue #99. Source code is the authority; this plan documents the work that actually shipped so future stories can reuse the patterns.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `dispatcher.service.ts` stub with a real dispatch loop: when a booking transitions to `PAID`, query technicians within 10 km via `getTechniciansWithinRadius`, post-filter by haversine to drop bounding-box corner techs outside the actual circle, rank by (distance ASC, rating DESC) — **never** by decline history (FR-9.1), record a `DispatchAttemptDoc` with a 30-second expiry, transition the booking to `SEARCHING`, and send FCM `JOB_OFFER` data messages to the top 3 candidates. Add a `PATCH /v1/technicians/fcm-token` endpoint so the technician app can register its push token. Lock the Karnataka invariance with a CI test that fails if any future change re-introduces a decline-based ranking term.
+
+**Architecture:**
+- **Pure ranking function:** `rankTechnicians(techs, bookingLat, bookingLng)` is exported separately from the orchestrator so it can be unit-tested without mocking Cosmos. It takes only `location` and `rating` from each tech — no decline-history field is even available on `TechnicianProfile` (E05-S01 ensured this).
+- **Constants:** `DISPATCH_RADIUS_KM = 10`, `OFFER_WINDOW_MS = 30_000`, `TOP_N = 3`. All three are local consts; promoting them to env vars is deferred until pilot data justifies it.
+- **Booking state transitions:** `PAID → SEARCHING` after the dispatch attempt is recorded (so the stale-booking reconciler in E05-S04 can find stuck dispatches). On zero candidates: `PAID → UNFULFILLED` (no `SEARCHING` middle state — there is nothing to search for).
+- **FCM data messages:** silent (no `notification` payload), so they don't appear in the system tray. Technician app's `HomeservicesFcmService` (E05-S03) intercepts and shows an in-app full-screen overlay.
+- **Karnataka FR-9.1 CI gate:** `tests/integration/dispatcher-up-ranking.test.ts` asserts ranking is invariant to decline history *and* asserts the schema does not expose any decline-related field. Any change that fails this test fails CI.
+
+**Tech stack:** TypeScript + Zod + Cosmos SDK + firebase-admin/messaging + Vitest. Single sub-project (`api/`).
+
+**Prerequisites:** E05-S01 (TechnicianProfile schema + ST_WITHIN repo) + E03-S04 (booking PAID transition) + Firebase Admin SDK initialised (already done).
+
+---
+
+## File Inventory
+
+**Created:**
+- `api/src/schemas/dispatch-attempt.ts`
+- `api/src/schemas/booking-event.ts`
+- `api/src/middleware/verifyTechnicianToken.ts`
+- `api/tests/integration/dispatcher-up-ranking.test.ts` (Karnataka FR-9.1 CI gate)
+- `api/tests/unit/dispatcher.service.test.ts`
+- `api/tests/unit/technicians.test.ts`
+
+**Modified:**
+- `api/src/cosmos/client.ts` — add `getDispatchAttemptsContainer` + `getBookingEventsContainer`
+- `api/src/cosmos/geo.ts` — add `haversine(lat1, lng1, lat2, lng2)`
+- `api/src/schemas/technician.ts` — add optional `fcmToken`, `rating` (already present from E05-S01 — re-asserted here)
+- `api/src/services/dispatcher.service.ts` — replace stub with real implementation
+- `api/src/functions/technicians.ts` — append `PATCH /v1/technicians/fcm-token` handler
+- `api/tests/services/dispatcher.service.test.ts` — extend existing tests for new orchestrator behaviour
+- `api/tests/webhooks/razorpay-webhook.test.ts` — drop 3 lines that no longer apply (booking transitions changed)
+
+---
+
+## WS-A — Schemas + container accessors
+
+### Task 1: `DispatchAttemptDoc` schema
+
+- [ ] Create `api/src/schemas/dispatch-attempt.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const DispatchAttemptStatusSchema = z.enum(['PENDING', 'ACCEPTED', 'EXPIRED']);
+
+export const DispatchAttemptDocSchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  technicianIds: z.array(z.string()),
+  sentAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  status: DispatchAttemptStatusSchema,
+});
+
+export type DispatchAttemptDoc = z.infer<typeof DispatchAttemptDocSchema>;
+export type DispatchAttemptStatus = z.infer<typeof DispatchAttemptStatusSchema>;
+```
+
+### Task 2: `BookingEventDoc` schema (append-only audit log)
+
+- [ ] Create `api/src/schemas/booking-event.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const BookingEventDocSchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  event: z.string(),
+  technicianId: z.string().optional(),
+  adminId: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  ts: z.string().datetime(),
+});
+
+export type BookingEventDoc = z.infer<typeof BookingEventDocSchema>;
+```
+
+> The repository (`bookingEventRepo.append`) is added in E05-S04 — only the schema is created here.
+
+### Task 3: Container accessors
+
+- [ ] Append to `api/src/cosmos/client.ts`:
+
+```typescript
+export function getDispatchAttemptsContainer() {
+  return getCosmosClient().database(DB_NAME).container('dispatch_attempts');
+}
+
+export function getBookingEventsContainer() {
+  return getCosmosClient().database(DB_NAME).container('booking_events');
+}
+```
+
+> Container partition keys: `dispatch_attempts` partitioned by `/bookingId`; `booking_events` partitioned by `/bookingId`. Document this in the runbook.
+
+### Task 4: Haversine helper
+
+- [ ] Append to `api/src/cosmos/geo.ts`:
+
+```typescript
+export function haversine(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+```
+
+- [ ] Commit WS-A together: `feat(api): dispatch_attempts + booking_events schemas + haversine helper`.
+
+---
+
+## WS-B — Karnataka FR-9.1 CI gate (TDD red — write FIRST)
+
+This test is the *most important* test in the entire dispatch path. It must fail any future implementation that re-introduces decline ranking.
+
+### Task 5: Failing dispatcher-up-ranking test
+
+- [ ] Create `api/tests/integration/dispatcher-up-ranking.test.ts`. Cover:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { rankTechnicians } from '../../src/services/dispatcher.service.js';
+import type { TechnicianProfile } from '../../src/schemas/technician.js';
+
+const BOOKING_LAT = 26.7922;  // Ayodhya pilot
+const BOOKING_LNG = 82.1998;
+
+function makeTech(id: string, lngOffset: number, overrides: Partial<TechnicianProfile> = {}): TechnicianProfile {
+  return {
+    id,
+    technicianId: id,
+    location: { type: 'Point', coordinates: [BOOKING_LNG + lngOffset, BOOKING_LAT] },
+    skills: ['svc-plumbing'],
+    availabilityWindows: [],
+    isOnline: true,
+    isAvailable: true,
+    kycStatus: 'APPROVED',
+    ...overrides,
+  };
+}
+
+describe('Dispatch ranking — invariant to decline history (Ayodhya pilot)', () => {
+  it('ranks closer technician first even when they have the highest simulated decline count', () => {
+    const techA = makeTech('tech-A', 0.02, { rating: 2.5 }); // ~2 km, low rating
+    const techB = makeTech('tech-B', 0.10, { rating: 4.9 });
+    const techC = makeTech('tech-C', 0.50, { rating: 5.0 });
+    const ranked = rankTechnicians([techC, techB, techA], BOOKING_LAT, BOOKING_LNG);
+    expect(ranked.map((t) => t.id)).toEqual(['tech-A', 'tech-B', 'tech-C']);
+  });
+
+  it('ranking is stable across all 6 permutations of input order', () => {
+    // ...iterate permutations, assert ['near', 'mid', 'far'] every time
+  });
+
+  it('TechnicianProfile schema does not expose a decline-related field', () => {
+    const profile = makeTech('check', 0.01);
+    expect(profile).not.toHaveProperty('declineCount');
+    expect(profile).not.toHaveProperty('declineHistory');
+    expect(profile).not.toHaveProperty('declines');
+  });
+});
+```
+
+- [ ] Run — fails (rankTechnicians not exported yet). Commit.
+
+> **Karnataka FR-9.1 — this is the legal-compliance teeth.** Any future PR that adds decline-aware ranking will trip this test in CI. Do NOT remove or weaken these assertions without an ADR + legal sign-off.
+
+---
+
+## WS-C — Dispatcher service (TDD green)
+
+### Task 6: Dispatcher unit tests
+
+- [ ] Create `api/tests/unit/dispatcher.service.test.ts`. Cover the orchestrator with `vi.mock` on `bookingRepo`, `getTechniciansWithinRadius`, `getDispatchAttemptsContainer`, `firebase-admin/messaging`:
+  - Booking not found → no-op + log
+  - Booking status !== `PAID` → no-op + log (e.g. already `ASSIGNED`)
+  - Zero candidates → booking transitions `PAID → UNFULFILLED`, no FCM, no DispatchAttemptDoc
+  - 5 candidates within bounding box, but 2 outside actual radius → only 3 sent (haversine post-filter drops the corners)
+  - More than 3 candidates → only TOP_N=3 receive FCM
+  - DispatchAttemptDoc.expiresAt is exactly `sentAt + 30_000 ms`
+  - DispatchAttemptDoc.status is `PENDING` at create
+  - Technician with no `fcmToken` is in the attempt doc (so accept can still match by id) but does not receive an FCM send
+  - Booking transitions `PAID → SEARCHING` after the attempt is created
+  - FCM payload `data` includes: `type: "JOB_OFFER"`, `bookingId`, `serviceId`, `addressText`, `slotDate`, `slotWindow`, `amount` (string), `distanceKm` (string), `expiresAt` (ISO string), `dispatchAttemptId`
+  - All technicians with `kycStatus: PENDING` or `REJECTED` are filtered out by the repo (already true from E05-S01) — re-asserted here
+
+### Task 7: Dispatcher implementation
+
+- [ ] Replace `api/src/services/dispatcher.service.ts`:
+
+```typescript
+import { randomUUID } from 'node:crypto';
+import { getMessaging } from 'firebase-admin/messaging';
+import { bookingRepo, updateBookingFields } from '../cosmos/booking-repository.js';
+import { getTechniciansWithinRadius } from '../cosmos/technician-repository.js';
+import { haversine } from '../cosmos/geo.js';
+import { getDispatchAttemptsContainer } from '../cosmos/client.js';
+import type { TechnicianProfile } from '../schemas/technician.js';
+import type { DispatchAttemptDoc } from '../schemas/dispatch-attempt.js';
+
+const DISPATCH_RADIUS_KM = 10;
+const OFFER_WINDOW_MS = 30_000;
+const TOP_N = 3;
+
+export function rankTechnicians(
+  techs: TechnicianProfile[],
+  bookingLat: number,
+  bookingLng: number,
+): TechnicianProfile[] {
+  // GeoJSON coordinates: [longitude, latitude]
+  return techs
+    .map((t) => ({
+      tech: t,
+      distanceKm: haversine(bookingLat, bookingLng, t.location.coordinates[1], t.location.coordinates[0]),
+    }))
+    .sort((a, b) => {
+      if (a.distanceKm !== b.distanceKm) return a.distanceKm - b.distanceKm;
+      // Operator policy (Ayodhya pilot): secondary sort is rating only — decline history must never be used
+      return (b.tech.rating ?? 0) - (a.tech.rating ?? 0);
+    })
+    .map((x) => x.tech);
+}
+
+export const dispatcherService = {
+  async triggerDispatch(bookingId: string): Promise<void> {
+    const booking = await bookingRepo.getById(bookingId);
+    if (!booking || booking.status !== 'PAID') {
+      console.log(`DISPATCH_SKIP bookingId=${bookingId} status=${booking?.status ?? 'NOT_FOUND'}`);
+      return;
+    }
+
+    const { lat, lng } = booking.addressLatLng;
+    // Cosmos uses a bounding-box (square) query; filter to the actual circle radius
+    const candidates = (await getTechniciansWithinRadius(lat, lng, DISPATCH_RADIUS_KM, booking.serviceId))
+      .filter((t) => haversine(lat, lng, t.location.coordinates[1], t.location.coordinates[0]) <= DISPATCH_RADIUS_KM);
+
+    if (candidates.length === 0) {
+      console.log(`DISPATCH_NO_TECHS bookingId=${bookingId}`);
+      await updateBookingFields(bookingId, { status: 'UNFULFILLED' });
+      return;
+    }
+
+    const ranked = rankTechnicians(candidates, lat, lng).slice(0, TOP_N);
+    const sentAt = new Date();
+    const expiresAt = new Date(sentAt.getTime() + OFFER_WINDOW_MS);
+
+    const attempt: DispatchAttemptDoc = {
+      id: randomUUID(),
+      bookingId,
+      technicianIds: ranked.map((t) => t.id),
+      sentAt: sentAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      status: 'PENDING',
+    };
+
+    await getDispatchAttemptsContainer().items.create(attempt);
+    // Transition to SEARCHING so the stale-booking reconciler can find stuck dispatches
+    await updateBookingFields(bookingId, { status: 'SEARCHING' });
+
+    const messaging = getMessaging();
+    await Promise.allSettled(
+      ranked.map(async (tech) => {
+        if (!tech.fcmToken) return;
+        await messaging.send({
+          token: tech.fcmToken,
+          data: {
+            type: 'JOB_OFFER',
+            bookingId,
+            serviceId: booking.serviceId,
+            addressText: booking.addressText,
+            slotDate: booking.slotDate,
+            slotWindow: booking.slotWindow,
+            amount: String(booking.amount),
+            distanceKm: String(haversine(lat, lng, tech.location.coordinates[1], tech.location.coordinates[0])),
+            expiresAt: expiresAt.toISOString(),
+            dispatchAttemptId: attempt.id,
+          },
+        });
+      }),
+    );
+
+    console.log(`DISPATCH_SENT bookingId=${bookingId} technicianIds=${ranked.map((t) => t.id).join(',')}`);
+  },
+};
+```
+
+- [ ] Run dispatcher tests + Karnataka invariance test — green. Commit.
+
+---
+
+## WS-D — Technician token middleware + FCM-token endpoint (TDD)
+
+### Task 8: `verifyTechnicianToken` middleware
+
+- [ ] Create `api/src/middleware/verifyTechnicianToken.ts`:
+
+```typescript
+import { HttpRequest } from '@azure/functions';
+import { verifyFirebaseIdToken } from '../services/firebaseAdmin.js';
+
+export async function verifyTechnicianToken(req: HttpRequest): Promise<{ uid: string }> {
+  const authorization = req.headers.get('Authorization') ?? '';
+  const token = authorization.replace('Bearer ', '');
+  if (!token) throw new Error('No token');
+  const decoded = await verifyFirebaseIdToken(token);
+  return { uid: decoded.uid };
+}
+```
+
+> **Codex P1 fix in-PR:** Use `verifyFirebaseIdToken` (not the lower-level `getAuth().verifyIdToken`) so Firebase Admin is guaranteed initialised on cold starts.
+
+### Task 9: FCM-token endpoint tests
+
+- [ ] Create `api/tests/unit/technicians.test.ts`. Cover:
+  - 401 when no `Authorization` header
+  - 401 when `verifyTechnicianToken` throws
+  - 400 `VALIDATION_ERROR` on missing `fcmToken` body field
+  - 400 `PARSE_ERROR` on malformed JSON
+  - 200 with `{ ok: true }` on valid call; verifies upsert was called with `{ ...existing, fcmToken: <new> }`
+
+### Task 10: FCM-token endpoint implementation
+
+- [ ] Append to `api/src/functions/technicians.ts`:
+
+```typescript
+const PatchFcmTokenBodySchema = z.object({
+  fcmToken: z.string().min(1),
+});
+
+export const patchFcmTokenHandler: HttpHandler = async (req, _ctx: InvocationContext) => {
+  let uid: string;
+  try {
+    const decoded = await verifyTechnicianToken(req);
+    uid = decoded.uid;
+  } catch {
+    return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } };
+  }
+
+  let body: { fcmToken: string };
+  try {
+    const raw: unknown = await req.json();
+    const result = PatchFcmTokenBodySchema.safeParse(raw);
+    if (!result.success) {
+      return { status: 400, jsonBody: { code: 'VALIDATION_ERROR', issues: result.error.issues } };
+    }
+    body = result.data;
+  } catch {
+    return { status: 400, jsonBody: { code: 'PARSE_ERROR' } };
+  }
+
+  const container = getCosmosClient().database(DB_NAME).container('technicians');
+  const { resource: existing } = await container.item(uid, uid).read<Record<string, unknown>>();
+  const doc = { ...(existing ?? { id: uid }), fcmToken: body.fcmToken };
+  await container.items.upsert(doc);
+
+  return { status: 200, jsonBody: { ok: true } };
+};
+
+app.http('patchTechnicianFcmToken', {
+  route: 'v1/technicians/fcm-token',
+  methods: ['PATCH'],
+  handler: patchFcmTokenHandler,
+});
+```
+
+- [ ] Run technician endpoint tests — green. Commit.
+
+---
+
+## WS-E — Smoke gate, Codex review, PR
+
+### Task 11: Pre-Codex smoke gate
+
+```bash
+bash tools/pre-codex-smoke-api.sh
+# Expected: 61 test files / 353 tests passing, exit 0
+```
+
+### Task 12: Codex review
+
+- [ ] `codex review --base main`
+- [ ] Expected P1 findings to address before merge:
+  - **P1**: `haversine` post-filter drops bounding-box corner techs beyond 10 km (already in the implementation above — keep)
+  - **P1**: `verifyTechnicianToken` uses `verifyFirebaseIdToken` for cold-start init (already done above — keep)
+  - **P2**: booking transitions to `SEARCHING` after dispatch attempt is created (already done — keep)
+- [ ] Write `.codex-review-passed` marker after resolution.
+
+### Task 13: PR
+
+- [ ] Push branch, open PR with title:
+  > `feat(api): E05-S02 — dispatcher engine (geo-rank + FCM job offers + dispatch attempts)`
+- [ ] PR body lists the test plan: dispatcher 0-techs UNFULFILLED, cap-at-3, expiresAt+30s, skip-no-fcm-token, SEARCHING transition, bounding-box corner filter; FCM token endpoint 401/400/200 cases; Karnataka invariance gate (3 tests).
+
+---
+
+## Self-review
+
+### Spec coverage
+| Requirement | Task |
+|---|---|
+| Geo-query within 10 km via `getTechniciansWithinRadius` | Task 7 |
+| Haversine post-filter drops corner techs | Task 7 |
+| Rank by (distance ASC, rating DESC) — never decline | Task 7 (rankTechnicians) |
+| Karnataka FR-9.1 invariance CI gate | Task 5 (3 assertions) |
+| Top-3 cap | Task 7 (`.slice(0, TOP_N)`) |
+| 30-s offer window | Task 7 (`OFFER_WINDOW_MS`) |
+| `DispatchAttemptDoc` schema + container | Tasks 1, 3 |
+| FCM data message with full payload | Task 7 |
+| Skip-FCM when `fcmToken` absent (still in attempt doc) | Task 7 |
+| Booking PAID → SEARCHING after attempt | Task 7 |
+| Booking PAID → UNFULFILLED on zero candidates | Task 7 |
+| `PATCH /v1/technicians/fcm-token` Firebase-auth + Zod | Tasks 8, 10 |
+| Cold-start-safe Firebase init | Task 8 |
+
+### Files-do-not-touch
+- Booking schemas — already define `PAID`, `SEARCHING`, `UNFULFILLED`, `ASSIGNED`, `COMPLETED`, `UNFULFILLED` from E03-S04
+- `api/src/cosmos/dispatch-attempt-repository.ts` — added in E05-S04 (accept/decline)
+- `api/src/cosmos/booking-event-repository.ts` — added in E05-S04
+- `api/src/functions/job-offers.ts` — added in E05-S04

--- a/plans/E05-S03.md
+++ b/plans/E05-S03.md
@@ -1,0 +1,345 @@
+# E05-S03 Technician-app FCM Job Offer Card — Implementation Plan
+
+> **Retroactive plan** — reverse-engineered from PR #29 (merged 2026-04-23, commit d162932) for issue #100. Source code is the authority; this plan documents the work that actually shipped so future stories can reuse the patterns.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a full-screen Compose overlay to `technician-app/` that wakes up on FCM `JOB_OFFER` data messages, renders rich job context (service, address, slot, distance, earnings) plus a 30-s countdown ring with haptic feedback in the last 5 seconds, and provides large Accept (green) / Decline (outline) buttons that hit the E05-S02 / E05-S04 backend. Sync the FCM token on login and on `onNewToken`.
+
+**Architecture:**
+- **FCM service** (`HomeservicesFcmService`, `@AndroidEntryPoint`, field-injected): intercepts `data["type"] == "JOB_OFFER"`, parses payload into a `JobOffer` domain model, emits to a `@Singleton` `JobOfferEventBus` (`MutableSharedFlow<JobOffer>`, replay=0, extraBufferCapacity=1). On `onNewToken`, hands off to `FcmTokenSyncUseCase`.
+- **Use cases** (all `@Singleton`, internal-constructed, public-callable):
+  - `AcceptJobOfferUseCase(api, firebaseAuth)` — fetches Firebase ID token, calls `PATCH .../accept`, maps `200 → Accepted`, `410 → Expired`, anything else → throws (caught by ViewModel as Expired).
+  - `DeclineJobOfferUseCase(api, firebaseAuth)` — fires the API call but **always returns `Declined`** regardless of HTTP status, because user intention to decline is the source of truth (FR-9.1: decline counts must never be inferred from server outcome).
+  - `FcmTokenSyncUseCase(api, firebaseAuth)` — `invoke()` fetches FCM token from `FirebaseMessaging.getInstance().token.await()` then delegates; `invokeWithFcmToken(token)` is the testable seam (no static FirebaseMessaging access in unit tests).
+- **UI** (`JobOfferScreen`, internal Compose): observes `JobOfferViewModel.uiState`. Sealed `JobOfferUiState`: `Idle`, `Offering(offer, remainingSeconds)`, `Accepted(bookingId)`, `Declined`, `Expired`. ViewModel owns the per-second countdown coroutine + haptic guard. `AppNavigation` overlays `JobOfferScreen` over the existing nav graph when state is `Offering | Declined | Expired` (Accepted triggers nav to `activeJob/{bookingId}`).
+- **Hilt module** (`JobOfferModule`): provides `JobOfferApiService` Retrofit client. Uses unqualified `OkHttpClient` with `HttpLoggingInterceptor` (BODY level — debug ergonomics; safe because no PII in JobOffer endpoint payloads).
+- **AndroidManifest**: declares `HomeservicesFcmService` with `<intent-filter>com.google.firebase.MESSAGING_EVENT</intent-filter>`. Adds POST_NOTIFICATIONS permission (Android 13+).
+
+**Tech stack:** Kotlin + Compose + Hilt + Retrofit/Moshi + Firebase Auth + FCM + Coroutines + JUnit 4 + MockK + Paparazzi. Single sub-project (`technician-app/`).
+
+**Karnataka FR-9.1 enforcement (Android side):**
+- `DeclineJobOfferUseCase` always returns `Declined` even when the HTTP call throws — user intention is the source of truth.
+- File-level comment in `DeclineJobOfferUseCase.kt`: `// Per Karnataka FR-9.1: decline is logged server-side to booking_events but NEVER fed back to ranking.`
+- No "decline count" UI element anywhere in the screen.
+- Unit test asserts the use case returns `Declined` even when the API throws an `IOException`.
+
+**Prerequisites:** E05-S01 (TechnicianProfile schema), E05-S02 (dispatcher + FCM-token endpoint + accept/decline routes are *expected* to exist by E05-S04 — Android can ship its calls because the Retrofit interface is statically typed and the `JOB_OFFER` payload is forward-compatible).
+
+---
+
+## File Inventory
+
+**Created:**
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferEventBus.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferApiService.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/di/JobOfferModule.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/DeclineJobOfferUseCase.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOffer.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferUiState.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferScreen.kt`
+- Tests: `AcceptJobOfferUseCaseTest`, `DeclineJobOfferUseCaseTest`, `FcmTokenSyncUseCaseTest`, `JobOfferViewModelTest`, `JobOfferScreenPaparazziTest`
+
+**Modified:**
+- `technician-app/app/build.gradle.kts` — add `firebase-messaging-ktx`, `play-services-auth`, `lifecycle-runtime-compose`, `hilt-navigation-compose`
+- `technician-app/gradle/libs.versions.toml` — add `firebase-messaging-ktx` version coordinate (sync from customer-app first per CLAUDE.md invariant)
+- `technician-app/app/src/main/AndroidManifest.xml` — declare `HomeservicesFcmService`, add `POST_NOTIFICATIONS`
+- `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/AppNavigation.kt` — collect `JobOfferViewModel.uiState`, overlay `JobOfferScreen`, navigate to `activeJob/{bookingId}` on Accepted
+- `technician-app/app/src/main/res/values/strings.xml` — `job_offer_accepted`, `job_offer_declined`, `job_offer_expired`
+
+---
+
+## WS-E init — libs.versions.toml sync (FIRST, blocks everything)
+
+### Task 0: Sync libs.versions.toml from customer-app
+
+```bash
+cp customer-app/gradle/libs.versions.toml technician-app/gradle/libs.versions.toml
+```
+
+- [ ] Add the `firebase-messaging-ktx` version coordinate if not already present.
+- [ ] Commit: `chore(technician-app): sync libs.versions.toml from customer-app + firebase-messaging-ktx`
+
+> **CLAUDE.md invariant:** every technician-app story starts with this sync to prevent post-Codex drift.
+
+---
+
+## WS-A — Domain models (TDD)
+
+### Task 1: `JobOffer` data class
+
+- [ ] Create `domain/jobOffer/model/JobOffer.kt`:
+
+```kotlin
+package com.homeservices.technician.domain.jobOffer.model
+
+public data class JobOffer(
+    val bookingId: String,
+    val serviceId: String,
+    val serviceName: String,
+    val addressText: String,
+    val slotDate: String,
+    val slotWindow: String,
+    val amountPaise: Long,
+    val distanceKm: Double,
+    val expiresAtMs: Long,
+)
+```
+
+### Task 2: `JobOfferResult` sealed class
+
+- [ ] Create `domain/jobOffer/model/JobOfferResult.kt`:
+
+```kotlin
+package com.homeservices.technician.domain.jobOffer.model
+
+public sealed class JobOfferResult {
+    public data class Accepted(val bookingId: String) : JobOfferResult()
+    public data class Declined(val bookingId: String) : JobOfferResult()
+    public data class Expired(val bookingId: String) : JobOfferResult()
+}
+```
+
+- [ ] Commit WS-A: `feat(technician-app): JobOffer + JobOfferResult domain models`
+
+---
+
+## WS-B — Use cases (TDD, parallel-friendly per use case)
+
+> Each use case is independent. In a real execution, dispatch each as a parallel Sonnet subagent (per `superpowers:dispatching-parallel-agents`).
+
+### Task 3: AcceptJobOfferUseCase (TDD red → green)
+
+- [ ] Write `AcceptJobOfferUseCaseTest.kt` first. Cover:
+  - 200 success → `Accepted(bookingId)`
+  - 410 → `Expired(bookingId)`
+  - 500 → throws `RuntimeException`
+  - No authenticated user → throws `IllegalStateException`
+- [ ] Implement:
+
+```kotlin
+@Singleton
+public class AcceptJobOfferUseCase
+    @Inject
+    internal constructor(
+        private val api: JobOfferApiService,
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        public suspend operator fun invoke(bookingId: String): JobOfferResult {
+            val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token
+                ?: throw IllegalStateException("No authenticated user for job offer acceptance")
+            val response = api.acceptOffer("Bearer $token", bookingId)
+            return when {
+                response.isSuccessful -> JobOfferResult.Accepted(bookingId)
+                response.code() == 410 -> JobOfferResult.Expired(bookingId)
+                else -> throw RuntimeException("Accept offer failed: HTTP ${response.code()}")
+            }
+        }
+    }
+```
+
+### Task 4: DeclineJobOfferUseCase (TDD red → green)
+
+- [ ] Write `DeclineJobOfferUseCaseTest.kt` first. Cover:
+  - API success → `Declined(bookingId)`
+  - API IOException → `Declined(bookingId)` (Karnataka invariant: user intention wins)
+  - API non-2xx → `Declined(bookingId)` (response code intentionally ignored)
+- [ ] Implement:
+
+```kotlin
+// Per Karnataka FR-9.1: decline is logged server-side to booking_events but
+// NEVER fed back to ranking. Decline counts MUST NEVER appear in any UI label,
+// sort order, or analytics event.
+@Singleton
+public class DeclineJobOfferUseCase
+    @Inject
+    internal constructor(
+        private val api: JobOfferApiService,
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        public suspend operator fun invoke(bookingId: String): JobOfferResult {
+            val token = firebaseAuth.currentUser?.getIdToken(false)?.await()?.token.orEmpty()
+            return try {
+                api.declineOffer("Bearer $token", bookingId)
+                JobOfferResult.Declined(bookingId)
+            } catch (_: IOException) {
+                JobOfferResult.Declined(bookingId)
+            }
+        }
+    }
+```
+
+### Task 5: FcmTokenSyncUseCase (TDD red → green)
+
+- [ ] Write `FcmTokenSyncUseCaseTest.kt` first. Cover:
+  - Token sync success — passes Bearer + body
+  - IOException on `api.syncFcmToken` — swallowed (best-effort)
+  - `invokeWithFcmToken(token)` is the testable seam — `invoke()` (which uses static `FirebaseMessaging`) is excluded from unit tests
+- [ ] Implement (see source — test-first split between `invoke()` and `invokeWithFcmToken(token)` for testability).
+
+- [ ] Commit WS-B per use case: `feat(technician-app): {Accept|Decline|FcmTokenSync}JobOfferUseCase + tests`
+
+---
+
+## WS-C — FCM service + EventBus + Hilt module
+
+### Task 6: JobOfferEventBus
+
+- [ ] Create as a `@Singleton` `MutableSharedFlow<JobOffer>` with `replay=0, extraBufferCapacity=1`. Public `tryEmit(offer)` so the FCM service does not block.
+
+### Task 7: HomeservicesFcmService (`@AndroidEntryPoint`)
+
+- [ ] Field-injected `eventBus: JobOfferEventBus`, `fcmTokenSyncUseCase: FcmTokenSyncUseCase`, `ratingPromptEventBus: RatingPromptEventBus` (the last is for E07-S01 and is already wired).
+- [ ] `onMessageReceived(message)` switches on `data["type"]`:
+  - `"JOB_OFFER"` → parse via `parseJobOffer(data)`, `eventBus.tryEmit(offer)`
+  - `"RATING_PROMPT_TECHNICIAN"` → forward `bookingId` to `ratingPromptEventBus.post(bookingId)` (touched by E07-S01)
+- [ ] `parseJobOffer` returns `null` on any missing field; safely catches `Instant.parse` exceptions
+- [ ] `onNewToken(token)` → launch `serviceScope { fcmTokenSyncUseCase.invokeWithFcmToken(token) }`
+- [ ] `serviceScope` is `CoroutineScope(SupervisorJob() + Dispatchers.IO)`; cancelled in `onDestroy`
+
+### Task 8: JobOfferApiService (Retrofit)
+
+- [ ] Define internal interface with three suspending methods: `acceptOffer`, `declineOffer`, `syncFcmToken`. All take `Authorization` header explicitly (not via interceptor) to keep the Retrofit module dependency-free.
+- [ ] Internal `FcmTokenRequest(fcmToken: String)` data class.
+
+### Task 9: JobOfferModule (Hilt)
+
+- [ ] `@Module @InstallIn(SingletonComponent::class) public object`. Provides `JobOfferApiService` from a Retrofit `Builder` with `MoshiConverterFactory` and an `OkHttpClient` carrying an `HttpLoggingInterceptor(BODY)`.
+- [ ] Base URL: `https://homeservices-api.azurewebsites.net/api/`
+
+- [ ] Commit WS-C together: `feat(technician-app): FCM service + JobOfferEventBus + Hilt module`
+
+---
+
+## WS-D — UI + ViewModel + AppNavigation overlay (TDD)
+
+### Task 10: JobOfferUiState sealed class
+
+```kotlin
+public sealed class JobOfferUiState {
+    public data object Idle : JobOfferUiState()
+    public data class Offering(val offer: JobOffer, val remainingSeconds: Int) : JobOfferUiState()
+    public data class Accepted(val bookingId: String) : JobOfferUiState()
+    public data object Declined : JobOfferUiState()
+    public data object Expired : JobOfferUiState()
+}
+```
+
+### Task 11: JobOfferViewModel (TDD red → green)
+
+- [ ] Write `JobOfferViewModelTest.kt` first. Cover:
+  - Initial state `Idle`
+  - Bus emits offer → state `Offering(offer, ~30)`
+  - `delay(1000)` ticks → `remainingSeconds` decrements
+  - Reaching 0 → `Expired`
+  - Receiving an already-expired offer (`expiresAtMs` in past) → `Expired` immediately
+  - `accept()` while `Offering` → `Accepted` (success) or `Expired` (410) or `Expired` (catch)
+  - `decline()` while `Offering` → `Declined`
+  - `accept()` / `decline()` outside `Offering` → no-op
+  - After terminal state, `scheduleReset(2000)` returns to `Idle`
+- [ ] Implement (see source). Key details:
+  - `init` collects `eventBus.events`; cancels any in-flight `countdownJob` before starting a new one.
+  - Per-second loop computes seconds-remaining from `expiresAtMs - currentTimeMillis()` once at init, then decrements locally to avoid drift.
+  - `accept()` / `decline()` cancel `countdownJob` before launching the API call.
+
+### Task 12: JobOfferScreen (Compose overlay)
+
+- [ ] `Surface(fillMaxSize, color = MaterialTheme.colorScheme.background)` containing one of four sub-composables based on `uiState`:
+  - `Idle`: `Unit` (renders nothing — overlay is hidden upstream)
+  - `Offering`: large countdown ring (CircularProgressIndicator with `progress = remainingSeconds / 30f`, color `error` when `≤ 5s` else `primary`), centered `remainingSeconds` text, service name + address + slot + distance + earnings, large green Accept button (`Color(0xFF2E7D32)`), large outline Decline button.
+  - `Accepted` / `Declined` / `Expired`: centred result text using `JobOfferResultContent`.
+- [ ] **Haptic in last 5 seconds:** `LaunchedEffect(uiState)` — if `Offering` and `remainingSeconds in 1..5`, trigger `VibrationEffect.EFFECT_TICK`. Guard with `Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q` and a try/catch (haptic unavailable on emulator).
+- [ ] Use `hiltViewModel()` for the inner `JobOfferScreen`; expose `JobOfferScreenContent(uiState, onAccept, onDecline)` as the testable composable for Paparazzi.
+
+### Task 13: AppNavigation overlay wire-in
+
+- [ ] In `AppNavigation`:
+  - `val jobOfferViewModel: JobOfferViewModel = hiltViewModel()`
+  - `val jobOfferState by jobOfferViewModel.uiState.collectAsStateWithLifecycle()`
+  - `LaunchedEffect(jobOfferState)` — if `Accepted`, navigate to `activeJob/{bookingId}` (route added by E06-S01 — placeholder for now).
+  - In `Box(modifier = modifier)`, render `NavHost(...)` and conditionally render `JobOfferScreen(...)` overlay when state is not `Idle | Accepted` (Accepted is the nav-away case).
+
+### Task 14: Paparazzi stubs (4 `@Ignore`d)
+
+- [ ] `JobOfferScreenPaparazziTest` — 4 `@Ignore`d snapshot tests for `Idle | Offering(30s, 5s) | Accepted | Declined | Expired` representative states.
+- [ ] **Do NOT record on Windows** (per `docs/patterns/paparazzi-cross-os-goldens.md`); record via `paparazzi-record.yml` workflow_dispatch on CI Linux after merge.
+
+- [ ] Commit WS-D: `feat(technician-app): JobOfferScreen overlay + ViewModel + Paparazzi stubs`
+
+---
+
+## WS-Z — AndroidManifest + strings + smoke gate + Codex
+
+### Task 15: AndroidManifest
+
+- [ ] Add inside `<application>`:
+  ```xml
+  <service
+      android:name=".data.fcm.HomeservicesFcmService"
+      android:exported="false">
+      <intent-filter>
+          <action android:name="com.google.firebase.MESSAGING_EVENT" />
+      </intent-filter>
+  </service>
+  ```
+- [ ] Add `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` (Android 13+).
+
+### Task 16: Strings
+
+- [ ] Add to `res/values/strings.xml`:
+  ```xml
+  <string name="job_offer_accepted">Offer accepted — heading to booking…</string>
+  <string name="job_offer_declined">Offer declined</string>
+  <string name="job_offer_expired">Offer expired</string>
+  ```
+
+### Task 17: Pre-Codex smoke gate
+
+```bash
+bash tools/pre-codex-smoke.sh technician-app
+# Expected: assembleDebug → ktlintCheck → testDebugUnitTest (128 tests, 0 failures) → koverVerify (≥80%)
+```
+
+### Task 18: Codex review + Kover exclusions
+
+- [ ] `codex review --base main` → resolve P1/P2 (expect: nested `runTest`, ktlint warnings on long lines, possibly the `@Suppress("DEPRECATION")` on the haptic call needing justification).
+- [ ] Add Kover exclusions for:
+  - `JobOfferModule` (DI factory — no logic to cover)
+  - `HomeservicesFcmService` (Android system service — JVM tests can't reach `onMessageReceived`)
+  - `JobOfferScreen` composables (Paparazzi covers UI)
+- [ ] `.codex-review-passed` marker after resolution.
+
+### Task 19: PR
+
+- [ ] Push branch, open PR with title:
+  > `feat(technician-app): E05-S03 — FCM job offer full-screen card with countdown`
+- [ ] PR body lists the work-stream table (WS-E init / WS-A / WS-B / WS-C / WS-D / Smoke fixes), the constraints satisfied (FR-9.1 Karnataka decline-blind, ₹0 infra FCM-only, Paparazzi CI record), and the test plan (smoke gate + manual device test).
+- [ ] After merge: trigger `paparazzi-record.yml` workflow_dispatch on CI to commit goldens.
+
+---
+
+## Self-review
+
+### Spec coverage
+| Requirement | Task |
+|---|---|
+| FCM `JOB_OFFER` data message intercepted + parsed | Task 7 |
+| Full-screen overlay with countdown ring | Tasks 12, 13 |
+| Last-5-second haptic (API 29+ guarded) | Task 12 |
+| Accept button → API call → `Accepted` state → navigate to active job | Tasks 3, 11, 13 |
+| Decline button → API call → `Declined` (always, regardless of HTTP) | Tasks 4, 11 |
+| FCM token sync on login + on `onNewToken` | Tasks 5, 7 |
+| Karnataka FR-9.1 decline-blind enforcement | Task 4 (always Declined; file-level comment) |
+| Auto-dismiss after 2s on terminal state | Task 11 (`scheduleReset(2_000L)`) |
+| Paparazzi stubs `@Ignore`d on Windows; CI record post-merge | Task 14, Task 19 |
+| libs.versions.toml sync (first task) | Task 0 |
+
+### Files-do-not-touch
+- `customer-app/` — this is the technician-app story
+- `api/` — backend endpoints exist from E05-S02 / E05-S04 in parallel branches
+- Existing rating prompt flow (`RatingPromptEventBus`) — preserve in `HomeservicesFcmService` switch

--- a/plans/E05-S04.md
+++ b/plans/E05-S04.md
@@ -1,0 +1,346 @@
+# E05-S04 Accept/Decline Job-Offer API + Optimistic Concurrency — Implementation Plan
+
+> **Retroactive plan** — reverse-engineered from PR #28 (merged 2026-04-23, commit 8d47ec0) for issue #101. Source code is the authority; this plan documents the work that actually shipped.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the dispatch loop. When a technician accepts via `PATCH /v1/technicians/job-offers/{bookingId}/accept`, use Cosmos `_etag` + `If-Match` so exactly one concurrent caller wins the race; on win, assign the booking and emit `OFFER_CANCELLED` FCM to the losing techs. When a tech declines via `PATCH .../decline`, write a `TECH_DECLINED` event but do **NOT** touch the `DispatchAttemptDoc` or booking status — declines are pure audit trail per FR-9.1. Add a 30-second timer trigger that flips stale `PENDING` attempts to `EXPIRED` and marks the booking `UNFULFILLED`.
+
+**Architecture:**
+- **Optimistic concurrency:** `dispatchAttemptRepo.acceptAttempt(id, bookingId)` does a Cosmos point-read, asserts `status === 'PENDING'` and `expiresAt > now`, then attempts a `replace` with `accessCondition: { type: 'IfMatch', condition: resource._etag }`. Cosmos returns 412 PreconditionFailed when another caller wins; that's mapped to `null` and the HTTP layer returns 409.
+- **Append-only event log:** `bookingEventRepo.append({ event, technicianId?, bookingId, ... })` writes to `booking_events` (partition key `bookingId`). No update or delete methods — declines are pure audit. The Karnataka FR-9.1 boundary is preserved: declines reach the audit log, never the dispatcher's ranking inputs.
+- **Loser FCM:** after a successful accept, the *other* techIds in `attempt.technicianIds` get a `OFFER_CANCELLED` data message via FCM topic (`tech_${techId}`) — they may or may not be subscribed at this point; `Promise.allSettled` tolerates failures.
+- **Stale-offer reconciler:** `expireStaleOffers` runs `*/30 * * * * *` (every 30s); queries `status='PENDING' AND expiresAt < now`, conditionally replaces to `EXPIRED` (via `_etag`), marks booking `UNFULFILLED`, writes `OFFER_EXPIRED` event. 412 conflicts are silently swallowed (a concurrent process — typically the accept handler — already updated the doc).
+- **Decline is FR-9.1-clean:** writes only `TECH_DECLINED` to `booking_events`; does NOT touch `DispatchAttemptDoc`, does NOT change booking status, does NOT call `acceptAttempt`. The attempt stays `PENDING` so other techs in the offer pool can still accept.
+
+**Tech stack:** TypeScript + Azure Functions HTTP + Timer trigger + Cosmos SDK + firebase-admin/messaging + Vitest. Single sub-project (`api/`).
+
+**Prerequisites:** E05-S02 (DispatchAttemptDoc schema, BookingEventDoc schema, container accessors, `verifyTechnicianToken`, dispatcher creates the attempts) — both ship in the same sprint, this story slots in *after*.
+
+---
+
+## File Inventory
+
+**Created:**
+- `api/src/cosmos/dispatch-attempt-repository.ts` — `getByBookingId`, `acceptAttempt` (with `_etag`)
+- `api/src/cosmos/booking-event-repository.ts` — `append` only
+- `api/src/functions/job-offers.ts` — accept handler, decline handler, expireStaleOffers timer
+- `api/tests/bookings/accept-decline.test.ts` — 7 tests covering all transitions
+
+**Not modified:** Schemas (`dispatch-attempt.ts`, `booking-event.ts`) and container accessors are already in main from E05-S02.
+
+---
+
+## WS-A — Repositories (TDD)
+
+### Task 1: dispatchAttemptRepo tests
+
+- [ ] Inside `tests/bookings/accept-decline.test.ts` (or a sibling unit test file) cover:
+  - `getByBookingId(bookingId)` queries by partition (returns first) — null when none
+  - `acceptAttempt(id, bookingId)` → null when doc missing
+  - `acceptAttempt` → null when `status !== 'PENDING'` (already ACCEPTED or EXPIRED)
+  - `acceptAttempt` → null when `expiresAt <= now`
+  - `acceptAttempt` → returns updated doc on successful `_etag` replace
+  - `acceptAttempt` → null when Cosmos throws 412 (race with concurrent accept)
+  - `acceptAttempt` → re-throws non-412 errors
+
+### Task 2: dispatchAttemptRepo implementation
+
+- [ ] Create `api/src/cosmos/dispatch-attempt-repository.ts`:
+
+```typescript
+import type { Resource } from '@azure/cosmos';
+import { getDispatchAttemptsContainer } from './client.js';
+import type { DispatchAttemptDoc } from '../schemas/dispatch-attempt.js';
+
+export const dispatchAttemptRepo = {
+  async getByBookingId(bookingId: string): Promise<DispatchAttemptDoc | null> {
+    const { resources } = await getDispatchAttemptsContainer()
+      .items
+      .query<DispatchAttemptDoc>({
+        query: 'SELECT * FROM c WHERE c.bookingId = @bookingId',
+        parameters: [{ name: '@bookingId', value: bookingId }],
+      })
+      .fetchAll();
+    return resources[0] ?? null;
+  },
+
+  async acceptAttempt(id: string, bookingId: string): Promise<DispatchAttemptDoc | null> {
+    const container = getDispatchAttemptsContainer();
+    const { resource } = await container.item(id, bookingId).read<DispatchAttemptDoc & Resource>();
+    if (!resource) return null;
+    if (resource.status !== 'PENDING') return null;
+    if (new Date(resource.expiresAt) <= new Date()) return null;
+
+    const updated: DispatchAttemptDoc = {
+      id: resource.id,
+      bookingId: resource.bookingId,
+      technicianIds: resource.technicianIds,
+      sentAt: resource.sentAt,
+      expiresAt: resource.expiresAt,
+      status: 'ACCEPTED',
+    };
+
+    try {
+      const { resource: replaced } = await container.item(id, bookingId).replace<DispatchAttemptDoc>(
+        updated,
+        { accessCondition: { type: 'IfMatch', condition: resource._etag } },
+      );
+      return replaced ?? null;
+    } catch (err: unknown) {
+      if (isCosmosConflict(err)) return null;
+      throw err;
+    }
+  },
+};
+
+function isCosmosConflict(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 412;
+}
+```
+
+> **Critical:** `If-Match` condition is the etag from the **same read** that asserted `status === 'PENDING'`. If the doc mutated between read and replace, the etag won't match, Cosmos returns 412, and `acceptAttempt` returns null. The HTTP layer maps that to 409.
+
+### Task 3: bookingEventRepo
+
+- [ ] Create `api/src/cosmos/booking-event-repository.ts`:
+
+```typescript
+import { randomUUID } from 'node:crypto';
+import { getBookingEventsContainer } from './client.js';
+import type { BookingEventDoc } from '../schemas/booking-event.js';
+
+export const bookingEventRepo = {
+  async append(event: Omit<BookingEventDoc, 'id' | 'ts'>): Promise<void> {
+    const doc: BookingEventDoc = {
+      ...event,
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+    };
+    await getBookingEventsContainer().items.create<BookingEventDoc>(doc);
+  },
+};
+```
+
+> Append-only. **No update or delete methods exist.** This is the FR-9.1 audit-log surface — events get written, never mutated.
+
+- [ ] Commit WS-A: `feat(api): dispatchAttemptRepo with _etag accept + bookingEventRepo append-only`
+
+---
+
+## WS-B — HTTP handlers + timer (TDD)
+
+### Task 4: Accept-decline handler tests
+
+- [ ] Create `api/tests/bookings/accept-decline.test.ts`. Cover (matrix in PR #28 body):
+
+| # | Endpoint | Scenario | Expected |
+|---|---|---|---|
+| 1 | accept | first caller wins | 200 `ASSIGNED`; booking technicianId set; TECH_ACCEPTED event |
+| 2 | accept | `acceptAttempt` returns null (etag race) | 409 `OFFER_ALREADY_TAKEN` |
+| 3 | accept | `expiresAt < now` | 410 `OFFER_EXPIRED` |
+| 4 | accept | `attempt.status !== 'PENDING'` | 410 `OFFER_EXPIRED` |
+| 5 | accept | `technicianId` not in `attempt.technicianIds` | 403 `FORBIDDEN` |
+| 6 | accept | no Authorization header | 401 `UNAUTHORIZED` |
+| 7 | accept | no attempt for bookingId | 404 `OFFER_NOT_FOUND` |
+| 8 | decline | API call | 200 `DECLINED`; booking unchanged; `acceptAttempt` NOT called |
+| 9 | decline | event written | `TECH_DECLINED` event with `technicianId`, `bookingId`; **no ranking field** |
+| 10 | decline | no Authorization header | 401 `UNAUTHORIZED` |
+
+### Task 5: Accept handler
+
+- [ ] Create `api/src/functions/job-offers.ts`. Implement `acceptJobOfferHandler`:
+
+```typescript
+export async function acceptJobOfferHandler(
+  req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> {
+  let technicianId: string;
+  try {
+    const { uid } = await verifyTechnicianToken(req);
+    technicianId = uid;
+  } catch {
+    return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } };
+  }
+
+  const bookingId = (req as unknown as { params: { bookingId: string } }).params.bookingId;
+
+  const attempt = await dispatchAttemptRepo.getByBookingId(bookingId);
+  if (!attempt) return { status: 404, jsonBody: { code: 'OFFER_NOT_FOUND' } };
+  if (attempt.status !== 'PENDING' || new Date(attempt.expiresAt) <= new Date()) {
+    return { status: 410, jsonBody: { code: 'OFFER_EXPIRED' } };
+  }
+  if (!attempt.technicianIds.includes(technicianId)) {
+    return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+  }
+
+  const accepted = await dispatchAttemptRepo.acceptAttempt(attempt.id, bookingId);
+  if (!accepted) return { status: 409, jsonBody: { code: 'OFFER_ALREADY_TAKEN' } };
+
+  await updateBookingFields(bookingId, { status: 'ASSIGNED', technicianId });
+  await bookingEventRepo.append({ event: 'TECH_ACCEPTED', technicianId, bookingId });
+
+  const losingTechs = attempt.technicianIds.filter(id => id !== technicianId);
+  void notifyLosingTechs(losingTechs, bookingId);
+
+  return { status: 200, jsonBody: { bookingId, status: 'ASSIGNED' } };
+}
+```
+
+> **Order matters:** check 404 → 410 → 403 → optimistic-concurrency 409. Skipping the 403 check before `acceptAttempt` would let an off-list tech race the legitimate ones.
+
+### Task 6: Decline handler
+
+- [ ] Continue in `job-offers.ts`:
+
+```typescript
+export async function declineJobOfferHandler(
+  req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> {
+  let technicianId: string;
+  try {
+    const { uid } = await verifyTechnicianToken(req);
+    technicianId = uid;
+  } catch {
+    return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } };
+  }
+
+  const bookingId = (req as unknown as { params: { bookingId: string } }).params.bookingId;
+
+  await bookingEventRepo.append({ event: 'TECH_DECLINED', technicianId, bookingId });
+
+  return { status: 200, jsonBody: { bookingId, status: 'DECLINED' } };
+}
+```
+
+> **Decline does NOT call `dispatchAttemptRepo.acceptAttempt`.** The attempt stays `PENDING` until another tech accepts or it naturally expires. Decline is pure audit.
+
+### Task 7: Loser-notify helper
+
+- [ ] In `job-offers.ts`:
+
+```typescript
+async function notifyLosingTechs(techIds: string[], bookingId: string): Promise<void> {
+  const messaging = getMessaging();
+  await Promise.allSettled(
+    techIds.map(techId =>
+      messaging.send({
+        topic: `tech_${techId}`,
+        data: { type: 'OFFER_CANCELLED', bookingId },
+      })
+    )
+  );
+}
+```
+
+> Topic-based send (not direct token) — losing techs may not have an FCM token registered yet (E02-S03 KYC flow could land mid-window). Topic delivery is best-effort.
+
+### Task 8: Stale-offer timer
+
+- [ ] In `job-offers.ts`:
+
+```typescript
+async function expireStaleOffers(_timer: Timer, _ctx: InvocationContext): Promise<void> {
+  const container = getDispatchAttemptsContainer();
+  const { resources } = await container.items
+    .query<DispatchAttemptDoc & Resource>({
+      query: `SELECT * FROM c WHERE c.status = 'PENDING' AND c.expiresAt < @now`,
+      parameters: [{ name: '@now', value: new Date().toISOString() }],
+    })
+    .fetchAll();
+
+  await Promise.allSettled(
+    resources.map(async attempt => {
+      try {
+        await container.item(attempt.id, attempt.bookingId).replace(
+          { ...attempt, status: 'EXPIRED' },
+          { accessCondition: { type: 'IfMatch', condition: attempt._etag } },
+        );
+        await updateBookingFields(attempt.bookingId, { status: 'UNFULFILLED' });
+        await bookingEventRepo.append({ event: 'OFFER_EXPIRED', bookingId: attempt.bookingId });
+      } catch {
+        // 412 PreconditionFailed = concurrent process already updated this attempt; skip it
+      }
+    })
+  );
+}
+```
+
+### Task 9: HTTP + timer registrations
+
+- [ ] At the bottom of `job-offers.ts`:
+
+```typescript
+app.http('acceptJobOffer', {
+  route: 'v1/technicians/job-offers/{bookingId}/accept',
+  methods: ['PATCH'],
+  authLevel: 'anonymous',
+  handler: acceptJobOfferHandler,
+});
+
+app.http('declineJobOffer', {
+  route: 'v1/technicians/job-offers/{bookingId}/decline',
+  methods: ['PATCH'],
+  authLevel: 'anonymous',
+  handler: declineJobOfferHandler,
+});
+
+app.timer('expireStaleOffers', {
+  schedule: '*/30 * * * * *',
+  handler: expireStaleOffers,
+});
+```
+
+> `authLevel: 'anonymous'` because Firebase ID token verification happens in `verifyTechnicianToken` — we don't want Azure Functions' own key auth on top.
+
+- [ ] Commit WS-B: `feat(api): accept/decline job-offer endpoints + 30s stale-offer timer`
+
+---
+
+## WS-C — Smoke gate, Codex, PR
+
+### Task 10: Smoke gate
+
+```bash
+bash tools/pre-codex-smoke-api.sh
+# Expected: 360 tests / all green, exit 0
+```
+
+### Task 11: Codex review
+
+- [ ] `codex review --base main`. Likely findings:
+  - 412 conflict swallow in `expireStaleOffers` should be narrowed to that specific code (already is, but flagged as worth a comment)
+  - `notifyLosingTechs` uses topic — surface this in PR body so reviewer knows it's intentional vs token-based
+- [ ] `.codex-review-passed` after resolution.
+
+### Task 12: PR
+
+- [ ] PR title: `feat(api): E05-S04 — accept/decline job-offer API with _etag optimistic concurrency`
+- [ ] PR body lists the test matrix (10 cases above), highlights the FR-9.1 invariant (decline endpoint never touches `DispatchAttemptDoc` or booking status), and notes the 30s timer cadence.
+
+---
+
+## Self-review
+
+### Spec coverage
+| Requirement | Task |
+|---|---|
+| Accept with `_etag` + `If-Match` first-write-wins | Tasks 2, 5 |
+| 409 on `_etag` conflict | Task 5 |
+| 410 on expired or non-PENDING | Task 5 |
+| 403 if technician not in offer pool | Task 5 |
+| 404 if no attempt for booking | Task 5 |
+| 401 on missing/invalid auth | Tasks 5, 6 |
+| Booking → ASSIGNED + TECH_ACCEPTED event on win | Task 5 |
+| Decline writes TECH_DECLINED tombstone, never touches attempt or booking | Task 6 |
+| Loser FCM `OFFER_CANCELLED` (topic-based, allSettled) | Task 7 |
+| 30s timer flips stale PENDING → EXPIRED + UNFULFILLED + OFFER_EXPIRED event | Task 8 |
+| FR-9.1: no decline-related ranking input written | Tasks 3, 6 (event-only, no field on tech doc) |
+
+### Files-do-not-touch
+- `api/src/services/dispatcher.service.ts` — owned by E05-S02
+- `api/src/schemas/dispatch-attempt.ts` / `booking-event.ts` — owned by E05-S02
+- `api/src/cosmos/client.ts` — owned by E05-S02
+- `api/src/middleware/verifyTechnicianToken.ts` — owned by E05-S02


### PR DESCRIPTION
Closes #98 #99 #100 #101 #115 #116. Largest rescue — E05 dispatcher foundation. Per audit.

## Summary

Reverse-engineers documentation for 6 shipped E04 + E05 stories.

| Issue | Story | What was missing | Source PR | Plan file |
|---|---|---|---|---|
| #115 | E04-S01 | story only | #30 | plans/E04-S01-trust-dossier.md (existing) |
| #116 | E04-S02 | story only | #34 | plans/E04-S02a.md + E04-S02b.md (existing) |
| #98 | E05-S01 | both | #18 | plans/E05-S01.md (new) |
| #99 | E05-S02 | both | #26 | plans/E05-S02.md (new) |
| #100 | E05-S03 | both | #29 | plans/E05-S03.md (new) |
| #101 | E05-S04 | both | #28 | plans/E05-S04.md (new) |

E05-S01..S04 are all **Class A** — both story + plan reverse-engineered from merged code. Largest single rescue PR (10 files, 2305 lines).

## What's in this PR

- 6 story files in `docs/stories/` — acceptance criteria pulled from the merged source code, with retroactive notes pointing back to the source PRs
- 4 plan files in `plans/` — work-stream breakdown that mirrors how the code was actually shipped, sized proportional to surface area (E05-S02 dispatcher is the largest at 434 lines because it includes the Karnataka FR-9.1 invariance gate)

## What this PR does NOT touch

- `docs/stories/README.md` — out of scope (sprint plan unchanged)
- Source code — pure documentation rescue
- `plans/E04-S01-trust-dossier.md` / `plans/E04-S02a.md` / `plans/E04-S02b.md` — already in main; story files reference them

## Verification

- `wc -l` on the 10 files: 134–434 lines each, 2305 total
- Story files reference exact files / line ranges from the merged source
- Karnataka FR-9.1 invariance is documented in 4 places: E05-S01 schema (no decline field), E05-S02 `rankTechnicians` + CI gate test, E05-S03 `DeclineJobOfferUseCase` always-Declined behaviour, E05-S04 decline endpoint never touches DispatchAttemptDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)