### PR TITLE
feat(audit): W2-2' audit-log P1 coverage on full E07-S04 no-show implementation

### DIFF
--- a/.codex-review-passed
+++ b/.codex-review-passed
@@ -1,1 +1,1 @@
-codex-review-passed: 2026-04-29T01:55:23Z model=gpt-5.4 pr=132 rounds=1
+{"timestamp":"2026-04-28T23:14:07-04:00","commit":"df49d2095abb0b6ebcf605aacedf2ac69bd8771c","reviewer":"codex","round":7,"notes":"All P1s resolved. 3 remaining P2s are no-show detector crash-safety edge cases for audit trail (gaps on crash between credit-write and audit-call, redispatch-order, concurrent UNFULFILLED): deferred to follow-up story as they require new idempotency markers in BookingDoc and would risk regressions in tested recovery logic."}

--- a/api/src/functions/admin/auth/login.ts
+++ b/api/src/functions/admin/auth/login.ts
@@ -1,6 +1,8 @@
 import '../../../bootstrap.js';
+import { randomUUID } from 'node:crypto';
 import { app } from '@azure/functions';
 import type { HttpRequest, InvocationContext, HttpResponseInit, Cookie } from '@azure/functions';
+import * as Sentry from '@sentry/node';
 import { LoginRequestSchema } from '../../../schemas/admin-auth.js';
 import { verifyFirebaseIdToken } from '../../../services/firebaseAdmin.js';
 import { getAdminUserById } from '../../../services/adminUser.service.js';
@@ -8,6 +10,7 @@ import { decryptSecret, verifyToken } from '../../../services/totp.service.js';
 import { createAdminSession } from '../../../services/adminSession.service.js';
 import { signAccessToken, signSetupToken } from '../../../services/jwt.service.js';
 import { auditLog } from '../../../services/auditLog.service.js';
+import { appendAuditEntry } from '../../../cosmos/audit-log-repository.js';
 
 export async function adminLoginHandler(
   req: HttpRequest,
@@ -59,6 +62,8 @@ export async function adminLoginHandler(
 
   const secret = decryptSecret(adminUser.totpSecret!);
   if (!verifyToken(totpCode, secret)) {
+    const _ts = new Date().toISOString();
+    void appendAuditEntry({ id: randomUUID(), adminId: adminUser.adminId, role: adminUser.role, action: 'ADMIN_LOGIN_FAILED', resourceType: 'admin_session', resourceId: adminUser.adminId, payload: { reason: 'TOTP_INVALID' }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
     return { status: 422, jsonBody: { code: 'TOTP_INVALID' } };
   }
 

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -50,7 +50,7 @@ const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
 
   const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: customer.customerId, role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
 };

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -49,8 +49,12 @@ const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
 
-  const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  // Only audit when this call actually performed the transition. If status is PAID the webhook
+  // already processed the booking — this is an idempotent confirm, not a new event.
+  if (confirmed.status === 'SEARCHING') {
+    const _ts = new Date().toISOString();
+    void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  }
 
   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
 };

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -50,7 +50,7 @@ const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
 
   const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  void appendAuditEntry({ id: randomUUID(), adminId: customer.customerId, role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
 };

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -50,7 +50,7 @@ const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
 
   const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, customerId: customer.customerId, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
 };

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'node:crypto';
 import type { HttpHandler } from '@azure/functions';
 import { app } from '@azure/functions';
+import * as Sentry from '@sentry/node';
 import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
 import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
 import { RequestAddOnBodySchema, ApproveAddOnsBodySchema } from '../schemas/addon-approval.js';
@@ -8,6 +10,7 @@ import { createRazorpayOrder, verifyPaymentSignature } from '../services/razorpa
 import { catalogueRepo } from '../cosmos/catalogue-repository.js';
 import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
 import { sendPriceApprovalPush } from '../services/fcm.service.js';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 
 const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   const body = await req.json().catch(() => null);
@@ -45,6 +48,9 @@ const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
 
   const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
+
+  const _ts = new Date().toISOString();
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, customerId: customer.customerId, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
 };

--- a/api/src/functions/catalogue-admin.ts
+++ b/api/src/functions/catalogue-admin.ts
@@ -5,12 +5,14 @@ import {
   type InvocationContext,
 } from '@azure/functions';
 import '../bootstrap.js';
+import * as Sentry from '@sentry/node';
 import { catalogueRepo } from '../cosmos/catalogue-repository.js';
 import { CreateCategoryBodySchema, UpdateCategoryBodySchema } from '../schemas/service-category.js';
 import { CreateServiceBodySchema, UpdateServiceBodySchema } from '../schemas/service.js';
 import { requireAdmin } from '../middleware/requireAdmin.js';
 import type { AdminContext } from '../types/admin.js';
 import { ZodError } from 'zod';
+import { catalogueAuditEntry } from '../services/catalogueAudit.service.js';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' };
 
@@ -35,6 +37,7 @@ export async function createCategoryHandler(req: HttpRequest, _ctx: InvocationCo
     const existing = await catalogueRepo.getCategoryById(body.id);
     if (existing) return { status: 409, headers: JSON_HEADERS, jsonBody: { error: `Category '${body.id}' already exists` } };
     const created = await catalogueRepo.createCategory(body, admin.adminId);
+    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_CREATED', 'category', created.id, { name: created.name }).catch(Sentry.captureException);
     return { status: 201, headers: JSON_HEADERS, jsonBody: created };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -48,6 +51,7 @@ export async function updateCategoryHandler(req: HttpRequest, _ctx: InvocationCo
     const body = UpdateCategoryBodySchema.parse(await parseJson(req));
     const updated = await catalogueRepo.updateCategory(id, body, admin.adminId);
     if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Category not found' } };
+    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_UPDATED', 'category', id, { changes: body }).catch(Sentry.captureException);
     return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -59,6 +63,7 @@ export async function toggleCategoryHandler(req: HttpRequest, _ctx: InvocationCo
   const id = req.params['id']!;
   const updated = await catalogueRepo.toggleCategory(id, admin.adminId);
   if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Category not found' } };
+  void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_TOGGLED', 'category', id, { isActive: updated.isActive }).catch(Sentry.captureException);
   return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
 }
 
@@ -78,6 +83,7 @@ export async function createServiceHandler(req: HttpRequest, _ctx: InvocationCon
     const existing = await catalogueRepo.getServiceByIdCrossPartition(body.id);
     if (existing) return { status: 409, headers: JSON_HEADERS, jsonBody: { error: `Service '${body.id}' already exists` } };
     const created = await catalogueRepo.createService(body, admin.adminId);
+    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_CREATED', 'service', created.id, { name: created.name, categoryId: created.categoryId }).catch(Sentry.captureException);
     return { status: 201, headers: JSON_HEADERS, jsonBody: created };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -91,6 +97,7 @@ export async function updateServiceHandler(req: HttpRequest, _ctx: InvocationCon
     const body = UpdateServiceBodySchema.parse(await parseJson(req));
     const updated = await catalogueRepo.updateService(id, body, admin.adminId);
     if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Service not found' } };
+    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_UPDATED', 'service', id, { changes: body }).catch(Sentry.captureException);
     return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -102,6 +109,7 @@ export async function toggleServiceHandler(req: HttpRequest, _ctx: InvocationCon
   const id = req.params['id']!;
   const updated = await catalogueRepo.toggleService(id, admin.adminId);
   if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Service not found' } };
+  void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_TOGGLED', 'service', id, { isActive: updated.isActive }).catch(Sentry.captureException);
   return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
 }
 

--- a/api/src/functions/catalogue-admin.ts
+++ b/api/src/functions/catalogue-admin.ts
@@ -5,7 +5,6 @@ import {
   type InvocationContext,
 } from '@azure/functions';
 import '../bootstrap.js';
-import * as Sentry from '@sentry/node';
 import { catalogueRepo } from '../cosmos/catalogue-repository.js';
 import { CreateCategoryBodySchema, UpdateCategoryBodySchema } from '../schemas/service-category.js';
 import { CreateServiceBodySchema, UpdateServiceBodySchema } from '../schemas/service.js';
@@ -37,7 +36,7 @@ export async function createCategoryHandler(req: HttpRequest, _ctx: InvocationCo
     const existing = await catalogueRepo.getCategoryById(body.id);
     if (existing) return { status: 409, headers: JSON_HEADERS, jsonBody: { error: `Category '${body.id}' already exists` } };
     const created = await catalogueRepo.createCategory(body, admin.adminId);
-    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_CREATED', 'category', created.id, { name: created.name }).catch(Sentry.captureException);
+    await catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_CREATED', 'category', created.id, { name: created.name });
     return { status: 201, headers: JSON_HEADERS, jsonBody: created };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -51,7 +50,7 @@ export async function updateCategoryHandler(req: HttpRequest, _ctx: InvocationCo
     const body = UpdateCategoryBodySchema.parse(await parseJson(req));
     const updated = await catalogueRepo.updateCategory(id, body, admin.adminId);
     if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Category not found' } };
-    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_UPDATED', 'category', id, { changes: body }).catch(Sentry.captureException);
+    await catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_UPDATED', 'category', id, { changes: body });
     return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -63,7 +62,7 @@ export async function toggleCategoryHandler(req: HttpRequest, _ctx: InvocationCo
   const id = req.params['id']!;
   const updated = await catalogueRepo.toggleCategory(id, admin.adminId);
   if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Category not found' } };
-  void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_TOGGLED', 'category', id, { isActive: updated.isActive }).catch(Sentry.captureException);
+  await catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_CATEGORY_TOGGLED', 'category', id, { isActive: updated.isActive });
   return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
 }
 
@@ -83,7 +82,7 @@ export async function createServiceHandler(req: HttpRequest, _ctx: InvocationCon
     const existing = await catalogueRepo.getServiceByIdCrossPartition(body.id);
     if (existing) return { status: 409, headers: JSON_HEADERS, jsonBody: { error: `Service '${body.id}' already exists` } };
     const created = await catalogueRepo.createService(body, admin.adminId);
-    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_CREATED', 'service', created.id, { name: created.name, categoryId: created.categoryId }).catch(Sentry.captureException);
+    await catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_CREATED', 'service', created.id, { name: created.name, categoryId: created.categoryId });
     return { status: 201, headers: JSON_HEADERS, jsonBody: created };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -97,7 +96,7 @@ export async function updateServiceHandler(req: HttpRequest, _ctx: InvocationCon
     const body = UpdateServiceBodySchema.parse(await parseJson(req));
     const updated = await catalogueRepo.updateService(id, body, admin.adminId);
     if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Service not found' } };
-    void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_UPDATED', 'service', id, { changes: body }).catch(Sentry.captureException);
+    await catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_UPDATED', 'service', id, { changes: body });
     return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
   } catch (err) {
     if (err instanceof ZodError) return zodErr(err);
@@ -109,7 +108,7 @@ export async function toggleServiceHandler(req: HttpRequest, _ctx: InvocationCon
   const id = req.params['id']!;
   const updated = await catalogueRepo.toggleService(id, admin.adminId);
   if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { error: 'Service not found' } };
-  void catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_TOGGLED', 'service', id, { isActive: updated.isActive }).catch(Sentry.captureException);
+  await catalogueAuditEntry(admin.adminId, admin.role, 'CATALOGUE_SERVICE_TOGGLED', 'service', id, { isActive: updated.isActive });
   return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
 }
 

--- a/api/src/functions/kyc/submit-aadhaar.ts
+++ b/api/src/functions/kyc/submit-aadhaar.ts
@@ -1,5 +1,4 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
-import * as Sentry from '@sentry/node';
 import { verifyTechnicianToken } from '../../middleware/verifyTechnicianToken.js';
 import { exchangeCodeForAadhaar } from '../../services/digilocker.service.js';
 import { upsertKycStatus } from '../../cosmos/technician-repository.js';
@@ -36,7 +35,7 @@ export async function submitAadhaar(
       aadhaarVerified: false,
       kycStatus: 'PENDING_MANUAL',
     });
-    void kycAuditEntry(technicianId, 'AADHAAR', 'REJECTED', '').catch(Sentry.captureException);
+    void kycAuditEntry(technicianId, 'AADHAAR', 'REJECTED');
     return {
       status: 200,
       jsonBody: { kycStatus: 'PENDING_MANUAL', aadhaarVerified: false, aadhaarMaskedNumber: null },
@@ -48,7 +47,7 @@ export async function submitAadhaar(
     aadhaarMaskedNumber: aadhaarResult.maskedNumber,
     kycStatus: 'AADHAAR_DONE',
   });
-  void kycAuditEntry(technicianId, 'AADHAAR', 'VERIFIED', aadhaarResult.maskedNumber).catch(Sentry.captureException);
+  void kycAuditEntry(technicianId, 'AADHAAR', 'VERIFIED');
 
   return {
     status: 200,

--- a/api/src/functions/kyc/submit-aadhaar.ts
+++ b/api/src/functions/kyc/submit-aadhaar.ts
@@ -1,8 +1,10 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import * as Sentry from '@sentry/node';
 import { verifyTechnicianToken } from '../../middleware/verifyTechnicianToken.js';
 import { exchangeCodeForAadhaar } from '../../services/digilocker.service.js';
 import { upsertKycStatus } from '../../cosmos/technician-repository.js';
 import { SubmitAadhaarRequestSchema } from '../../schemas/kyc.js';
+import { kycAuditEntry } from '../../services/kycAudit.service.js';
 
 export async function submitAadhaar(
   req: HttpRequest,
@@ -34,6 +36,7 @@ export async function submitAadhaar(
       aadhaarVerified: false,
       kycStatus: 'PENDING_MANUAL',
     });
+    void kycAuditEntry(technicianId, 'AADHAAR', 'REJECTED', '').catch(Sentry.captureException);
     return {
       status: 200,
       jsonBody: { kycStatus: 'PENDING_MANUAL', aadhaarVerified: false, aadhaarMaskedNumber: null },
@@ -45,6 +48,7 @@ export async function submitAadhaar(
     aadhaarMaskedNumber: aadhaarResult.maskedNumber,
     kycStatus: 'AADHAAR_DONE',
   });
+  void kycAuditEntry(technicianId, 'AADHAAR', 'VERIFIED', aadhaarResult.maskedNumber).catch(Sentry.captureException);
 
   return {
     status: 200,

--- a/api/src/functions/kyc/submit-pan-ocr.ts
+++ b/api/src/functions/kyc/submit-pan-ocr.ts
@@ -1,8 +1,10 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import * as Sentry from '@sentry/node';
 import { extractPanFromStoragePath } from '../../services/formRecognizer.service.js';
 import { upsertKycStatus } from '../../cosmos/technician-repository.js';
 import { verifyTechnicianToken } from '../../middleware/verifyTechnicianToken.js';
 import { SubmitPanOcrRequestSchema } from '../../schemas/kyc.js';
+import { kycAuditEntry } from '../../services/kycAudit.service.js';
 
 export async function submitPanOcr(
   req: HttpRequest,
@@ -35,6 +37,7 @@ export async function submitPanOcr(
       panImagePath: firebaseStoragePath,
       kycStatus: 'PAN_DONE',
     });
+    void kycAuditEntry(technicianId, 'PAN', 'VERIFIED', ocrResult.panNumber ?? '').catch(Sentry.captureException);
     return { status: 200, jsonBody: { kycStatus: 'PAN_DONE', panNumber: ocrResult.panNumber } };
   }
 
@@ -42,6 +45,7 @@ export async function submitPanOcr(
     panImagePath: firebaseStoragePath,
     kycStatus: 'MANUAL_REVIEW',
   });
+  void kycAuditEntry(technicianId, 'PAN', 'REJECTED', '').catch(Sentry.captureException);
   return { status: 200, jsonBody: { kycStatus: 'MANUAL_REVIEW', panNumber: null } };
 }
 

--- a/api/src/functions/kyc/submit-pan-ocr.ts
+++ b/api/src/functions/kyc/submit-pan-ocr.ts
@@ -1,5 +1,4 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
-import * as Sentry from '@sentry/node';
 import { extractPanFromStoragePath } from '../../services/formRecognizer.service.js';
 import { upsertKycStatus } from '../../cosmos/technician-repository.js';
 import { verifyTechnicianToken } from '../../middleware/verifyTechnicianToken.js';
@@ -37,7 +36,7 @@ export async function submitPanOcr(
       panImagePath: firebaseStoragePath,
       kycStatus: 'PAN_DONE',
     });
-    void kycAuditEntry(technicianId, 'PAN', 'VERIFIED', ocrResult.panNumber ?? '').catch(Sentry.captureException);
+    void kycAuditEntry(technicianId, 'PAN', 'VERIFIED');
     return { status: 200, jsonBody: { kycStatus: 'PAN_DONE', panNumber: ocrResult.panNumber } };
   }
 
@@ -45,7 +44,7 @@ export async function submitPanOcr(
     panImagePath: firebaseStoragePath,
     kycStatus: 'MANUAL_REVIEW',
   });
-  void kycAuditEntry(technicianId, 'PAN', 'REJECTED', '').catch(Sentry.captureException);
+  void kycAuditEntry(technicianId, 'PAN', 'REJECTED');
   return { status: 200, jsonBody: { kycStatus: 'MANUAL_REVIEW', panNumber: null } };
 }
 

--- a/api/src/functions/rating-escalate.ts
+++ b/api/src/functions/rating-escalate.ts
@@ -97,7 +97,7 @@ export async function escalateRatingHandler(
   }
 
   const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  void appendAuditEntry({ id: randomUUID(), adminId: customer.customerId, role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   sendOwnerRatingShieldAlert({
     bookingId,

--- a/api/src/functions/rating-escalate.ts
+++ b/api/src/functions/rating-escalate.ts
@@ -97,7 +97,7 @@ export async function escalateRatingHandler(
   }
 
   const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, customerId: customer.customerId, technicianId: booking.technicianId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   sendOwnerRatingShieldAlert({
     bookingId,

--- a/api/src/functions/rating-escalate.ts
+++ b/api/src/functions/rating-escalate.ts
@@ -1,5 +1,7 @@
+import { randomUUID, createHash } from 'crypto';
 import { app } from '@azure/functions';
 import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import * as Sentry from '@sentry/node';
 import { requireCustomer } from '../middleware/requireCustomer.js';
 import type { CustomerContext } from '../types/customer.js';
 import { EscalateRatingBodySchema } from '../schemas/complaint.js';
@@ -8,7 +10,7 @@ import { bookingRepo } from '../cosmos/booking-repository.js';
 import { ratingRepo } from '../cosmos/rating-repository.js';
 import { createComplaint, findRatingShieldEscalation } from '../cosmos/complaints-repository.js';
 import { sendOwnerRatingShieldAlert } from '../services/fcm.service.js';
-import { createHash } from 'crypto';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 
 export async function escalateRatingHandler(
   req: HttpRequest,
@@ -93,6 +95,9 @@ export async function escalateRatingHandler(
     }
     throw err;
   }
+
+  const _ts = new Date().toISOString();
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, customerId: customer.customerId, technicianId: booking.technicianId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   sendOwnerRatingShieldAlert({
     bookingId,

--- a/api/src/functions/rating-escalate.ts
+++ b/api/src/functions/rating-escalate.ts
@@ -97,7 +97,7 @@ export async function escalateRatingHandler(
   }
 
   const _ts = new Date().toISOString();
-  void appendAuditEntry({ id: randomUUID(), adminId: customer.customerId, role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'RATING_SHIELD_ESCALATED', resourceType: 'booking', resourceId: bookingId, payload: { bookingId, complaintId: doc.id, draftOverall: parsed.data.draftOverall }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   sendOwnerRatingShieldAlert({
     bookingId,

--- a/api/src/functions/trigger-no-show-detector.ts
+++ b/api/src/functions/trigger-no-show-detector.ts
@@ -182,10 +182,12 @@ export async function detectNoShows(ctx: InvocationContext): Promise<void> {
             void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_REDISPATCH_INITIATED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
           } else {
             ctx.log(`detectNoShows: no techs found for ${booking.id} — booking marked UNFULFILLED`);
-            // Guard: a concurrent run may have already moved the booking to SEARCHING; only emit
-            // BOOKING_UNFULFILLED when the booking is genuinely stuck (not actively redispatching).
+            // Guard: dispatcher.redispatch() returns false both when no candidates exist AND when a
+            // concurrent invocation already moved the booking out of NO_SHOW_REDISPATCH (to SEARCHING
+            // or ASSIGNED). Only emit BOOKING_UNFULFILLED when the dispatcher actually set the status
+            // to UNFULFILLED (which it does only when candidate list is genuinely exhausted).
             const postDispatchDoc = await bookingRepo.getById(booking.id);
-            if (postDispatchDoc?.status !== 'SEARCHING') {
+            if (postDispatchDoc?.status === 'UNFULFILLED') {
               const _ts = new Date().toISOString();
               void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'BOOKING_UNFULFILLED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
             }

--- a/api/src/functions/trigger-no-show-detector.ts
+++ b/api/src/functions/trigger-no-show-detector.ts
@@ -1,4 +1,5 @@
 import '../bootstrap.js';
+import { randomUUID } from 'node:crypto';
 import { app } from '@azure/functions';
 import type { Timer, InvocationContext } from '@azure/functions';
 import * as Sentry from '@sentry/node';
@@ -6,6 +7,7 @@ import { bookingRepo, updateBookingFields } from '../cosmos/booking-repository.j
 import { customerCreditRepo } from '../cosmos/customer-credit-repository.js';
 import { dispatcherService } from '../services/dispatcher.service.js';
 import { sendNoShowCreditPush } from '../services/fcm.service.js';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 
 const NO_SHOW_CREDIT_PAISE = 50_000;
 const NO_SHOW_REDISPATCH_RADIUS_KM = 15;
@@ -84,6 +86,8 @@ export async function detectNoShows(ctx: InvocationContext): Promise<void> {
 
     if (creditCreated) {
       ctx.log(`detectNoShows: processing no-show bookingId=${booking.id}`);
+      const _ts = new Date().toISOString();
+      void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_CREDIT_ISSUED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, technicianId: noShowTechId, creditAmount: NO_SHOW_CREDIT_PAISE }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
     } else {
       ctx.log(`detectNoShows: credit already exists for ${booking.id} — retrying remaining steps`);
     }
@@ -174,8 +178,12 @@ export async function detectNoShows(ctx: InvocationContext): Promise<void> {
           redispatchOk = await dispatcherService.redispatch(booking.id, NO_SHOW_REDISPATCH_RADIUS_KM, noShowTechId);
           if (redispatchOk) {
             await updateBookingFields(booking.id, { noShowRedispatchAt: new Date().toISOString() });
+            const _ts = new Date().toISOString();
+            void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_TECH_SWAPPED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, oldTechId: noShowTechId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
           } else {
             ctx.log(`detectNoShows: no techs found for ${booking.id} — booking marked UNFULFILLED`);
+            const _ts = new Date().toISOString();
+            void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'BOOKING_UNFULFILLED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
           }
         } catch (err: unknown) {
           Sentry.captureException(err);

--- a/api/src/functions/trigger-no-show-detector.ts
+++ b/api/src/functions/trigger-no-show-detector.ts
@@ -172,6 +172,9 @@ export async function detectNoShows(ctx: InvocationContext): Promise<void> {
         // writing noShowRedispatchAt. The dispatch attempt is live — just write the timestamp.
         await updateBookingFields(booking.id, { noShowRedispatchAt: new Date().toISOString() });
         redispatchOk = true;
+        // Emit the audit that the prior run never wrote before crashing.
+        const _rts = new Date().toISOString();
+        void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_REDISPATCH_INITIATED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _rts, partitionKey: _rts.slice(0, 7) }).catch(Sentry.captureException);
         ctx.log(`detectNoShows: recovery — booking ${booking.id} already SEARCHING, completing noShowRedispatchAt write`);
       } else {
         try {

--- a/api/src/functions/trigger-no-show-detector.ts
+++ b/api/src/functions/trigger-no-show-detector.ts
@@ -87,7 +87,7 @@ export async function detectNoShows(ctx: InvocationContext): Promise<void> {
     if (creditCreated) {
       ctx.log(`detectNoShows: processing no-show bookingId=${booking.id}`);
       const _ts = new Date().toISOString();
-      void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_CREDIT_ISSUED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, technicianId: noShowTechId, creditAmount: NO_SHOW_CREDIT_PAISE }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+      void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_CREDIT_ISSUED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, creditAmount: NO_SHOW_CREDIT_PAISE }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
     } else {
       ctx.log(`detectNoShows: credit already exists for ${booking.id} — retrying remaining steps`);
     }
@@ -179,11 +179,16 @@ export async function detectNoShows(ctx: InvocationContext): Promise<void> {
           if (redispatchOk) {
             await updateBookingFields(booking.id, { noShowRedispatchAt: new Date().toISOString() });
             const _ts = new Date().toISOString();
-            void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_TECH_SWAPPED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, oldTechId: noShowTechId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+            void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'NO_SHOW_REDISPATCH_INITIATED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
           } else {
             ctx.log(`detectNoShows: no techs found for ${booking.id} — booking marked UNFULFILLED`);
-            const _ts = new Date().toISOString();
-            void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'BOOKING_UNFULFILLED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+            // Guard: a concurrent run may have already moved the booking to SEARCHING; only emit
+            // BOOKING_UNFULFILLED when the booking is genuinely stuck (not actively redispatching).
+            const postDispatchDoc = await bookingRepo.getById(booking.id);
+            if (postDispatchDoc?.status !== 'SEARCHING') {
+              const _ts = new Date().toISOString();
+              void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'BOOKING_UNFULFILLED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+            }
           }
         } catch (err: unknown) {
           Sentry.captureException(err);

--- a/api/src/functions/webhooks.ts
+++ b/api/src/functions/webhooks.ts
@@ -1,9 +1,11 @@
-import { createHmac } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 import type { HttpHandler, Timer } from '@azure/functions';
 import { type InvocationContext, app } from '@azure/functions';
+import * as Sentry from '@sentry/node';
 import { RazorpayWebhookPayloadSchema } from '../schemas/webhook.js';
 import { bookingRepo } from '../cosmos/booking-repository.js';
 import { dispatcherService } from '../services/dispatcher.service.js';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 
 export const razorpayWebhookHandler: HttpHandler = async (req, _ctx) => {
   const secret = process.env['RAZORPAY_WEBHOOK_SECRET'];
@@ -50,6 +52,9 @@ export const razorpayWebhookHandler: HttpHandler = async (req, _ctx) => {
   if (!updated) {
     return { status: 200, jsonBody: { received: true } };
   }
+
+  const _ts = new Date().toISOString();
+  void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'PAYMENT_CAPTURED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, paymentId, orderId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
 
   dispatcherService.triggerDispatch(booking.id).catch(() => {
     // fire-and-forget — dispatch failure does not fail the webhook ack

--- a/api/src/services/catalogueAudit.service.ts
+++ b/api/src/services/catalogueAudit.service.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from 'node:crypto';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+import type { AdminRole } from '../types/admin.js';
+
+export function catalogueAuditEntry(
+  adminId: string,
+  role: AdminRole,
+  action: string,
+  resourceType: string,
+  resourceId: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const ts = new Date().toISOString();
+  return appendAuditEntry({
+    id: randomUUID(),
+    adminId,
+    role,
+    action,
+    resourceType,
+    resourceId,
+    payload,
+    timestamp: ts,
+    partitionKey: ts.slice(0, 7),
+  });
+}

--- a/api/src/services/catalogueAudit.service.ts
+++ b/api/src/services/catalogueAudit.service.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from 'node:crypto';
+import * as Sentry from '@sentry/node';
 import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 import type { AdminRole } from '../types/admin.js';
 
-export function catalogueAuditEntry(
+// Synchronous (awaited by callers) but error-absorbing: admin catalogue actions
+// must be audited in order (not fire-and-forget) so the entry is guaranteed to
+// precede the HTTP response, yet a transient Cosmos failure should not 500 the
+// mutation that already succeeded.
+export async function catalogueAuditEntry(
   adminId: string,
   role: AdminRole,
   action: string,
@@ -10,16 +15,20 @@ export function catalogueAuditEntry(
   resourceId: string,
   payload: Record<string, unknown>,
 ): Promise<void> {
-  const ts = new Date().toISOString();
-  return appendAuditEntry({
-    id: randomUUID(),
-    adminId,
-    role,
-    action,
-    resourceType,
-    resourceId,
-    payload,
-    timestamp: ts,
-    partitionKey: ts.slice(0, 7),
-  });
+  try {
+    const ts = new Date().toISOString();
+    await appendAuditEntry({
+      id: randomUUID(),
+      adminId,
+      role,
+      action,
+      resourceType,
+      resourceId,
+      payload,
+      timestamp: ts,
+      partitionKey: ts.slice(0, 7),
+    });
+  } catch (err) {
+    Sentry.captureException(err);
+  }
 }

--- a/api/src/services/kycAudit.service.ts
+++ b/api/src/services/kycAudit.service.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from 'node:crypto';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+
+export function kycAuditEntry(
+  technicianId: string,
+  kycMethod: string,
+  kycStatus: string,
+  maskedIdentifier: string,
+): Promise<void> {
+  const ts = new Date().toISOString();
+  return appendAuditEntry({
+    id: randomUUID(),
+    adminId: 'system',
+    role: 'system',
+    action: `KYC_${kycMethod.toUpperCase()}_${kycStatus}`,
+    resourceType: 'technician',
+    resourceId: technicianId,
+    payload: { kycMethod, kycStatus, maskedIdentifier },
+    timestamp: ts,
+    partitionKey: ts.slice(0, 7),
+  });
+}

--- a/api/src/services/kycAudit.service.ts
+++ b/api/src/services/kycAudit.service.ts
@@ -1,22 +1,28 @@
 import { randomUUID } from 'node:crypto';
+import * as Sentry from '@sentry/node';
 import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 
-export function kycAuditEntry(
+// maskedIdentifier deliberately omitted: audit_log is immutable so PII (PAN,
+// Aadhaar) must never land in payload — erasure path only anonymizes resourceId.
+export async function kycAuditEntry(
   technicianId: string,
   kycMethod: string,
   kycStatus: string,
-  maskedIdentifier: string,
 ): Promise<void> {
-  const ts = new Date().toISOString();
-  return appendAuditEntry({
-    id: randomUUID(),
-    adminId: 'system',
-    role: 'system',
-    action: `KYC_${kycMethod.toUpperCase()}_${kycStatus}`,
-    resourceType: 'technician',
-    resourceId: technicianId,
-    payload: { kycMethod, kycStatus, maskedIdentifier },
-    timestamp: ts,
-    partitionKey: ts.slice(0, 7),
-  });
+  try {
+    const ts = new Date().toISOString();
+    await appendAuditEntry({
+      id: randomUUID(),
+      adminId: 'system',
+      role: 'system',
+      action: `KYC_${kycMethod.toUpperCase()}_${kycStatus}`,
+      resourceType: 'technician',
+      resourceId: technicianId,
+      payload: { kycMethod, kycStatus },
+      timestamp: ts,
+      partitionKey: ts.slice(0, 7),
+    });
+  } catch (err) {
+    Sentry.captureException(err);
+  }
 }

--- a/api/tests/bookings/confirm.test.ts
+++ b/api/tests/bookings/confirm.test.ts
@@ -76,7 +76,7 @@ describe('POST /v1/bookings/:id/confirm', () => {
     ) as HttpResponseInit;
     expect(res.status).toBe(200);
     expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceId: 'bk-1', adminId: 'cust-1' }),
+      expect.objectContaining({ action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceId: 'bk-1' }),
     );
   });
 

--- a/api/tests/bookings/confirm.test.ts
+++ b/api/tests/bookings/confirm.test.ts
@@ -76,7 +76,7 @@ describe('POST /v1/bookings/:id/confirm', () => {
     ) as HttpResponseInit;
     expect(res.status).toBe(200);
     expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceId: 'bk-1' }),
+      expect.objectContaining({ action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceId: 'bk-1', adminId: 'cust-1' }),
     );
   });
 

--- a/api/tests/bookings/confirm.test.ts
+++ b/api/tests/bookings/confirm.test.ts
@@ -23,7 +23,10 @@ vi.mock('../../src/services/razorpay.service.js', () => ({
   verifyPaymentSignature: vi.fn().mockReturnValue(true),
 }));
 
+vi.mock('../../src/cosmos/audit-log-repository.js', () => ({ appendAuditEntry: vi.fn().mockResolvedValue(undefined) }));
+
 import { confirmBookingHandler } from '../../src/functions/bookings.js';
+import { appendAuditEntry } from '../../src/cosmos/audit-log-repository.js';
 
 function confirmReq(id: string, body: unknown) {
   const req = new HttpRequest({
@@ -64,6 +67,17 @@ describe('POST /v1/bookings/:id/confirm', () => {
       {} as never,
     ) as HttpResponseInit;
     expect(res.status).toBe(404);
+  });
+
+  it('emits CUSTOMER_CONFIRMED_PAYMENT audit entry on successful confirmation', async () => {
+    const res = await confirmBookingHandler(
+      confirmReq('bk-1', { razorpayPaymentId: 'pay_audit', razorpayOrderId: 'order_1', razorpaySignature: 'sig' }),
+      {} as never,
+    ) as HttpResponseInit;
+    expect(res.status).toBe(200);
+    expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceId: 'bk-1' }),
+    );
   });
 
   it('returns 403 when customerId does not match booking', async () => {

--- a/api/tests/catalogue-admin.test.ts
+++ b/api/tests/catalogue-admin.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HttpRequest } from '@azure/functions';
 import type { AdminContext } from '../src/types/admin.js';
 import {
@@ -10,6 +10,7 @@ import {
   updateServiceHandler,
   toggleServiceHandler,
 } from '../src/functions/catalogue-admin.js';
+import { catalogueAuditEntry } from '../src/services/catalogueAudit.service.js';
 
 const mockAdmin: AdminContext = { adminId: 'dev-user', role: 'super-admin', sessionId: 'test-session' };
 
@@ -47,17 +48,29 @@ vi.mock('../src/middleware/requireAdmin.js', () => ({
   ),
 }));
 
+vi.mock('../src/services/catalogueAudit.service.js', () => ({ catalogueAuditEntry: vi.fn().mockResolvedValue(undefined) }));
+
 function makeReq(url: string, body?: unknown, params: Record<string, string> = {}, method = 'POST') {
   const req = new HttpRequest({ url, method, ...(body ? { body: { string: JSON.stringify(body) } } : {}) });
   Object.assign(req, { params });
   return req;
 }
 
+beforeEach(() => { vi.clearAllMocks(); });
+
 describe('POST /v1/admin/catalogue/categories', () => {
   it('returns 201 with created category', async () => {
     const body = { id: 'plumbing', name: 'Plumbing', heroImageUrl: 'https://example.com/p.jpg', sortOrder: 3 };
     const res = await createCategoryHandler(makeReq('http://localhost/api/v1/admin/catalogue/categories', body), {} as never, mockAdmin);
     expect(res.status).toBe(201);
+  });
+
+  it('emits CATALOGUE_CATEGORY_CREATED audit entry on success', async () => {
+    const body = { id: 'plumbing', name: 'Plumbing', heroImageUrl: 'https://example.com/p.jpg', sortOrder: 3 };
+    await createCategoryHandler(makeReq('http://localhost/api/v1/admin/catalogue/categories', body), {} as never, mockAdmin);
+    expect(vi.mocked(catalogueAuditEntry)).toHaveBeenCalledWith(
+      'dev-user', 'super-admin', 'CATALOGUE_CATEGORY_CREATED', 'category', 'plumbing', expect.any(Object),
+    );
   });
 
   it('returns 400 on invalid body', async () => {
@@ -72,6 +85,14 @@ describe('PUT /v1/admin/catalogue/categories/{id}', () => {
     const res = await updateCategoryHandler(makeReq('http://localhost/...', body, { id: 'plumbing' }, 'PUT'), {} as never, mockAdmin);
     expect(res.status).toBe(200);
   });
+
+  it('emits CATALOGUE_CATEGORY_UPDATED audit entry on success', async () => {
+    const body = { name: 'Plumbing Updated', heroImageUrl: 'https://example.com/p.jpg', sortOrder: 3 };
+    await updateCategoryHandler(makeReq('http://localhost/...', body, { id: 'plumbing' }, 'PUT'), {} as never, mockAdmin);
+    expect(vi.mocked(catalogueAuditEntry)).toHaveBeenCalledWith(
+      'dev-user', 'super-admin', 'CATALOGUE_CATEGORY_UPDATED', 'category', 'plumbing', expect.any(Object),
+    );
+  });
 });
 
 describe('PATCH /v1/admin/catalogue/categories/{id}/toggle', () => {
@@ -79,6 +100,13 @@ describe('PATCH /v1/admin/catalogue/categories/{id}/toggle', () => {
     const res = await toggleCategoryHandler(makeReq('http://localhost/...', undefined, { id: 'plumbing' }, 'PATCH'), {} as never, mockAdmin);
     expect(res.status).toBe(200);
     expect((res.jsonBody as { isActive: boolean }).isActive).toBe(false);
+  });
+
+  it('emits CATALOGUE_CATEGORY_TOGGLED audit entry on success', async () => {
+    await toggleCategoryHandler(makeReq('http://localhost/...', undefined, { id: 'plumbing' }, 'PATCH'), {} as never, mockAdmin);
+    expect(vi.mocked(catalogueAuditEntry)).toHaveBeenCalledWith(
+      'dev-user', 'super-admin', 'CATALOGUE_CATEGORY_TOGGLED', 'category', 'plumbing', expect.any(Object),
+    );
   });
 });
 
@@ -103,6 +131,18 @@ describe('POST /v1/admin/catalogue/services', () => {
     const res = await createServiceHandler(makeReq('http://localhost/...', body), {} as never, mockAdmin);
     expect(res.status).toBe(201);
   });
+
+  it('emits CATALOGUE_SERVICE_CREATED audit entry on success', async () => {
+    const body = {
+      id: 'leak-fix', categoryId: 'plumbing', name: 'Leak Fix', shortDescription: 'Fast.',
+      heroImageUrl: 'https://example.com/l.jpg', basePrice: 39900, commissionBps: 2250,
+      durationMinutes: 60, includes: [], faq: [], addOns: [], photoStages: [],
+    };
+    await createServiceHandler(makeReq('http://localhost/...', body), {} as never, mockAdmin);
+    expect(vi.mocked(catalogueAuditEntry)).toHaveBeenCalledWith(
+      'dev-user', 'super-admin', 'CATALOGUE_SERVICE_CREATED', 'service', 'leak-fix', expect.any(Object),
+    );
+  });
 });
 
 describe('PUT /v1/admin/catalogue/services/{id}', () => {
@@ -114,6 +154,17 @@ describe('PUT /v1/admin/catalogue/services/{id}', () => {
     const res = await updateServiceHandler(makeReq('http://localhost/...', body, { id: 'leak-fix' }, 'PUT'), {} as never, mockAdmin);
     expect(res.status).toBe(200);
   });
+
+  it('emits CATALOGUE_SERVICE_UPDATED audit entry on success', async () => {
+    const body = {
+      name: 'Leak Fix Updated', shortDescription: 'Faster.', heroImageUrl: 'https://example.com/l2.jpg',
+      basePrice: 49900, commissionBps: 2250, durationMinutes: 45, includes: [], faq: [], addOns: [], photoStages: [],
+    };
+    await updateServiceHandler(makeReq('http://localhost/...', body, { id: 'leak-fix' }, 'PUT'), {} as never, mockAdmin);
+    expect(vi.mocked(catalogueAuditEntry)).toHaveBeenCalledWith(
+      'dev-user', 'super-admin', 'CATALOGUE_SERVICE_UPDATED', 'service', 'leak-fix', expect.any(Object),
+    );
+  });
 });
 
 describe('PATCH /v1/admin/catalogue/services/{id}/toggle', () => {
@@ -121,5 +172,12 @@ describe('PATCH /v1/admin/catalogue/services/{id}/toggle', () => {
     const res = await toggleServiceHandler(makeReq('http://localhost/...', undefined, { id: 'leak-fix' }, 'PATCH'), {} as never, mockAdmin);
     expect(res.status).toBe(200);
     expect((res.jsonBody as { isActive: boolean }).isActive).toBe(false);
+  });
+
+  it('emits CATALOGUE_SERVICE_TOGGLED audit entry on success', async () => {
+    await toggleServiceHandler(makeReq('http://localhost/...', undefined, { id: 'leak-fix' }, 'PATCH'), {} as never, mockAdmin);
+    expect(vi.mocked(catalogueAuditEntry)).toHaveBeenCalledWith(
+      'dev-user', 'super-admin', 'CATALOGUE_SERVICE_TOGGLED', 'service', 'leak-fix', expect.any(Object),
+    );
   });
 });

--- a/api/tests/cosmos/audit-log-immutability.test.ts
+++ b/api/tests/cosmos/audit-log-immutability.test.ts
@@ -18,7 +18,7 @@
 // See docs/adr/0013-audit-log-immutability.md.
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { resolve, join, dirname, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -203,7 +203,6 @@ describe('container-name uniqueness invariant', () => {
 
   it('all approved files exist (guard against stale allowlist)', () => {
     const norm = (p: string) => p.split(sep).join('/');
-    const { existsSync } = require('node:fs') as typeof import('node:fs');
     for (const f of APPROVED_FILES) {
       expect(existsSync(f), `Approved file missing: ${norm(f)}`).toBe(true);
     }

--- a/api/tests/functions/admin/auth/login.test.ts
+++ b/api/tests/functions/admin/auth/login.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpRequest } from '@azure/functions';
+import type { InvocationContext, HttpResponseInit } from '@azure/functions';
+
+vi.mock('../../../../src/cosmos/audit-log-repository.js', () => ({ appendAuditEntry: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../../../src/services/firebaseAdmin.js', () => ({ verifyFirebaseIdToken: vi.fn() }));
+vi.mock('../../../../src/services/adminUser.service.js', () => ({ getAdminUserById: vi.fn() }));
+vi.mock('../../../../src/services/totp.service.js', () => ({
+  decryptSecret: vi.fn().mockReturnValue('decrypted_secret'),
+  verifyToken: vi.fn(),
+}));
+vi.mock('../../../../src/services/adminSession.service.js', () => ({
+  createAdminSession: vi.fn().mockResolvedValue({ sessionId: 'sess-1' }),
+}));
+vi.mock('../../../../src/services/jwt.service.js', () => ({
+  signAccessToken: vi.fn().mockResolvedValue('access-token'),
+  signSetupToken: vi.fn().mockResolvedValue('setup-token'),
+}));
+vi.mock('../../../../src/services/auditLog.service.js', () => ({ auditLog: vi.fn() }));
+
+import { adminLoginHandler } from '../../../../src/functions/admin/auth/login.js';
+import { appendAuditEntry } from '../../../../src/cosmos/audit-log-repository.js';
+import { verifyFirebaseIdToken } from '../../../../src/services/firebaseAdmin.js';
+import { getAdminUserById } from '../../../../src/services/adminUser.service.js';
+import { verifyToken } from '../../../../src/services/totp.service.js';
+
+const mockCtx = {} as InvocationContext;
+
+function loginReq(body: unknown) {
+  return new HttpRequest({
+    url: 'http://localhost/api/v1/admin/auth/login',
+    method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const validAdmin = {
+  adminId: 'admin-1', role: 'super-admin' as const,
+  email: 'admin@test.com', totpEnrolled: true,
+  totpSecret: 'encrypted_secret', deactivatedAt: undefined,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(appendAuditEntry).mockResolvedValue(undefined);
+  vi.mocked(verifyFirebaseIdToken).mockResolvedValue({ uid: 'admin-1' } as never);
+  vi.mocked(getAdminUserById).mockResolvedValue(validAdmin as never);
+  vi.mocked(verifyToken).mockReturnValue(true);
+});
+
+describe('POST /v1/admin/auth/login', () => {
+  it('emits ADMIN_LOGIN_FAILED audit entry on invalid TOTP code', async () => {
+    vi.mocked(verifyToken).mockReturnValue(false);
+
+    const res = await adminLoginHandler(
+      loginReq({ idToken: 'id-tok', totpCode: '000000' }),
+      mockCtx,
+    ) as HttpResponseInit;
+
+    expect(res.status).toBe(422);
+    expect((res.jsonBody as { code: string }).code).toBe('TOTP_INVALID');
+    expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'ADMIN_LOGIN_FAILED', resourceId: 'admin-1' }),
+    );
+  });
+
+  it('does NOT emit ADMIN_LOGIN_FAILED on successful login', async () => {
+    const res = await adminLoginHandler(
+      loginReq({ idToken: 'id-tok', totpCode: '123456' }),
+      mockCtx,
+    ) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    // appendAuditEntry is only called by the success auditLog wrapper, not our FAILED entry
+    const failedCall = vi.mocked(appendAuditEntry).mock.calls.find(
+      ([doc]) => (doc as { action: string }).action === 'ADMIN_LOGIN_FAILED',
+    );
+    expect(failedCall).toBeUndefined();
+  });
+});

--- a/api/tests/functions/rating-escalate.test.ts
+++ b/api/tests/functions/rating-escalate.test.ts
@@ -17,11 +17,13 @@ vi.mock('../../src/services/fcm.service.js', () => ({
 vi.mock('../../src/services/firebaseAdmin.js', () => ({
   verifyFirebaseIdToken: vi.fn().mockResolvedValue({ uid: 'customer_1' }),
 }));
+vi.mock('../../src/cosmos/audit-log-repository.js', () => ({ appendAuditEntry: vi.fn().mockResolvedValue(undefined) }));
 
 import { bookingRepo } from '../../src/cosmos/booking-repository.js';
 import { ratingRepo } from '../../src/cosmos/rating-repository.js';
 import { createComplaint, findRatingShieldEscalation } from '../../src/cosmos/complaints-repository.js';
 import { escalateRatingHandler } from '../../src/functions/rating-escalate.js';
+import { appendAuditEntry } from '../../src/cosmos/audit-log-repository.js';
 
 const closedBooking = { id: 'bk-1', customerId: 'customer_1', technicianId: 'tech_1', status: 'CLOSED' };
 const mockCustomer = { customerId: 'customer_1' };
@@ -130,6 +132,19 @@ describe('escalateRatingHandler', () => {
     const res = await escalateRatingHandler(badReq, mockCtx, mockCustomer);
     expect(res.status).toBe(400);
     expect(res.jsonBody).toMatchObject({ code: 'INVALID_JSON' });
+  });
+
+  it('emits RATING_SHIELD_ESCALATED audit entry on successful escalation', async () => {
+    (bookingRepo.getById as ReturnType<typeof vi.fn>).mockResolvedValue(closedBooking);
+    (findRatingShieldEscalation as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (createComplaint as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const res = await escalateRatingHandler(makeReq({ draftOverall: 2 }), mockCtx, mockCustomer);
+
+    expect(res.status).toBe(201);
+    expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'RATING_SHIELD_ESCALATED', resourceId: 'bk-1' }),
+    );
   });
 
   it('returns 409 NO_TECHNICIAN when booking has no assigned technician', async () => {

--- a/api/tests/functions/rating-escalate.test.ts
+++ b/api/tests/functions/rating-escalate.test.ts
@@ -143,7 +143,7 @@ describe('escalateRatingHandler', () => {
 
     expect(res.status).toBe(201);
     expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'RATING_SHIELD_ESCALATED', resourceId: 'bk-1', adminId: 'customer_1' }),
+      expect.objectContaining({ action: 'RATING_SHIELD_ESCALATED', resourceId: 'bk-1' }),
     );
   });
 

--- a/api/tests/functions/rating-escalate.test.ts
+++ b/api/tests/functions/rating-escalate.test.ts
@@ -143,7 +143,7 @@ describe('escalateRatingHandler', () => {
 
     expect(res.status).toBe(201);
     expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'RATING_SHIELD_ESCALATED', resourceId: 'bk-1' }),
+      expect.objectContaining({ action: 'RATING_SHIELD_ESCALATED', resourceId: 'bk-1', adminId: 'customer_1' }),
     );
   });
 

--- a/api/tests/integration/audit-log-coverage-invariant.test.ts
+++ b/api/tests/integration/audit-log-coverage-invariant.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Audit-log coverage invariant (W2-2' gate).
+ *
+ * Each handler listed below MUST reference an audit-producing call.
+ * Add a handler to AUDIT_HANDLERS when you wire a new audit entry so this
+ * test catches future accidental removals at CI time.
+ *
+ * Modeled on dispatcher-data-isolation.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const API_ROOT = resolve(here, '..', '..');
+
+function readApiFile(rel: string): string {
+  return readFileSync(resolve(API_ROOT, rel), 'utf8');
+}
+
+/** Each entry: [relative path, token that must appear in the source]. */
+const AUDIT_HANDLERS: [string, string][] = [
+  ['src/functions/trigger-no-show-detector.ts', 'NO_SHOW_CREDIT_ISSUED'],
+  ['src/functions/trigger-no-show-detector.ts', 'NO_SHOW_TECH_SWAPPED'],
+  ['src/functions/trigger-no-show-detector.ts', 'BOOKING_UNFULFILLED'],
+  ['src/functions/webhooks.ts', 'PAYMENT_CAPTURED'],
+  ['src/functions/bookings.ts', 'CUSTOMER_CONFIRMED_PAYMENT'],
+  ['src/functions/kyc/submit-aadhaar.ts', 'kycAuditEntry'],
+  ['src/functions/kyc/submit-pan-ocr.ts', 'kycAuditEntry'],
+  ['src/functions/admin/auth/login.ts', 'ADMIN_LOGIN_FAILED'],
+  ['src/functions/rating-escalate.ts', 'RATING_SHIELD_ESCALATED'],
+  ['src/functions/catalogue-admin.ts', 'CATALOGUE_CATEGORY_CREATED'],
+  ['src/functions/catalogue-admin.ts', 'CATALOGUE_CATEGORY_UPDATED'],
+  ['src/functions/catalogue-admin.ts', 'CATALOGUE_CATEGORY_TOGGLED'],
+  ['src/functions/catalogue-admin.ts', 'CATALOGUE_SERVICE_CREATED'],
+  ['src/functions/catalogue-admin.ts', 'CATALOGUE_SERVICE_UPDATED'],
+  ['src/functions/catalogue-admin.ts', 'CATALOGUE_SERVICE_TOGGLED'],
+];
+
+describe('Audit-log P1 coverage invariant', () => {
+  it.each(AUDIT_HANDLERS)(
+    '%s contains audit token "%s"',
+    (file, token) => {
+      const content = readApiFile(file);
+      expect(content).toContain(token);
+    },
+  );
+});

--- a/api/tests/integration/audit-log-coverage-invariant.test.ts
+++ b/api/tests/integration/audit-log-coverage-invariant.test.ts
@@ -22,7 +22,7 @@ function readApiFile(rel: string): string {
 /** Each entry: [relative path, token that must appear in the source]. */
 const AUDIT_HANDLERS: [string, string][] = [
   ['src/functions/trigger-no-show-detector.ts', 'NO_SHOW_CREDIT_ISSUED'],
-  ['src/functions/trigger-no-show-detector.ts', 'NO_SHOW_TECH_SWAPPED'],
+  ['src/functions/trigger-no-show-detector.ts', 'NO_SHOW_REDISPATCH_INITIATED'],
   ['src/functions/trigger-no-show-detector.ts', 'BOOKING_UNFULFILLED'],
   ['src/functions/webhooks.ts', 'PAYMENT_CAPTURED'],
   ['src/functions/bookings.ts', 'CUSTOMER_CONFIRMED_PAYMENT'],

--- a/api/tests/kyc/submit-aadhaar.test.ts
+++ b/api/tests/kyc/submit-aadhaar.test.ts
@@ -80,7 +80,7 @@ describe('POST /v1/kyc/aadhaar', () => {
     });
     await handler(req, new InvocationContext());
 
-    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'AADHAAR', 'VERIFIED', 'XXXX-XXXX-1234');
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'AADHAAR', 'VERIFIED');
   });
 
   it('emits KYC_AADHAAR_REJECTED audit entry when DigiLocker returns null', async () => {
@@ -97,7 +97,7 @@ describe('POST /v1/kyc/aadhaar', () => {
     });
     await handler(req, new InvocationContext());
 
-    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'AADHAAR', 'REJECTED', '');
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'AADHAAR', 'REJECTED');
   });
 
   it('returns 401 on invalid token', async () => {

--- a/api/tests/kyc/submit-aadhaar.test.ts
+++ b/api/tests/kyc/submit-aadhaar.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/middleware/verifyTechnicianToken.js', () => ({
 vi.mock('../../src/services/digilocker.service.js', () => ({
   exchangeCodeForAadhaar: vi.fn(),
 }));
+vi.mock('../../src/services/kycAudit.service.js', () => ({ kycAuditEntry: vi.fn().mockResolvedValue(undefined) }));
 
 describe('POST /v1/kyc/aadhaar', () => {
   let handler: typeof import('../../src/functions/kyc/submit-aadhaar.js').submitAadhaar;
@@ -61,6 +62,42 @@ describe('POST /v1/kyc/aadhaar', () => {
     const body = res.jsonBody as Record<string, unknown>;
     expect(body['kycStatus']).toBe('PENDING_MANUAL');
     expect(body['aadhaarVerified']).toBe(false);
+  });
+
+  it('emits KYC_AADHAAR_VERIFIED audit entry on successful DigiLocker exchange', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { exchangeCodeForAadhaar } = await import('../../src/services/digilocker.service.js');
+    const { upsertKycStatus } = await import('../../src/cosmos/technician-repository.js');
+    const { kycAuditEntry } = await import('../../src/services/kycAudit.service.js');
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-001' });
+    vi.mocked(exchangeCodeForAadhaar).mockResolvedValue({ maskedNumber: 'XXXX-XXXX-1234' });
+    vi.mocked(upsertKycStatus).mockResolvedValue(undefined);
+
+    const req = new HttpRequest({
+      method: 'POST', url: 'http://localhost/v1/kyc/aadhaar',
+      headers: { Authorization: 'Bearer valid' },
+      body: { string: JSON.stringify({ technicianId: 'tech-001', authCode: 'digicode', redirectUri: 'https://homeservices.app/digilocker' }) },
+    });
+    await handler(req, new InvocationContext());
+
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'AADHAAR', 'VERIFIED', 'XXXX-XXXX-1234');
+  });
+
+  it('emits KYC_AADHAAR_REJECTED audit entry when DigiLocker returns null', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { exchangeCodeForAadhaar } = await import('../../src/services/digilocker.service.js');
+    const { kycAuditEntry } = await import('../../src/services/kycAudit.service.js');
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-001' });
+    vi.mocked(exchangeCodeForAadhaar).mockResolvedValue(null);
+
+    const req = new HttpRequest({
+      method: 'POST', url: 'http://localhost/v1/kyc/aadhaar',
+      headers: { Authorization: 'Bearer valid' },
+      body: { string: JSON.stringify({ technicianId: 'tech-001', authCode: '', redirectUri: 'https://homeservices.app/digilocker' }) },
+    });
+    await handler(req, new InvocationContext());
+
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'AADHAAR', 'REJECTED', '');
   });
 
   it('returns 401 on invalid token', async () => {

--- a/api/tests/kyc/submit-pan-ocr.test.ts
+++ b/api/tests/kyc/submit-pan-ocr.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../src/cosmos/technician-repository.js', () => ({
 vi.mock('../../src/middleware/verifyTechnicianToken.js', () => ({
   verifyTechnicianToken: vi.fn(),
 }));
+vi.mock('../../src/services/kycAudit.service.js', () => ({ kycAuditEntry: vi.fn().mockResolvedValue(undefined) }));
 
 describe('POST /v1/kyc/pan-ocr', () => {
   let handler: typeof import('../../src/functions/kyc/submit-pan-ocr.js').submitPanOcr;
@@ -62,6 +63,42 @@ describe('POST /v1/kyc/pan-ocr', () => {
     const body = res.jsonBody as { kycStatus: string; panNumber: null };
     expect(body.kycStatus).toBe('MANUAL_REVIEW');
     expect(body.panNumber).toBeNull();
+  });
+
+  it('emits KYC_PAN_VERIFIED audit entry on OCR success', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { extractPanFromStoragePath } = await import('../../src/services/formRecognizer.service.js');
+    const { upsertKycStatus } = await import('../../src/cosmos/technician-repository.js');
+    const { kycAuditEntry } = await import('../../src/services/kycAudit.service.js');
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-001' });
+    vi.mocked(extractPanFromStoragePath).mockResolvedValue({ status: 'PAN_DONE', panNumber: 'ABCDE1234F' });
+    vi.mocked(upsertKycStatus).mockResolvedValue(undefined);
+
+    const req = new HttpRequest({
+      method: 'POST', url: 'http://localhost/v1/kyc/pan-ocr',
+      headers: { Authorization: 'Bearer valid-token' },
+      body: { string: JSON.stringify({ technicianId: 'tech-001', firebaseStoragePath: 'technicians/tech-001/pan.jpg' }) },
+    });
+    await handler(req, new InvocationContext());
+
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'PAN', 'VERIFIED', 'ABCDE1234F');
+  });
+
+  it('emits KYC_PAN_REJECTED audit entry on OCR failure', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { extractPanFromStoragePath } = await import('../../src/services/formRecognizer.service.js');
+    const { kycAuditEntry } = await import('../../src/services/kycAudit.service.js');
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-001' });
+    vi.mocked(extractPanFromStoragePath).mockResolvedValue({ status: 'MANUAL_REVIEW', panNumber: null });
+
+    const req = new HttpRequest({
+      method: 'POST', url: 'http://localhost/v1/kyc/pan-ocr',
+      headers: { Authorization: 'Bearer valid-token' },
+      body: { string: JSON.stringify({ technicianId: 'tech-001', firebaseStoragePath: 'technicians/tech-001/pan.jpg' }) },
+    });
+    await handler(req, new InvocationContext());
+
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'PAN', 'REJECTED', '');
   });
 
   it('returns 401 when token invalid', async () => {

--- a/api/tests/kyc/submit-pan-ocr.test.ts
+++ b/api/tests/kyc/submit-pan-ocr.test.ts
@@ -81,7 +81,7 @@ describe('POST /v1/kyc/pan-ocr', () => {
     });
     await handler(req, new InvocationContext());
 
-    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'PAN', 'VERIFIED', 'ABCDE1234F');
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'PAN', 'VERIFIED');
   });
 
   it('emits KYC_PAN_REJECTED audit entry on OCR failure', async () => {
@@ -98,7 +98,7 @@ describe('POST /v1/kyc/pan-ocr', () => {
     });
     await handler(req, new InvocationContext());
 
-    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'PAN', 'REJECTED', '');
+    expect(vi.mocked(kycAuditEntry)).toHaveBeenCalledWith('tech-001', 'PAN', 'REJECTED');
   });
 
   it('returns 401 when token invalid', async () => {

--- a/api/tests/unit/trigger-no-show-detector.test.ts
+++ b/api/tests/unit/trigger-no-show-detector.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
 }));
 vi.mock('../../src/services/fcm.service.js');
 vi.mock('@sentry/node', () => ({ captureException: vi.fn() }));
+vi.mock('../../src/cosmos/audit-log-repository.js', () => ({ appendAuditEntry: vi.fn() }));
 
 import { detectNoShows } from '../../src/functions/trigger-no-show-detector.js';
 import { bookingRepo, updateBookingFields } from '../../src/cosmos/booking-repository.js';
@@ -20,6 +21,7 @@ import { customerCreditRepo } from '../../src/cosmos/customer-credit-repository.
 import { dispatcherService } from '../../src/services/dispatcher.service.js';
 import * as fcmService from '../../src/services/fcm.service.js';
 import * as Sentry from '@sentry/node';
+import { appendAuditEntry } from '../../src/cosmos/audit-log-repository.js';
 import type { BookingDoc } from '../../src/schemas/booking.js';
 
 const mockCtx = { log: vi.fn() } as unknown as InvocationContext;
@@ -78,6 +80,7 @@ beforeEach(() => {
   // call 1: fresh-read → ASSIGNED (guard passes), call 2+: push-check → no noShowPushSentAt
   mockGetByIdSequence({ status: 'ASSIGNED' }, { status: 'NO_SHOW_REDISPATCH' });
   vi.mocked(customerCreditRepo.createCreditIfAbsent).mockResolvedValue(true);
+  vi.mocked(appendAuditEntry).mockResolvedValue(undefined);
   vi.mocked(updateBookingFields).mockResolvedValue(null);
   vi.mocked(dispatcherService.redispatch).mockResolvedValue(true);
   vi.mocked(fcmService.sendNoShowCreditPush).mockResolvedValue(undefined);
@@ -293,6 +296,43 @@ describe('detectNoShows', () => {
     );
     expect(customerCreditRepo.createCreditIfAbsent).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: 'bk-notdue' }),
+    );
+  });
+
+  it('emits NO_SHOW_CREDIT_ISSUED audit entry when credit is first written', async () => {
+    vi.mocked(bookingRepo.getAssignedBookingsBefore)
+      .mockResolvedValue([makeAssignedBooking('bk-audit-credit', 45)]);
+    mockGetByIdSequence({ status: 'ASSIGNED' }, { status: 'NO_SHOW_REDISPATCH' });
+
+    await detectNoShows(mockCtx);
+
+    expect(appendAuditEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'NO_SHOW_CREDIT_ISSUED', resourceId: 'bk-audit-credit' }),
+    );
+  });
+
+  it('emits NO_SHOW_TECH_SWAPPED audit entry when redispatch succeeds', async () => {
+    vi.mocked(bookingRepo.getAssignedBookingsBefore)
+      .mockResolvedValue([makeAssignedBooking('bk-audit-swap', 45)]);
+    mockGetByIdSequence({ status: 'ASSIGNED' }, { status: 'NO_SHOW_REDISPATCH' });
+
+    await detectNoShows(mockCtx);
+
+    expect(appendAuditEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'NO_SHOW_TECH_SWAPPED', resourceId: 'bk-audit-swap' }),
+    );
+  });
+
+  it('emits BOOKING_UNFULFILLED audit entry when no techs are available', async () => {
+    vi.mocked(bookingRepo.getAssignedBookingsBefore)
+      .mockResolvedValue([makeAssignedBooking('bk-audit-unf', 45)]);
+    vi.mocked(dispatcherService.redispatch).mockResolvedValue(false);
+    mockGetByIdSequence({ status: 'ASSIGNED' }, { status: 'NO_SHOW_REDISPATCH' });
+
+    await detectNoShows(mockCtx);
+
+    expect(appendAuditEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'BOOKING_UNFULFILLED', resourceId: 'bk-audit-unf' }),
     );
   });
 

--- a/api/tests/unit/trigger-no-show-detector.test.ts
+++ b/api/tests/unit/trigger-no-show-detector.test.ts
@@ -323,16 +323,16 @@ describe('detectNoShows', () => {
     );
   });
 
-  it('emits BOOKING_UNFULFILLED audit entry when no techs are available and booking is not SEARCHING', async () => {
+  it('emits BOOKING_UNFULFILLED audit entry when dispatcher set status to UNFULFILLED', async () => {
     vi.mocked(bookingRepo.getAssignedBookingsBefore)
       .mockResolvedValue([makeAssignedBooking('bk-audit-unf', 45)]);
     vi.mocked(dispatcherService.redispatch).mockResolvedValue(false);
-    // getById sequence: fresh-read → ASSIGNED, preDispatch → NO_SHOW_REDISPATCH, postDispatch → NO_SHOW_REDISPATCH (not SEARCHING)
+    // getById sequence: fresh-read → ASSIGNED, preDispatch → NO_SHOW_REDISPATCH, postDispatch → UNFULFILLED
     mockGetByIdSequence(
       { status: 'ASSIGNED' },
       { status: 'NO_SHOW_REDISPATCH' },
-      { status: 'NO_SHOW_REDISPATCH' },
-      { status: 'NO_SHOW_REDISPATCH' },
+      { status: 'UNFULFILLED' },
+      { status: 'UNFULFILLED' },
     );
 
     await detectNoShows(mockCtx);
@@ -342,11 +342,11 @@ describe('detectNoShows', () => {
     );
   });
 
-  it('does NOT emit BOOKING_UNFULFILLED when concurrent run moved booking to SEARCHING', async () => {
+  it('does NOT emit BOOKING_UNFULFILLED when concurrent run moved booking to SEARCHING or ASSIGNED', async () => {
     vi.mocked(bookingRepo.getAssignedBookingsBefore)
       .mockResolvedValue([makeAssignedBooking('bk-race', 45)]);
     vi.mocked(dispatcherService.redispatch).mockResolvedValue(false);
-    // postDispatch read shows SEARCHING — concurrent run is handling this booking
+    // postDispatch read shows SEARCHING (not UNFULFILLED) — concurrent run is handling this booking
     mockGetByIdSequence(
       { status: 'ASSIGNED' },
       { status: 'NO_SHOW_REDISPATCH' },

--- a/api/tests/unit/trigger-no-show-detector.test.ts
+++ b/api/tests/unit/trigger-no-show-detector.test.ts
@@ -311,29 +311,55 @@ describe('detectNoShows', () => {
     );
   });
 
-  it('emits NO_SHOW_TECH_SWAPPED audit entry when redispatch succeeds', async () => {
+  it('emits NO_SHOW_REDISPATCH_INITIATED audit entry when redispatch succeeds', async () => {
     vi.mocked(bookingRepo.getAssignedBookingsBefore)
-      .mockResolvedValue([makeAssignedBooking('bk-audit-swap', 45)]);
+      .mockResolvedValue([makeAssignedBooking('bk-audit-rdp', 45)]);
     mockGetByIdSequence({ status: 'ASSIGNED' }, { status: 'NO_SHOW_REDISPATCH' });
 
     await detectNoShows(mockCtx);
 
     expect(appendAuditEntry).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'NO_SHOW_TECH_SWAPPED', resourceId: 'bk-audit-swap' }),
+      expect.objectContaining({ action: 'NO_SHOW_REDISPATCH_INITIATED', resourceId: 'bk-audit-rdp' }),
     );
   });
 
-  it('emits BOOKING_UNFULFILLED audit entry when no techs are available', async () => {
+  it('emits BOOKING_UNFULFILLED audit entry when no techs are available and booking is not SEARCHING', async () => {
     vi.mocked(bookingRepo.getAssignedBookingsBefore)
       .mockResolvedValue([makeAssignedBooking('bk-audit-unf', 45)]);
     vi.mocked(dispatcherService.redispatch).mockResolvedValue(false);
-    mockGetByIdSequence({ status: 'ASSIGNED' }, { status: 'NO_SHOW_REDISPATCH' });
+    // getById sequence: fresh-read → ASSIGNED, preDispatch → NO_SHOW_REDISPATCH, postDispatch → NO_SHOW_REDISPATCH (not SEARCHING)
+    mockGetByIdSequence(
+      { status: 'ASSIGNED' },
+      { status: 'NO_SHOW_REDISPATCH' },
+      { status: 'NO_SHOW_REDISPATCH' },
+      { status: 'NO_SHOW_REDISPATCH' },
+    );
 
     await detectNoShows(mockCtx);
 
     expect(appendAuditEntry).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'BOOKING_UNFULFILLED', resourceId: 'bk-audit-unf' }),
     );
+  });
+
+  it('does NOT emit BOOKING_UNFULFILLED when concurrent run moved booking to SEARCHING', async () => {
+    vi.mocked(bookingRepo.getAssignedBookingsBefore)
+      .mockResolvedValue([makeAssignedBooking('bk-race', 45)]);
+    vi.mocked(dispatcherService.redispatch).mockResolvedValue(false);
+    // postDispatch read shows SEARCHING — concurrent run is handling this booking
+    mockGetByIdSequence(
+      { status: 'ASSIGNED' },
+      { status: 'NO_SHOW_REDISPATCH' },
+      { status: 'SEARCHING' },
+      { status: 'SEARCHING' },
+    );
+
+    await detectNoShows(mockCtx);
+
+    const unfulfilledCall = vi.mocked(appendAuditEntry).mock.calls.find(
+      ([doc]) => (doc as { action: string }).action === 'BOOKING_UNFULFILLED',
+    );
+    expect(unfulfilledCall).toBeUndefined();
   });
 
   it('continues to next booking when createCreditIfAbsent throws for one booking (loop isolation)', async () => {

--- a/api/tests/webhooks/razorpay-webhook.test.ts
+++ b/api/tests/webhooks/razorpay-webhook.test.ts
@@ -16,9 +16,12 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
   dispatcherService: { triggerDispatch: vi.fn().mockResolvedValue(undefined) },
 }));
 
+vi.mock('../../src/cosmos/audit-log-repository.js', () => ({ appendAuditEntry: vi.fn().mockResolvedValue(undefined) }));
+
 import { razorpayWebhookHandler, reconcileStaleBookingsHandler } from '../../src/functions/webhooks.js';
 import { bookingRepo } from '../../src/cosmos/booking-repository.js';
 import { dispatcherService } from '../../src/services/dispatcher.service.js';
+import { appendAuditEntry } from '../../src/cosmos/audit-log-repository.js';
 
 function makeSignature(body: string, secret = 'webhook_secret') {
   return createHmac('sha256', secret).update(body).digest('hex');
@@ -81,6 +84,26 @@ describe('POST /v1/webhooks/razorpay', () => {
     expect((res.jsonBody as { received: boolean }).received).toBe(true);
     expect(vi.mocked(bookingRepo.markPaid)).toHaveBeenCalledWith('bk-1', 'pay_123');
     expect(vi.mocked(dispatcherService.triggerDispatch)).toHaveBeenCalledWith('bk-1');
+  });
+
+  it('emits PAYMENT_CAPTURED audit entry after successful markPaid', async () => {
+    const body = JSON.stringify({
+      event: 'payment.captured',
+      payload: { payment: { entity: { id: 'pay_audit', order_id: 'order_audit' } } },
+    });
+    const signature = makeSignature(body);
+    const req = makeWebhookReq(body, signature);
+
+    (bookingRepo.getByPaymentOrderId as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'bk-audit', status: 'SEARCHING', paymentOrderId: 'order_audit',
+    });
+    (bookingRepo.markPaid as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ id: 'bk-audit', status: 'PAID' });
+
+    await razorpayWebhookHandler(req, mockCtx);
+
+    expect(vi.mocked(appendAuditEntry)).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'PAYMENT_CAPTURED', resourceId: 'bk-audit' }),
+    );
   });
 
   it('idempotency — second call on PAID booking returns 200, markPaid not called', async () => {


### PR DESCRIPTION
## Summary

Re-implements W2-2 (PR #134, closed) on top of the full 223-line `trigger-no-show-detector.ts` now on `main`. PR #134 was closed because it targeted a stub (60-line, `detectAndResolve` returns `[]`).

**8 handlers audited (TDD per handler):**

| Handler | Events |
|---|---|
| `trigger-no-show-detector.ts` | `NO_SHOW_CREDIT_ISSUED`, `NO_SHOW_REDISPATCH_INITIATED`, `BOOKING_UNFULFILLED` |
| `webhooks.ts` | `PAYMENT_CAPTURED` |
| `bookings.ts` confirmBooking | `CUSTOMER_CONFIRMED_PAYMENT` |
| `kyc/submit-aadhaar.ts` | `KYC_AADHAAR_VERIFIED` / `KYC_AADHAAR_REJECTED` |
| `kyc/submit-pan-ocr.ts` | `KYC_PAN_VERIFIED` / `KYC_PAN_REJECTED` |
| `admin/auth/login.ts` | `ADMIN_LOGIN_FAILED` (TOTP_INVALID path) |
| `rating-escalate.ts` | `RATING_SHIELD_ESCALATED` |
| `catalogue-admin.ts` | 6× `CATALOGUE_*` mutations |

**New files:** `kycAudit.service.ts`, `catalogueAudit.service.ts`  
**New invariant test:** `audit-log-coverage-invariant.test.ts` (CI gate)  
**Fixed:** pre-existing lint issue in `audit-log-immutability.test.ts` (`require` → `import`)

## Design decisions (from 7 Codex review rounds)

- **KYC payloads are PII-free** — `maskedIdentifier`/`panNumber` omitted; `audit_log` is immutable and erasure only anonymizes `resourceId`
- **Catalogue audit writes are synchronous** (awaited, error-absorbed) — admin mutations must be audited in-order; fire-and-forget would leave actions permanently unaudited on transient Cosmos failure
- **`NO_SHOW_REDISPATCH_INITIATED` not `NO_SHOW_TECH_SWAPPED`** — at redispatch time only offers have been sent; no replacement tech has accepted
- **BOOKING_UNFULFILLED guarded** — only emits when post-dispatch read confirms `status === 'UNFULFILLED'` (the value dispatcher sets on exhausted candidates); avoids false events under concurrent invocations or fast accepts
- **`CUSTOMER_CONFIRMED_PAYMENT` guarded** — only emits when `confirmed.status === 'SEARCHING'`; `confirmPayment()` returns existing PAID doc on idempotent calls
- **Recovery path audit backfilled** — `NO_SHOW_REDISPATCH_INITIATED` also emitted in the `SEARCHING` recovery branch
- **Customer attribution deferred** — `adminId: 'system'` for customer events; `adminId: customerId` breaks DPDP export/erasure (which scans `resourceId` only); follow-up story needed to fix `listAuditLogForUser()` to also scan `adminId`

## Known P2 limitations (follow-up)

Three no-show detector crash-safety audit gaps remain (Codex round 7): `NO_SHOW_CREDIT_ISSUED` can be lost if the process crashes after the credit write; `NO_SHOW_REDISPATCH_INITIATED` can be lost if the process crashes between `noShowRedispatchAt` write and audit fire; concurrent UNFULFILLED audits possible on overlapping timer executions. All require adding new idempotency markers to `BookingDoc` — out of scope for this audit-coverage story.

## Test plan

- [x] 813 tests pass (`pnpm -C api test`)
- [x] Pre-codex smoke gate green (typecheck + lint + vitest)
- [x] Codex review passed (7 rounds, all P1s resolved)
- [x] Invariant test guards against future removal of audit calls

Closes #56 #58 #60 #61 #63 #66 #68 #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)