### PR TITLE
feat(e10-s04): launch readiness gate — GrowthBook soft-launch + marketing-pause flags

### DIFF
--- a/.codex-review-passed
+++ b/.codex-review-passed
@@ -1,1 +1,1 @@
-{"timestamp":"2026-04-29T08:19:43-04:00","commit":"f3220c078680820ac45f08abd15a7b9d3ab4a8ce","reviewer":"codex","note":"P2a warm-start-while-unauthenticated accepted — pre-existing limitation documented in commit message"}
+{"timestamp":"2026-04-29T16:29:32-04:00","commit":"21ca079ca5f49816be610c9d7806612d2f9bf52b","reviewer":"codex","findings":{"P1":"fixed — init() success check","P2":"fixed — customer userId attributes"}}

--- a/.github/workflows/api-ship.yml
+++ b/.github/workflows/api-ship.yml
@@ -60,6 +60,12 @@ jobs:
       - name: openapi spec quality (spectral — contract lint)
         run: pnpm run openapi:lint
 
+      - name: verify launch env vars configured
+        run: |
+          if [ -z "${{ secrets.GROWTHBOOK_CLIENT_KEY }}" ]; then
+            echo "::warning::GROWTHBOOK_CLIENT_KEY not set in repository secrets — soft_launch_enabled flag will not work"
+          fi
+
       - name: semgrep SAST
         uses: returntocorp/semgrep-action@v1
         with:

--- a/api/local.settings.example.json
+++ b/api/local.settings.example.json
@@ -7,6 +7,8 @@
     "ACS_CONNECTION_STRING": "<azure-communication-services-connection-string>",
     "ACS_SENDER_ADDRESS": "DoNotReply@<domain>.azurecomm.net",
     "SSC_OWNER_EMAIL": "<owner-email@example.com>",
-    "COSMOS_CONNECTION_STRING": "<azure-cosmos-db-connection-string>"
+    "COSMOS_CONNECTION_STRING": "<azure-cosmos-db-connection-string>",
+    "GROWTHBOOK_API_HOST": "https://cdn.growthbook.io",
+    "GROWTHBOOK_CLIENT_KEY": ""
   }
 }

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -14,10 +14,10 @@ import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 import { isSoftLaunchEnabled, isMarketingPaused } from '../services/featureFlags.service.js';
 
 const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
-  if (!(await isSoftLaunchEnabled())) {
+  if (!(await isSoftLaunchEnabled(customer.customerId))) {
     return { status: 503, jsonBody: { code: 'SERVICE_UNAVAILABLE', message: 'Launch coming soon' } };
   }
-  if (await isMarketingPaused()) {
+  if (await isMarketingPaused(customer.customerId)) {
     return { status: 503, jsonBody: { code: 'TEMPORARILY_UNAVAILABLE', message: 'We are pausing new bookings briefly' } };
   }
 

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -11,8 +11,16 @@ import { catalogueRepo } from '../cosmos/catalogue-repository.js';
 import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
 import { sendPriceApprovalPush } from '../services/fcm.service.js';
 import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+import { isSoftLaunchEnabled, isMarketingPaused } from '../services/featureFlags.service.js';
 
 const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  if (!(await isSoftLaunchEnabled())) {
+    return { status: 503, jsonBody: { code: 'SERVICE_UNAVAILABLE', message: 'Launch coming soon' } };
+  }
+  if (await isMarketingPaused()) {
+    return { status: 503, jsonBody: { code: 'TEMPORARILY_UNAVAILABLE', message: 'We are pausing new bookings briefly' } };
+  }
+
   const body = await req.json().catch(() => null);
   const parsed = CreateBookingRequestSchema.safeParse(body);
   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };

--- a/api/src/services/featureFlags.service.ts
+++ b/api/src/services/featureFlags.service.ts
@@ -1,53 +1,64 @@
 import { GrowthBook } from '@growthbook/growthbook';
 
-export type FeatureFlagClient = Pick<GrowthBook, 'loadFeatures' | 'isOn'>;
+// Use Pick<> over 'init' (not the deprecated loadFeatures) so:
+//   1. init() returns InitResponse with a success field we can inspect
+//   2. On timeout, SDK resolves {success:false} instead of rejecting — catch alone is insufficient
+export type FeatureFlagClient = Pick<GrowthBook, 'init' | 'isOn'>;
 
-// Module-level singleton — shared across invocations within the same Function App instance.
-// Created lazily on first call so the missing-key guard runs at call time, not module load time.
-let _singleton: FeatureFlagClient | null = null;
-
-function getSingleton(): FeatureFlagClient {
-  if (!_singleton) {
-    _singleton = new GrowthBook({
-      apiHost: process.env['GROWTHBOOK_API_HOST'] ?? 'https://cdn.growthbook.io',
-      clientKey: process.env['GROWTHBOOK_CLIENT_KEY'] ?? '',
-    });
-  }
-  return _singleton;
+function createRequestClient(userId?: string): FeatureFlagClient {
+  return new GrowthBook({
+    apiHost: process.env['GROWTHBOOK_API_HOST'] ?? 'https://cdn.growthbook.io',
+    clientKey: process.env['GROWTHBOOK_CLIENT_KEY'] ?? '',
+    // Pass userId so per-user F&F targeting rules in GrowthBook evaluate correctly.
+    // GrowthBook's module-level feature cache is shared across instances — network round-trips
+    // are deduplicated; creating per-request instances is safe and avoids singleton mutation.
+    ...(userId ? { attributes: { id: userId } } : {}),
+  });
 }
 
 /**
  * Returns true when bookings should be accepted.
- * Fail-open contract: SDK timeout or error → return true (allow booking).
- * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return true (skip flag entirely).
  *
- * @param client - injectable for testing; defaults to module singleton
+ * Fail-open contracts:
+ *   - init() resolves with success=false (real timeout/network error) → return true
+ *   - init() throws (unexpected SDK error) → return true
+ *   - Empty GROWTHBOOK_CLIENT_KEY (local dev) → return true, skip GrowthBook entirely
+ *
+ * @param userId  - Firebase UID of the requesting customer; used for GrowthBook
+ *                  per-user targeting (F&F allowlist). Optional — global eval if omitted.
+ * @param client  - Injectable for testing; defaults to a fresh per-request instance.
  */
-export async function isSoftLaunchEnabled(client?: FeatureFlagClient): Promise<boolean> {
+export async function isSoftLaunchEnabled(userId?: string, client?: FeatureFlagClient): Promise<boolean> {
   if (!process.env['GROWTHBOOK_CLIENT_KEY']) return true; // local dev — fail open
-  const gb = client ?? getSingleton();
+  const gb = client ?? createRequestClient(userId);
   try {
-    await gb.loadFeatures({ timeout: 1000 });
+    const result = await gb.init({ timeout: 1000 });
+    if (!result.success) return true; // timeout or network error → fail open
     return gb.isOn('soft_launch_enabled');
   } catch {
-    return true; // SDK failure must never block bookings
+    return true; // unexpected SDK throw → fail open
   }
 }
 
 /**
  * Returns true when the owner has manually paused new bookings (e.g. surge / incident).
- * Fail-open contract: SDK timeout or error → return false (do not accidentally pause).
- * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return false (never paused locally).
  *
- * @param client - injectable for testing; defaults to module singleton
+ * Fail-open contracts:
+ *   - init() resolves with success=false → return false (do not accidentally pause)
+ *   - init() throws → return false
+ *   - Empty GROWTHBOOK_CLIENT_KEY (local dev) → return false, never paused locally
+ *
+ * @param userId  - Firebase UID; used for completeness / future per-user overrides.
+ * @param client  - Injectable for testing.
  */
-export async function isMarketingPaused(client?: FeatureFlagClient): Promise<boolean> {
+export async function isMarketingPaused(userId?: string, client?: FeatureFlagClient): Promise<boolean> {
   if (!process.env['GROWTHBOOK_CLIENT_KEY']) return false; // local dev — never paused
-  const gb = client ?? getSingleton();
+  const gb = client ?? createRequestClient(userId);
   try {
-    await gb.loadFeatures({ timeout: 1000 });
+    const result = await gb.init({ timeout: 1000 });
+    if (!result.success) return false; // timeout or network error → do not accidentally pause
     return gb.isOn('marketing_pause_enabled');
   } catch {
-    return false; // SDK failure must never accidentally pause bookings
+    return false; // unexpected SDK throw → do not accidentally pause
   }
 }

--- a/api/src/services/featureFlags.service.ts
+++ b/api/src/services/featureFlags.service.ts
@@ -1,0 +1,53 @@
+import { GrowthBook } from '@growthbook/growthbook';
+
+export type FeatureFlagClient = Pick<GrowthBook, 'loadFeatures' | 'isOn'>;
+
+// Module-level singleton — shared across invocations within the same Function App instance.
+// Created lazily on first call so the missing-key guard runs at call time, not module load time.
+let _singleton: FeatureFlagClient | null = null;
+
+function getSingleton(): FeatureFlagClient {
+  if (!_singleton) {
+    _singleton = new GrowthBook({
+      apiHost: process.env['GROWTHBOOK_API_HOST'] ?? 'https://cdn.growthbook.io',
+      clientKey: process.env['GROWTHBOOK_CLIENT_KEY'] ?? '',
+    });
+  }
+  return _singleton;
+}
+
+/**
+ * Returns true when bookings should be accepted.
+ * Fail-open contract: SDK timeout or error → return true (allow booking).
+ * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return true (skip flag entirely).
+ *
+ * @param client - injectable for testing; defaults to module singleton
+ */
+export async function isSoftLaunchEnabled(client?: FeatureFlagClient): Promise<boolean> {
+  if (!process.env['GROWTHBOOK_CLIENT_KEY']) return true; // local dev — fail open
+  const gb = client ?? getSingleton();
+  try {
+    await gb.loadFeatures({ timeout: 1000 });
+    return gb.isOn('soft_launch_enabled');
+  } catch {
+    return true; // SDK failure must never block bookings
+  }
+}
+
+/**
+ * Returns true when the owner has manually paused new bookings (e.g. surge / incident).
+ * Fail-open contract: SDK timeout or error → return false (do not accidentally pause).
+ * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return false (never paused locally).
+ *
+ * @param client - injectable for testing; defaults to module singleton
+ */
+export async function isMarketingPaused(client?: FeatureFlagClient): Promise<boolean> {
+  if (!process.env['GROWTHBOOK_CLIENT_KEY']) return false; // local dev — never paused
+  const gb = client ?? getSingleton();
+  try {
+    await gb.loadFeatures({ timeout: 1000 });
+    return gb.isOn('marketing_pause_enabled');
+  } catch {
+    return false; // SDK failure must never accidentally pause bookings
+  }
+}

--- a/api/tests/unit/launch-gate.test.ts
+++ b/api/tests/unit/launch-gate.test.ts
@@ -4,11 +4,17 @@ import { isSoftLaunchEnabled, isMarketingPaused, type FeatureFlagClient } from '
 const ENV_KEY = 'GROWTHBOOK_CLIENT_KEY';
 const savedKey = process.env[ENV_KEY];
 
-function makeClient(flags: Record<string, boolean>, throws = false): FeatureFlagClient {
+// Build a mock FeatureFlagClient (init + isOn).
+// GrowthBook SDK resolves (does not reject) on timeout/network errors:
+//   init() → { success: false, source: 'timeout' | 'error' }
+// Only truly unexpected errors cause init() to throw.
+type FailureMode = 'ok' | 'sdk-timeout' | 'throws';
+
+function makeClient(flags: Record<string, boolean>, failureMode: FailureMode = 'ok'): FeatureFlagClient {
   return {
-    loadFeatures: throws
-      ? vi.fn().mockRejectedValue(new Error('GrowthBook SDK timeout'))
-      : vi.fn().mockResolvedValue(undefined),
+    init: failureMode === 'throws'
+      ? vi.fn().mockRejectedValue(new Error('Unexpected GrowthBook SDK error'))
+      : vi.fn().mockResolvedValue({ success: failureMode === 'ok', source: failureMode === 'ok' ? 'network' : 'timeout' }),
     isOn: vi.fn((flag: string) => flags[flag] ?? false),
   };
 }
@@ -28,26 +34,33 @@ afterEach(() => {
 describe('isSoftLaunchEnabled', () => {
   it('returns false when soft_launch_enabled = false → createBooking must return 503 SERVICE_UNAVAILABLE', async () => {
     const client = makeClient({ soft_launch_enabled: false });
-    const result = await isSoftLaunchEnabled(client);
+    const result = await isSoftLaunchEnabled('user-123', client);
     expect(result).toBe(false);
   });
 
   it('returns true when soft_launch_enabled = true → booking flow proceeds normally', async () => {
     const client = makeClient({ soft_launch_enabled: true });
-    const result = await isSoftLaunchEnabled(client);
+    const result = await isSoftLaunchEnabled('user-123', client);
     expect(result).toBe(true);
   });
 
-  it('fails open when GrowthBook SDK throws → booking proceeds (SDK failure must not block users)', async () => {
-    const client = makeClient({}, true /* throws */);
-    const result = await isSoftLaunchEnabled(client);
-    expect(result).toBe(true); // fail open
+  it('fails open when GrowthBook init resolves with success=false (real SDK timeout/network error)', async () => {
+    // GrowthBook SDK does NOT throw on timeout — it resolves {success:false}.
+    // The catch block alone is insufficient; we must check result.success.
+    const client = makeClient({}, 'sdk-timeout');
+    const result = await isSoftLaunchEnabled('user-123', client);
+    expect(result).toBe(true); // fail open — never block bookings due to flags SDK issue
+  });
+
+  it('fails open when GrowthBook init throws unexpectedly (defensive catch)', async () => {
+    const client = makeClient({}, 'throws');
+    const result = await isSoftLaunchEnabled('user-123', client);
+    expect(result).toBe(true);
   });
 
   it('returns true when GROWTHBOOK_CLIENT_KEY is empty → local-dev passthrough (no GrowthBook call)', async () => {
     delete process.env[ENV_KEY];
-    // No client passed — uses module singleton path, which bails early when key is missing
-    const result = await isSoftLaunchEnabled();
+    const result = await isSoftLaunchEnabled('user-123');
     expect(result).toBe(true);
   });
 });
@@ -55,25 +68,31 @@ describe('isSoftLaunchEnabled', () => {
 describe('isMarketingPaused', () => {
   it('returns true when marketing_pause_enabled = true → 503 TEMPORARILY_UNAVAILABLE even during soft launch', async () => {
     const client = makeClient({ marketing_pause_enabled: true });
-    const result = await isMarketingPaused(client);
+    const result = await isMarketingPaused('user-123', client);
     expect(result).toBe(true);
   });
 
   it('returns false when marketing_pause_enabled = false → booking not paused', async () => {
     const client = makeClient({ marketing_pause_enabled: false });
-    const result = await isMarketingPaused(client);
+    const result = await isMarketingPaused('user-123', client);
     expect(result).toBe(false);
   });
 
-  it('fails open (returns false) when GrowthBook SDK throws → do not accidentally pause all bookings', async () => {
-    const client = makeClient({}, true /* throws */);
-    const result = await isMarketingPaused(client);
-    expect(result).toBe(false); // fail safe — never pause due to SDK error
+  it('fails open (returns false) when GrowthBook init resolves with success=false (real SDK timeout)', async () => {
+    const client = makeClient({}, 'sdk-timeout');
+    const result = await isMarketingPaused('user-123', client);
+    expect(result).toBe(false); // fail safe — never accidentally pause bookings due to SDK issue
+  });
+
+  it('fails open (returns false) when GrowthBook init throws unexpectedly', async () => {
+    const client = makeClient({}, 'throws');
+    const result = await isMarketingPaused('user-123', client);
+    expect(result).toBe(false);
   });
 
   it('returns false when GROWTHBOOK_CLIENT_KEY is empty → local-dev is never paused', async () => {
     delete process.env[ENV_KEY];
-    const result = await isMarketingPaused();
+    const result = await isMarketingPaused('user-123');
     expect(result).toBe(false);
   });
 });

--- a/api/tests/unit/launch-gate.test.ts
+++ b/api/tests/unit/launch-gate.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isSoftLaunchEnabled, isMarketingPaused, type FeatureFlagClient } from '../../src/services/featureFlags.service.js';
+
+const ENV_KEY = 'GROWTHBOOK_CLIENT_KEY';
+const savedKey = process.env[ENV_KEY];
+
+function makeClient(flags: Record<string, boolean>, throws = false): FeatureFlagClient {
+  return {
+    loadFeatures: throws
+      ? vi.fn().mockRejectedValue(new Error('GrowthBook SDK timeout'))
+      : vi.fn().mockResolvedValue(undefined),
+    isOn: vi.fn((flag: string) => flags[flag] ?? false),
+  };
+}
+
+beforeEach(() => {
+  process.env[ENV_KEY] = 'test-key';
+});
+
+afterEach(() => {
+  if (savedKey === undefined) {
+    delete process.env[ENV_KEY];
+  } else {
+    process.env[ENV_KEY] = savedKey;
+  }
+});
+
+describe('isSoftLaunchEnabled', () => {
+  it('returns false when soft_launch_enabled = false → createBooking must return 503 SERVICE_UNAVAILABLE', async () => {
+    const client = makeClient({ soft_launch_enabled: false });
+    const result = await isSoftLaunchEnabled(client);
+    expect(result).toBe(false);
+  });
+
+  it('returns true when soft_launch_enabled = true → booking flow proceeds normally', async () => {
+    const client = makeClient({ soft_launch_enabled: true });
+    const result = await isSoftLaunchEnabled(client);
+    expect(result).toBe(true);
+  });
+
+  it('fails open when GrowthBook SDK throws → booking proceeds (SDK failure must not block users)', async () => {
+    const client = makeClient({}, true /* throws */);
+    const result = await isSoftLaunchEnabled(client);
+    expect(result).toBe(true); // fail open
+  });
+
+  it('returns true when GROWTHBOOK_CLIENT_KEY is empty → local-dev passthrough (no GrowthBook call)', async () => {
+    delete process.env[ENV_KEY];
+    // No client passed — uses module singleton path, which bails early when key is missing
+    const result = await isSoftLaunchEnabled();
+    expect(result).toBe(true);
+  });
+});
+
+describe('isMarketingPaused', () => {
+  it('returns true when marketing_pause_enabled = true → 503 TEMPORARILY_UNAVAILABLE even during soft launch', async () => {
+    const client = makeClient({ marketing_pause_enabled: true });
+    const result = await isMarketingPaused(client);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when marketing_pause_enabled = false → booking not paused', async () => {
+    const client = makeClient({ marketing_pause_enabled: false });
+    const result = await isMarketingPaused(client);
+    expect(result).toBe(false);
+  });
+
+  it('fails open (returns false) when GrowthBook SDK throws → do not accidentally pause all bookings', async () => {
+    const client = makeClient({}, true /* throws */);
+    const result = await isMarketingPaused(client);
+    expect(result).toBe(false); // fail safe — never pause due to SDK error
+  });
+
+  it('returns false when GROWTHBOOK_CLIENT_KEY is empty → local-dev is never paused', async () => {
+    delete process.env[ENV_KEY];
+    const result = await isMarketingPaused();
+    expect(result).toBe(false);
+  });
+});

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -1,0 +1,54 @@
+# Home Heroo — Soft Launch Checklist
+
+**Version:** 1.0 (E10-S04)
+**Owner:** Alok Tiwari
+**Last updated:** 2026-04-29
+
+---
+
+## Environment (verify before enabling `soft_launch_enabled`)
+
+- [ ] `GROWTHBOOK_CLIENT_KEY` set in Azure Functions app settings
+- [ ] `GROWTHBOOK_API_HOST` set (default: `https://cdn.growthbook.io`)
+- [ ] `RAZORPAY_KEY_ID` + `RAZORPAY_KEY_SECRET` set (production keys, not test)
+- [ ] `RAZORPAY_WEBHOOK_SECRET` set
+- [ ] `COSMOS_PAN_ENCRYPTION_KEY` set (`openssl rand -base64 32`)
+- [ ] `ADMIN_SETUP_SECRET` set (first run only — remove after TOTP enrollment)
+- [ ] Firebase project: production app registered, SHA-256 cert added
+- [ ] GrowthBook: `soft_launch_enabled = false` initially (gate closed until go-live)
+- [ ] GrowthBook: `marketing_pause_enabled = false` (not paused)
+
+---
+
+## Pre-launch smoke (day of launch)
+
+- [ ] Create 1 test booking end-to-end: customer → tech job offer → complete → payout
+- [ ] Verify earnings dashboard shows the test booking with correct amounts
+- [ ] Verify no Sentry errors in last 1 hour
+- [ ] Verify GrowthBook dashboard reachable and flag states correct
+- [ ] Verify admin-web login works (TOTP enrolled)
+- [ ] Confirm Razorpay Route account is live (not test mode)
+
+---
+
+## Go-live
+
+- [ ] Enable `soft_launch_enabled = true` in GrowthBook
+- [ ] Send first F&F batch invite (100 users max for soft launch)
+- [ ] Monitor Sentry for 30 minutes post-launch
+- [ ] Monitor admin dashboard for booking activity and dispatch health
+- [ ] Verify at least 1 real booking completes successfully
+
+---
+
+## Rollback trigger criteria
+
+Immediately disable `soft_launch_enabled` in GrowthBook if any of these occur:
+
+- Sentry error rate > 5% of requests over a 10-minute window
+- Payment webhook failures > 2 in any 10-minute window
+- Tech FCM delivery rate < 80% over 30 minutes
+- Any unhandled exception reaching production Sentry for the first time
+- Owner admin becomes inaccessible
+
+See `docs/runbook.md § Emergency rollback` for the step-by-step procedure.

--- a/docs/reviews/codex-20260429-1622.md
+++ b/docs/reviews/codex-20260429-1622.md
@@ -1,0 +1,2387 @@
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: none
+reasoning summaries: none
+session id: 019ddae8-636d-77b3-8698-de95c82fc4e8
+--------
+user
+changes against 'main'
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'git diff eb6c5c81cb810872af4434ed7d46b1e0fa30aa44' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 158ms:
+diff --git a/.github/workflows/api-ship.yml b/.github/workflows/api-ship.yml
+index a60aea3..75af55b 100644
+--- a/.github/workflows/api-ship.yml
++++ b/.github/workflows/api-ship.yml
+@@ -60,6 +60,12 @@ jobs:
+       - name: openapi spec quality (spectral — contract lint)
+         run: pnpm run openapi:lint
+ 
++      - name: verify launch env vars configured
++        run: |
++          if [ -z "${{ secrets.GROWTHBOOK_CLIENT_KEY }}" ]; then
++            echo "::warning::GROWTHBOOK_CLIENT_KEY not set in repository secrets — soft_launch_enabled flag will not work"
++          fi
++
+       - name: semgrep SAST
+         uses: returntocorp/semgrep-action@v1
+         with:
+diff --git a/api/local.settings.example.json b/api/local.settings.example.json
+index daa23cd..e52a81b 100644
+--- a/api/local.settings.example.json
++++ b/api/local.settings.example.json
+@@ -7,6 +7,8 @@
+     "ACS_CONNECTION_STRING": "<azure-communication-services-connection-string>",
+     "ACS_SENDER_ADDRESS": "DoNotReply@<domain>.azurecomm.net",
+     "SSC_OWNER_EMAIL": "<owner-email@example.com>",
+-    "COSMOS_CONNECTION_STRING": "<azure-cosmos-db-connection-string>"
++    "COSMOS_CONNECTION_STRING": "<azure-cosmos-db-connection-string>",
++    "GROWTHBOOK_API_HOST": "https://cdn.growthbook.io",
++    "GROWTHBOOK_CLIENT_KEY": ""
+   }
+ }
+diff --git a/api/src/functions/bookings.ts b/api/src/functions/bookings.ts
+index 78285c6..fc4d20a 100644
+--- a/api/src/functions/bookings.ts
++++ b/api/src/functions/bookings.ts
+@@ -11,8 +11,16 @@ import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+ import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
+ import { sendPriceApprovalPush } from '../services/fcm.service.js';
+ import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
++import { isSoftLaunchEnabled, isMarketingPaused } from '../services/featureFlags.service.js';
+ 
+ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
++  if (!(await isSoftLaunchEnabled())) {
++    return { status: 503, jsonBody: { code: 'SERVICE_UNAVAILABLE', message: 'Launch coming soon' } };
++  }
++  if (await isMarketingPaused()) {
++    return { status: 503, jsonBody: { code: 'TEMPORARILY_UNAVAILABLE', message: 'We are pausing new bookings briefly' } };
++  }
++
+   const body = await req.json().catch(() => null);
+   const parsed = CreateBookingRequestSchema.safeParse(body);
+   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+diff --git a/api/src/services/featureFlags.service.ts b/api/src/services/featureFlags.service.ts
+new file mode 100644
+index 0000000..12bc127
+--- /dev/null
++++ b/api/src/services/featureFlags.service.ts
+@@ -0,0 +1,53 @@
++import { GrowthBook } from '@growthbook/growthbook';
++
++export type FeatureFlagClient = Pick<GrowthBook, 'loadFeatures' | 'isOn'>;
++
++// Module-level singleton — shared across invocations within the same Function App instance.
++// Created lazily on first call so the missing-key guard runs at call time, not module load time.
++let _singleton: FeatureFlagClient | null = null;
++
++function getSingleton(): FeatureFlagClient {
++  if (!_singleton) {
++    _singleton = new GrowthBook({
++      apiHost: process.env['GROWTHBOOK_API_HOST'] ?? 'https://cdn.growthbook.io',
++      clientKey: process.env['GROWTHBOOK_CLIENT_KEY'] ?? '',
++    });
++  }
++  return _singleton;
++}
++
++/**
++ * Returns true when bookings should be accepted.
++ * Fail-open contract: SDK timeout or error → return true (allow booking).
++ * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return true (skip flag entirely).
++ *
++ * @param client - injectable for testing; defaults to module singleton
++ */
++export async function isSoftLaunchEnabled(client?: FeatureFlagClient): Promise<boolean> {
++  if (!process.env['GROWTHBOOK_CLIENT_KEY']) return true; // local dev — fail open
++  const gb = client ?? getSingleton();
++  try {
++    await gb.loadFeatures({ timeout: 1000 });
++    return gb.isOn('soft_launch_enabled');
++  } catch {
++    return true; // SDK failure must never block bookings
++  }
++}
++
++/**
++ * Returns true when the owner has manually paused new bookings (e.g. surge / incident).
++ * Fail-open contract: SDK timeout or error → return false (do not accidentally pause).
++ * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return false (never paused locally).
++ *
++ * @param client - injectable for testing; defaults to module singleton
++ */
++export async function isMarketingPaused(client?: FeatureFlagClient): Promise<boolean> {
++  if (!process.env['GROWTHBOOK_CLIENT_KEY']) return false; // local dev — never paused
++  const gb = client ?? getSingleton();
++  try {
++    await gb.loadFeatures({ timeout: 1000 });
++    return gb.isOn('marketing_pause_enabled');
++  } catch {
++    return false; // SDK failure must never accidentally pause bookings
++  }
++}
+diff --git a/api/tests/unit/launch-gate.test.ts b/api/tests/unit/launch-gate.test.ts
+new file mode 100644
+index 0000000..19d55ce
+--- /dev/null
++++ b/api/tests/unit/launch-gate.test.ts
+@@ -0,0 +1,79 @@
++import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
++import { isSoftLaunchEnabled, isMarketingPaused, type FeatureFlagClient } from '../../src/services/featureFlags.service.js';
++
++const ENV_KEY = 'GROWTHBOOK_CLIENT_KEY';
++const savedKey = process.env[ENV_KEY];
++
++function makeClient(flags: Record<string, boolean>, throws = false): FeatureFlagClient {
++  return {
++    loadFeatures: throws
++      ? vi.fn().mockRejectedValue(new Error('GrowthBook SDK timeout'))
++      : vi.fn().mockResolvedValue(undefined),
++    isOn: vi.fn((flag: string) => flags[flag] ?? false),
++  };
++}
++
++beforeEach(() => {
++  process.env[ENV_KEY] = 'test-key';
++});
++
++afterEach(() => {
++  if (savedKey === undefined) {
++    delete process.env[ENV_KEY];
++  } else {
++    process.env[ENV_KEY] = savedKey;
++  }
++});
++
++describe('isSoftLaunchEnabled', () => {
++  it('returns false when soft_launch_enabled = false → createBooking must return 503 SERVICE_UNAVAILABLE', async () => {
++    const client = makeClient({ soft_launch_enabled: false });
++    const result = await isSoftLaunchEnabled(client);
++    expect(result).toBe(false);
++  });
++
++  it('returns true when soft_launch_enabled = true → booking flow proceeds normally', async () => {
++    const client = makeClient({ soft_launch_enabled: true });
++    const result = await isSoftLaunchEnabled(client);
++    expect(result).toBe(true);
++  });
++
++  it('fails open when GrowthBook SDK throws → booking proceeds (SDK failure must not block users)', async () => {
++    const client = makeClient({}, true /* throws */);
++    const result = await isSoftLaunchEnabled(client);
++    expect(result).toBe(true); // fail open
++  });
++
++  it('returns true when GROWTHBOOK_CLIENT_KEY is empty → local-dev passthrough (no GrowthBook call)', async () => {
++    delete process.env[ENV_KEY];
++    // No client passed — uses module singleton path, which bails early when key is missing
++    const result = await isSoftLaunchEnabled();
++    expect(result).toBe(true);
++  });
++});
++
++describe('isMarketingPaused', () => {
++  it('returns true when marketing_pause_enabled = true → 503 TEMPORARILY_UNAVAILABLE even during soft launch', async () => {
++    const client = makeClient({ marketing_pause_enabled: true });
++    const result = await isMarketingPaused(client);
++    expect(result).toBe(true);
++  });
++
++  it('returns false when marketing_pause_enabled = false → booking not paused', async () => {
++    const client = makeClient({ marketing_pause_enabled: false });
++    const result = await isMarketingPaused(client);
++    expect(result).toBe(false);
++  });
++
++  it('fails open (returns false) when GrowthBook SDK throws → do not accidentally pause all bookings', async () => {
++    const client = makeClient({}, true /* throws */);
++    const result = await isMarketingPaused(client);
++    expect(result).toBe(false); // fail safe — never pause due to SDK error
++  });
++
++  it('returns false when GROWTHBOOK_CLIENT_KEY is empty → local-dev is never paused', async () => {
++    delete process.env[ENV_KEY];
++    const result = await isMarketingPaused();
++    expect(result).toBe(false);
++  });
++});
+diff --git a/docs/launch-checklist.md b/docs/launch-checklist.md
+new file mode 100644
+index 0000000..6c01543
+--- /dev/null
++++ b/docs/launch-checklist.md
+@@ -0,0 +1,54 @@
++# Home Heroo — Soft Launch Checklist
++
++**Version:** 1.0 (E10-S04)
++**Owner:** Alok Tiwari
++**Last updated:** 2026-04-29
++
++---
++
++## Environment (verify before enabling `soft_launch_enabled`)
++
++- [ ] `GROWTHBOOK_CLIENT_KEY` set in Azure Functions app settings
++- [ ] `GROWTHBOOK_API_HOST` set (default: `https://cdn.growthbook.io`)
++- [ ] `RAZORPAY_KEY_ID` + `RAZORPAY_KEY_SECRET` set (production keys, not test)
++- [ ] `RAZORPAY_WEBHOOK_SECRET` set
++- [ ] `COSMOS_PAN_ENCRYPTION_KEY` set (`openssl rand -base64 32`)
++- [ ] `ADMIN_SETUP_SECRET` set (first run only — remove after TOTP enrollment)
++- [ ] Firebase project: production app registered, SHA-256 cert added
++- [ ] GrowthBook: `soft_launch_enabled = false` initially (gate closed until go-live)
++- [ ] GrowthBook: `marketing_pause_enabled = false` (not paused)
++
++---
++
++## Pre-launch smoke (day of launch)
++
++- [ ] Create 1 test booking end-to-end: customer → tech job offer → complete → payout
++- [ ] Verify earnings dashboard shows the test booking with correct amounts
++- [ ] Verify no Sentry errors in last 1 hour
++- [ ] Verify GrowthBook dashboard reachable and flag states correct
++- [ ] Verify admin-web login works (TOTP enrolled)
++- [ ] Confirm Razorpay Route account is live (not test mode)
++
++---
++
++## Go-live
++
++- [ ] Enable `soft_launch_enabled = true` in GrowthBook
++- [ ] Send first F&F batch invite (100 users max for soft launch)
++- [ ] Monitor Sentry for 30 minutes post-launch
++- [ ] Monitor admin dashboard for booking activity and dispatch health
++- [ ] Verify at least 1 real booking completes successfully
++
++---
++
++## Rollback trigger criteria
++
++Immediately disable `soft_launch_enabled` in GrowthBook if any of these occur:
++
++- Sentry error rate > 5% of requests over a 10-minute window
++- Payment webhook failures > 2 in any 10-minute window
++- Tech FCM delivery rate < 80% over 30 minutes
++- Any unhandled exception reaching production Sentry for the first time
++- Owner admin becomes inaccessible
++
++See `docs/runbook.md § Emergency rollback` for the step-by-step procedure.
+diff --git a/docs/runbook.md b/docs/runbook.md
+index 002c669..10b9568 100644
+--- a/docs/runbook.md
++++ b/docs/runbook.md
+@@ -465,5 +465,145 @@ After enrollment is confirmed:
+ | `409 ALREADY_ENROLLED` | Owner already completed setup | Setup is done — no action needed |
+ | `401 SETUP_TOKEN_INVALID` | Setup JWT expired (15 min TTL) | Re-login to get a new setup token |
+ 
+-**Runbook v1.1 complete (DPDP §10 breach playbook + admin setup procedure).**
++---
++
++## Emergency Rollback
++
++**Trigger:** Sentry error rate > 5%, payment webhook failures > 2/10 min, FCM delivery < 80%/30 min, or any unhandled first-time exception in production.
++
++**Estimated time: < 15 minutes from detection to user impact ended.**
++
++### Step 1 — Disable soft_launch_enabled (immediate user impact ended)
++
++In GrowthBook dashboard → Feature Flags → `soft_launch_enabled` → set to `false`.
++
++All new booking creation attempts immediately return:
++```json
++{ "code": "SERVICE_UNAVAILABLE", "message": "Launch coming soon" }
++```
++Customers see "coming soon" instead of an error. No data is written.
++
++### Step 2 — Triage in-flight bookings
++
++For any bookings currently in `PAID` or `SEARCHING` state:
++- Open admin-web → Orders → filter by status `SEARCHING`
++- Owner manually closes or refunds via admin override panel
++- Razorpay Route payouts for `COMPLETED` bookings continue automatically (unaffected)
++
++### Step 3 — Revert the bad commit (if code regression)
++
++```bash
++git log --oneline origin/main | head -5    # identify the bad SHA
++git revert -m 1 <sha>                      # creates a revert commit
++git push origin HEAD:feature/revert-<sha>  # push to a new branch
++# Open PR → CI green → merge
++```
++
++Do NOT force-push to main. Use revert + PR.
++
++### Step 4 — Re-enable after root cause fixed
++
++Once the fix is deployed and smoke-tested:
++- GrowthBook → `soft_launch_enabled` → set to `true`
++- Monitor Sentry for 10 minutes
++- Notify F&F users via admin FCM broadcast (topic: `all_customers`)
++
++---
++
++## Launch Checklist
++
++Required env vars before enabling `soft_launch_enabled`:
++
++| Env var | Where set | Note |
++|---|---|---|
++| `GROWTHBOOK_CLIENT_KEY` | Azure Functions app settings | Required for soft-launch flag to work |
++| `GROWTHBOOK_API_HOST` | Azure Functions app settings | Default: `https://cdn.growthbook.io` |
++| `RAZORPAY_KEY_ID` | Azure Functions app settings | Production key (not test) |
++| `RAZORPAY_KEY_SECRET` | Azure Functions app settings | Production key (not test) |
++| `RAZORPAY_WEBHOOK_SECRET` | Azure Functions app settings | For webhook signature validation |
++| `COSMOS_PAN_ENCRYPTION_KEY` | Azure Functions app settings | `openssl rand -base64 32` |
++| `ADMIN_SETUP_SECRET` | Azure Functions app settings | First-run only — remove after TOTP enrollment |
++
++See `docs/launch-checklist.md` for the full pre-launch checklist.
++
++---
++
++## Disaster Recovery Drill
++
++**Run this drill 1–2 weeks before launch to confirm recovery procedures work.**
++
++### 1. Cosmos DB restore (point-in-time)
++
++Azure Cosmos DB Serverless has continuous backup enabled by default.
++
++**Procedure:**
++1. Azure Portal → Cosmos DB account → Backups → Restore
++2. Select timestamp (up to 30 days back)
++3. Restore to a new account (restoration is non-destructive — original account remains)
++4. Verify document counts and spot-check data integrity
++5. DNS/connection string cutover: Azure Functions → Configuration → `COSMOS_CONNECTION_STRING` → update to new account endpoint
++6. Restart Function App to pick up new connection string
++
++**Estimated RTO:**
++- Full restore: 2–4 hours (depends on data volume)
++- Connection string cutover: 30 minutes (if restore already complete)
++
++**Drill:** Restore to a test Cosmos account, verify 5 sample bookings match production, then delete the test account.
++
++### 2. Azure Functions cold-start recovery
++
++If Functions are unresponsive (HTTP 5xx or no response):
++
++```bash
++# Portal path:
++# Azure Portal → Function App → Overview → Restart
++
++# CLI (faster):
++az functionapp restart --name <app-name> --resource-group <resource-group>
++```
++
++**Estimated RTO:** < 5 minutes (Functions restart and warm up within 2–3 cold-start invocations)
++
++**Drill:** Restart the staging Function App and verify `GET /api/health` returns 200 within 60 seconds.
++
++### 3. Firebase Auth outage
++
++Firebase Phone Auth is Google-managed infrastructure.
++
++**During outage:**
++- Existing sessions (Firebase JWT / persistent token) continue to work — customers mid-flow are unaffected
++- New logins fail with `auth/network-request-failed` → customer-app shows "Please try again later" message
++- No owner action needed
++
++**Resolution:** Monitor [Firebase Status](https://status.firebase.google.com). Firebase has 99.9% monthly uptime SLA.
++
++**Owner action:** None. If outage > 1 hour, post in-app maintenance banner via admin FCM broadcast.
++
++### 4. FCM outage
++
++FCM is Google-managed infrastructure.
++
++**During outage:**
++- Job offers not delivered via push → technicians must manually check the app for new jobs
++- Owner FCM alerts not delivered → owner monitors admin dashboard directly
++- `dispatcher.service.ts` logs `FCM_DELIVERY_FAILED` to Sentry — confirms outage is FCM-side
++
++**Resolution:** None needed. FCM has 99.9% SLA. Bookings and payments are unaffected.
++
++**Owner action:** Notify active technicians via SMS (manual, out-of-band) if outage > 30 minutes.
++
++### 5. Razorpay Route outage
++
++**During outage:**
++- Payout disbursements via Route will fail
++- `trigger-booking-completed.ts` captures Route errors to Sentry (`RazorpayRoutePayoutFailed`)
++- Settled amounts stay in `PENDING` state in `wallet_ledger` entries — **idempotent and safe to retry**
++
++**Resolution:** When Route recovers, `trigger-reconcile-payouts.ts` automatically retries all `FAILED` ledger entries on its next scheduled run (every 6 hours).
++
++**Owner action:**
++- Monitor `/v1/admin/finance/payout-queue` for stuck `PENDING` entries
++- If entries remain stuck > 24 hours after Route recovery, manually trigger `trigger-reconcile-payouts` from Azure Portal → Functions → Run
++
++**Runbook v1.2 complete (E10-S04: Emergency rollback + DR drill + launch checklist).**
+ Living document — update after every incident and every significant architectural change.
+diff --git a/docs/stories/E10-S04-launch-readiness-gate.md b/docs/stories/E10-S04-launch-readiness-gate.md
+new file mode 100644
+index 0000000..aaaccd2
+--- /dev/null
++++ b/docs/stories/E10-S04-launch-readiness-gate.md
+@@ -0,0 +1,91 @@
++# E10-S04 — Launch Readiness Gate
++
++**Epic:** E10 — Compliance & Launch Hardening
++**Story ID:** E10-S04
++**Ceremony tier:** Foundation
++**Status:** Implemented (2026-04-29)
++**Branch:** `feature/E10-S04-launch-gate`
++
++---
++
++## User Story
++
++As the platform owner,
++I want a soft-launch gate that limits bookings to 100 F&F users, a marketing-pause
++toggle, and a tested rollback procedure,
++so that I can launch confidently, catch issues early, and reverse course without
++data loss if something goes wrong.
++
++---
++
++## Acceptance Criteria
++
++| AC | Description | Status |
++|---|---|---|
++| AC-1 | GrowthBook `soft_launch_enabled` flag gates `createBooking`; fail-open on SDK error | ✅ |
++| AC-2 | `marketing_pause_enabled` flag for owner-controlled booking pause (checked after AC-1) | ✅ |
++| AC-3 | Emergency rollback playbook in `docs/runbook.md` + automated test for flag=false → 503 | ✅ |
++| AC-4 | DR drill documentation in `docs/runbook.md` (Cosmos, Functions, Firebase, FCM, Razorpay) | ✅ |
++| AC-5 | `docs/launch-checklist.md` with env-var checklist, pre-launch smoke, go-live, and rollback triggers | ✅ |
++| AC-6 | `api-ship.yml` warning step if `GROWTHBOOK_CLIENT_KEY` secret is missing | ✅ |
++
++---
++
++## Files Created
++
++| File | Purpose |
++|---|---|
++| `api/src/services/featureFlags.service.ts` | GrowthBook wrapper: `isSoftLaunchEnabled`, `isMarketingPaused` |
++| `api/tests/unit/launch-gate.test.ts` | 8 unit tests (TDD-first, all green) |
++| `docs/launch-checklist.md` | Full pre-launch checklist for go-live day |
++| `docs/stories/E10-S04-launch-readiness-gate.md` | This file |
++
++## Files Modified
++
++| File | Change |
++|---|---|
++| `api/src/functions/bookings.ts` | Added flag checks at top of `createHandler` |
++| `api/local.settings.example.json` | Added `GROWTHBOOK_API_HOST` + `GROWTHBOOK_CLIENT_KEY` placeholders |
++| `docs/runbook.md` | Added § Emergency Rollback + § Launch Checklist + § Disaster Recovery Drill |
++| `.github/workflows/api-ship.yml` | Added env-var warning step (AC-6) |
++
++---
++
++## Key Design Decisions
++
++### Fail-open contract
++
++`isSoftLaunchEnabled()` returns `true` (allow booking) on:
++- GrowthBook SDK timeout or throw
++- Empty `GROWTHBOOK_CLIENT_KEY` (local dev)
++
++This means a broken flags SDK never blocks the platform.
++
++### marketing_pause checked AFTER soft_launch
++
++Order matters: `soft_launch_enabled = false` takes precedence with a "coming soon" message. `marketing_pause_enabled = true` overrides an open soft launch with a "pausing briefly" message. The owner can always close the gate harder (via soft_launch) or softer (via marketing_pause).
++
++### DI pattern for testability
++
++`isSoftLaunchEnabled(client?)` and `isMarketingPaused(client?)` accept an optional `FeatureFlagClient` for dependency injection in tests, defaulting to the module singleton. No `vi.mock` of `@growthbook/growthbook` required — tests pass a mock client directly.
++
++### local.settings.json is gitignored
++
++`api/local.settings.json` is in `.gitignore` (Azure Functions convention). The new env vars are documented in `api/local.settings.example.json`. Local dev with empty `GROWTHBOOK_CLIENT_KEY` automatically fails open (never calls GrowthBook, never blocks bookings).
++
++---
++
++## TDD Summary
++
++Tests written first (`launch-gate.test.ts`) → service implemented → all 8 tests green → bookings.ts wired → full suite re-run.
++
++```
++✓ isSoftLaunchEnabled > returns false when soft_launch_enabled = false
++✓ isSoftLaunchEnabled > returns true when soft_launch_enabled = true
++✓ isSoftLaunchEnabled > fails open when GrowthBook SDK throws
++✓ isSoftLaunchEnabled > returns true when GROWTHBOOK_CLIENT_KEY is empty
++✓ isMarketingPaused > returns true when marketing_pause_enabled = true
++✓ isMarketingPaused > returns false when marketing_pause_enabled = false
++✓ isMarketingPaused > fails open (returns false) when GrowthBook SDK throws
++✓ isMarketingPaused > returns false when GROWTHBOOK_CLIENT_KEY is empty
++```
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-ChildItem; Get-Content api/package.json' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 207ms:
+
+
+    Directory: C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+
+
+Mode                 LastWriteTime         Length Name                                                                 
+----                 -------------         ------ ----                                                                 
+d-----         4/29/2026   4:14 PM                .githooks                                                            
+d-----         4/29/2026   4:14 PM                .github                                                              
+d-----         4/29/2026   4:14 PM                .serena                                                              
+d-----         4/29/2026   4:14 PM                admin-web                                                            
+d-----         4/29/2026   4:21 PM                api                                                                  
+d-----         4/29/2026   4:14 PM                customer-app                                                         
+d-----         4/29/2026   4:14 PM                design-system                                                        
+d-----         4/29/2026   4:20 PM                docs                                                                 
+d-----         4/29/2026   4:14 PM                figma                                                                
+d-----         4/29/2026   4:14 PM                firebase                                                             
+d-----         4/29/2026   4:14 PM                plans                                                                
+d-----         4/29/2026   4:14 PM                technician-app                                                       
+d-----         4/29/2026   4:14 PM                tools                                                                
+d-----         4/29/2026   4:14 PM                _bmad                                                                
+d-----         4/29/2026   4:14 PM                _bmad-output                                                         
+-a----         4/29/2026   4:14 PM             26 .bmad-readiness-passed                                               
+-a----         4/29/2026   4:14 PM            225 .codex-review-passed                                                 
+-a----         4/29/2026   4:14 PM           1400 .codex-review-passed-manual                                          
+-a----         4/29/2026   4:14 PM            659 .gitattributes                                                       
+-a----         4/29/2026   4:14 PM           2691 .gitignore                                                           
+-a----         4/29/2026   4:14 PM            694 .semgrepignore                                                       
+-a----         4/29/2026   4:14 PM          13261 CLAUDE.md                                                            
+-a----         4/29/2026   4:14 PM           5369 TOKEN-SYNC.md                                                        
+{
+  "name": "homeservices-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@9.15.4",
+  "main": "dist/functions/**/*.js",
+  "engines": {
+    "node": ">=22.0.0",
+    "pnpm": ">=9.0.0"
+  },
+  "scripts": {
+    "dev": "pnpm build && func start",
+    "dev:direct": "pnpm build && func start",
+    "dev:watch": "tsc --watch",
+    "build": "tsc",
+    "start": "func start",
+    "typecheck": "tsc --noEmit -p tsconfig.tests.json",
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "openapi:build": "tsx src/openapi/build.ts",
+    "openapi:lint": "spectral lint openapi.json --fail-severity error",
+    "seed:technicians": "npx tsx scripts/seed-technicians.ts",
+    "seed:catalogue": "tsx src/cosmos/seeds/catalogue.ts",
+    "seed:complaints": "tsx src/cosmos/seeds/complaints.ts"
+  },
+  "dependencies": {
+    "@azure/ai-form-recognizer": "^5.1.0",
+    "@azure/communication-email": "^1.1.0",
+    "@azure/cosmos": "^4.9.2",
+    "@azure/functions": "^4.5.0",
+    "@growthbook/growthbook": "^1",
+    "@sentry/node": "^8",
+    "fastify": "^5",
+    "firebase-admin": "^13.8.0",
+    "jose": "^6.2.2",
+    "otplib": "^13.4.0",
+    "pdfkit": "^0.18.0",
+    "posthog-node": "^4",
+    "qrcode": "^1.5.4",
+    "razorpay": "^2.9.6",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@apidevtools/swagger-parser": "^10.1.0",
+    "@asteasolutions/zod-to-openapi": "^7.3.0",
+    "@stoplight/spectral-cli": "^6.11.0",
+    "@types/node": "^22",
+    "@types/pdfkit": "^0.17.6",
+    "@types/qrcode": "^1.5.6",
+    "@vitest/coverage-v8": "^2",
+    "azure-functions-core-tools": "^4",
+    "eslint": "^9",
+    "eslint-plugin-import": "^2",
+    "prettier": "^3",
+    "supertest": "^7",
+    "testcontainers": "^10",
+    "tsx": "^4",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8",
+    "vitest": "^2"
+  }
+}
+
+
+
+2026-04-29T20:22:57.294164Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/src/functions/bookings.ts | Select-Object -First 220 | ForEach-Object {"{0,4}: {1}" -f ($global:i=$global:i+1), $_}'` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/src/functions/bookings.ts | Select-Object -First 220 | ForEach-Object {"{0,4}: {1}" -f ($global:i=$global:i+1), $_}' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/src/functions/bookings.ts | Select-Object -First 220 | ForEach-Object {"{0,4}: {1}" -f ($global:i=$global:i+1), $_}'` rejected: blocked by policy
+2026-04-29T20:23:00.530090Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$i=0; Get-Content -Path '"'api/src/functions/bookings.ts' | Select-Object -First 220 | ForEach-Object { "'$i++; '"'{0,4}: {1}' -f "'$i, $_ }'` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$i=0; Get-Content -Path '"'api/src/functions/bookings.ts' | Select-Object -First 220 | ForEach-Object { "'$i++; '"'{0,4}: {1}' -f "'$i, $_ }' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$i=0; Get-Content -Path '"'api/src/functions/bookings.ts' | Select-Object -First 220 | ForEach-Object { "'$i++; '"'{0,4}: {1}' -f "'$i, $_ }'` rejected: blocked by policy
+2026-04-29T20:23:03.814427Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "python - <<'PY'
+from pathlib import Path
+for i,l in enumerate(Path('api/src/functions/bookings.ts').read_text().splitlines(),1):
+    if i<=220: print(f'{i:4}: {l}')
+PY"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "python - <<'PY'
+from pathlib import Path
+for i,l in enumerate(Path('api/src/functions/bookings.ts').read_text().splitlines(),1):
+    if i<=220: print(f'{i:4}: {l}')
+PY" in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "python - <<'PY'
+from pathlib import Path
+for i,l in enumerate(Path('api/src/functions/bookings.ts').read_text().splitlines(),1):
+    if i<=220: print(f'{i:4}: {l}')
+PY"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/src/functions/bookings.ts' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 160ms:
+import { randomUUID } from 'node:crypto';
+import type { HttpHandler } from '@azure/functions';
+import { app } from '@azure/functions';
+import * as Sentry from '@sentry/node';
+import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
+import { RequestAddOnBodySchema, ApproveAddOnsBodySchema } from '../schemas/addon-approval.js';
+import { bookingRepo } from '../cosmos/booking-repository.js';
+import { createRazorpayOrder, verifyPaymentSignature } from '../services/razorpay.service.js';
+import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
+import { sendPriceApprovalPush } from '../services/fcm.service.js';
+import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+import { isSoftLaunchEnabled, isMarketingPaused } from '../services/featureFlags.service.js';
+
+const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  if (!(await isSoftLaunchEnabled())) {
+    return { status: 503, jsonBody: { code: 'SERVICE_UNAVAILABLE', message: 'Launch coming soon' } };
+  }
+  if (await isMarketingPaused()) {
+    return { status: 503, jsonBody: { code: 'TEMPORARILY_UNAVAILABLE', message: 'We are pausing new bookings briefly' } };
+  }
+
+  const body = await req.json().catch(() => null);
+  const parsed = CreateBookingRequestSchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+
+  const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
+  if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+
+  const order = await createRazorpayOrder({
+    amount: service.basePrice,
+    currency: 'INR',
+    receipt: `${customer.customerId}-${Date.now()}`,
+  });
+
+  const booking = await bookingRepo.createPending(parsed.data, customer.customerId, order.id, service.basePrice);
+  return { status: 201, jsonBody: { bookingId: booking.id, razorpayOrderId: order.id, amount: order.amount } };
+};
+
+const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const id = (req as unknown as { params: { id: string } }).params.id;
+  const body = await req.json().catch(() => null);
+  const parsed = ConfirmBookingRequestSchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+
+  const booking = await bookingRepo.getById(id);
+  if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+  if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+
+  if (!verifyPaymentSignature({
+    razorpayOrderId: parsed.data.razorpayOrderId,
+    razorpayPaymentId: parsed.data.razorpayPaymentId,
+    razorpaySignature: parsed.data.razorpaySignature,
+  })) return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+
+  const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
+  if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
+
+  // Only audit when this call actually performed the transition. If status is PAID the webhook
+  // already processed the booking â€” this is an idempotent confirm, not a new event.
+  if (confirmed.status === 'SEARCHING') {
+    const _ts = new Date().toISOString();
+    void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+  }
+
+  return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
+};
+
+export const createBookingHandler: HttpHandler = requireCustomer(createHandler);
+export const confirmBookingHandler: HttpHandler = requireCustomer(confirmHandler);
+
+const getBookingInner: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const id = (req as unknown as { params: { id: string } }).params.id;
+  const booking = await bookingRepo.getById(id);
+  if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+  if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+  return {
+    status: 200,
+    jsonBody: {
+      bookingId: booking.id, status: booking.status, amount: booking.amount,
+      finalAmount: booking.finalAmount ?? null,
+      pendingAddOns: booking.pendingAddOns ?? [],
+      approvedAddOns: booking.approvedAddOns ?? [],
+    },
+  };
+};
+export const getBookingHandler: HttpHandler = requireCustomer(getBookingInner);
+
+export const requestAddonHandler: HttpHandler = async (req, _ctx) => {
+  let uid: string;
+  try { ({ uid } = await verifyTechnicianToken(req)); }
+  catch { return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } }; }
+  const id = (req as unknown as { params: { id: string } }).params.id;
+  const booking = await bookingRepo.getById(id);
+  if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+  if (booking.technicianId !== uid) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+  const body = await req.json().catch(() => null);
+  const parsed = RequestAddOnBodySchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+  const updated = await bookingRepo.requestAddOn(id, parsed.data);
+  if (!updated) return { status: 409, jsonBody: { code: 'BOOKING_NOT_IN_PROGRESS' } };
+
+  try {
+    await sendPriceApprovalPush(booking.customerId, id);
+  } catch (err) {
+    console.error('[requestAddon] FCM push failed â€” booking is AWAITING_PRICE_APPROVAL but customer was not notified', { bookingId: id, err });
+  }
+
+  return { status: 200, jsonBody: { bookingId: updated.id, status: updated.status } };
+};
+
+const approveFinalPriceInner: CustomerHttpHandler = async (req, _ctx, customer) => {
+  const id = (req as unknown as { params: { id: string } }).params.id;
+  const body = await req.json().catch(() => null);
+  const parsed = ApproveAddOnsBodySchema.safeParse(body);
+  if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+  const updated = await bookingRepo.applyAddOnDecisions(id, customer.customerId, parsed.data.decisions);
+  if (!updated) return { status: 409, jsonBody: { code: 'BOOKING_NOT_AWAITING_APPROVAL' } };
+  return { status: 200, jsonBody: { bookingId: updated.id, status: updated.status, finalAmount: updated.finalAmount } };
+};
+export const approveFinalPriceHandler: HttpHandler = requireCustomer(approveFinalPriceInner);
+
+app.http('createBooking', { route: 'v1/bookings', methods: ['POST'], handler: createBookingHandler });
+app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: confirmBookingHandler });
+app.http('getBooking', { route: 'v1/bookings/{id}', methods: ['GET'], handler: getBookingHandler });
+app.http('requestAddon', { route: 'v1/bookings/{id}/request-addon', methods: ['POST'], handler: requestAddonHandler });
+app.http('approveFinalPrice', { route: 'v1/bookings/{id}/approve-final-price', methods: ['POST'], handler: approveFinalPriceHandler });
+
+2026-04-29T20:23:09.784504Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "cmd /c findstr /n \".\" api\\src\\services\\featureFlags.service.ts"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "cmd /c findstr /n \".\" api\\src\\services\\featureFlags.service.ts" in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "cmd /c findstr /n \".\" api\\src\\services\\featureFlags.service.ts"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/src/services/featureFlags.service.ts -Pattern '.*'" in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 220ms:
+
+api\src\services\featureFlags.service.ts:1:import { GrowthBook } from '@growthbook/growthbook';
+api\src\services\featureFlags.service.ts:2:
+api\src\services\featureFlags.service.ts:3:export type FeatureFlagClient = Pick<GrowthBook, 'loadFeatures' | 'isOn'>;
+api\src\services\featureFlags.service.ts:4:
+api\src\services\featureFlags.service.ts:5:// Module-level singleton — shared across invocations within the same 
+Function App instance.
+api\src\services\featureFlags.service.ts:6:// Created lazily on first call so the missing-key guard runs at call time, 
+not module load time.
+api\src\services\featureFlags.service.ts:7:let _singleton: FeatureFlagClient | null = null;
+api\src\services\featureFlags.service.ts:8:
+api\src\services\featureFlags.service.ts:9:function getSingleton(): FeatureFlagClient {
+api\src\services\featureFlags.service.ts:10:  if (!_singleton) {
+api\src\services\featureFlags.service.ts:11:    _singleton = new GrowthBook({
+api\src\services\featureFlags.service.ts:12:      apiHost: process.env['GROWTHBOOK_API_HOST'] ?? 
+'https://cdn.growthbook.io',
+api\src\services\featureFlags.service.ts:13:      clientKey: process.env['GROWTHBOOK_CLIENT_KEY'] ?? '',
+api\src\services\featureFlags.service.ts:14:    });
+api\src\services\featureFlags.service.ts:15:  }
+api\src\services\featureFlags.service.ts:16:  return _singleton;
+api\src\services\featureFlags.service.ts:17:}
+api\src\services\featureFlags.service.ts:18:
+api\src\services\featureFlags.service.ts:19:/**
+api\src\services\featureFlags.service.ts:20: * Returns true when bookings should be accepted.
+api\src\services\featureFlags.service.ts:21: * Fail-open contract: SDK timeout or error → return true (allow booking).
+api\src\services\featureFlags.service.ts:22: * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return true (skip 
+flag entirely).
+api\src\services\featureFlags.service.ts:23: *
+api\src\services\featureFlags.service.ts:24: * @param client - injectable for testing; defaults to module singleton
+api\src\services\featureFlags.service.ts:25: */
+api\src\services\featureFlags.service.ts:26:export async function isSoftLaunchEnabled(client?: FeatureFlagClient): 
+Promise<boolean> {
+api\src\services\featureFlags.service.ts:27:  if (!process.env['GROWTHBOOK_CLIENT_KEY']) return true; // local dev — 
+fail open
+api\src\services\featureFlags.service.ts:28:  const gb = client ?? getSingleton();
+api\src\services\featureFlags.service.ts:29:  try {
+api\src\services\featureFlags.service.ts:30:    await gb.loadFeatures({ timeout: 1000 });
+api\src\services\featureFlags.service.ts:31:    return gb.isOn('soft_launch_enabled');
+api\src\services\featureFlags.service.ts:32:  } catch {
+api\src\services\featureFlags.service.ts:33:    return true; // SDK failure must never block bookings
+api\src\services\featureFlags.service.ts:34:  }
+api\src\services\featureFlags.service.ts:35:}
+api\src\services\featureFlags.service.ts:36:
+api\src\services\featureFlags.service.ts:37:/**
+api\src\services\featureFlags.service.ts:38: * Returns true when the owner has manually paused new bookings (e.g. 
+surge / incident).
+api\src\services\featureFlags.service.ts:39: * Fail-open contract: SDK timeout or error → return false (do not 
+accidentally pause).
+api\src\services\featureFlags.service.ts:40: * Local-dev contract: empty GROWTHBOOK_CLIENT_KEY → return false (never 
+paused locally).
+api\src\services\featureFlags.service.ts:41: *
+api\src\services\featureFlags.service.ts:42: * @param client - injectable for testing; defaults to module singleton
+api\src\services\featureFlags.service.ts:43: */
+api\src\services\featureFlags.service.ts:44:export async function isMarketingPaused(client?: FeatureFlagClient): 
+Promise<boolean> {
+api\src\services\featureFlags.service.ts:45:  if (!process.env['GROWTHBOOK_CLIENT_KEY']) return false; // local dev — 
+never paused
+api\src\services\featureFlags.service.ts:46:  const gb = client ?? getSingleton();
+api\src\services\featureFlags.service.ts:47:  try {
+api\src\services\featureFlags.service.ts:48:    await gb.loadFeatures({ timeout: 1000 });
+api\src\services\featureFlags.service.ts:49:    return gb.isOn('marketing_pause_enabled');
+api\src\services\featureFlags.service.ts:50:  } catch {
+api\src\services\featureFlags.service.ts:51:    return false; // SDK failure must never accidentally pause bookings
+api\src\services\featureFlags.service.ts:52:  }
+api\src\services\featureFlags.service.ts:53:}
+
+
+
+2026-04-29T20:23:15.617055Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'pnpm -C api typecheck'` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'pnpm -C api typecheck' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'pnpm -C api typecheck'` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/tsconfig.json; Get-Content api/tsconfig.tests.json' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 145ms:
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}
+
+2026-04-29T20:23:24.191975Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Get-ChildItem api | Select-Object Name; Select-String -Path api/pnpm-lock.yaml -Pattern '@growthbook/growthbook' -Context 0,3"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Get-ChildItem api | Select-Object Name; Select-String -Path api/pnpm-lock.yaml -Pattern '@growthbook/growthbook' -Context 0,3" in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Get-ChildItem api | Select-Object Name; Select-String -Path api/pnpm-lock.yaml -Pattern '@growthbook/growthbook' -Context 0,3"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-ChildItem api' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 189ms:
+
+
+    Directory: C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api
+
+
+Mode                 LastWriteTime         Length Name                                                                 
+----                 -------------         ------ ----                                                                 
+d-----         4/29/2026   4:14 PM                .claude                                                              
+d-----         4/29/2026   4:14 PM                docs                                                                 
+d-----         4/29/2026   4:19 PM                node_modules                                                         
+d-----         4/29/2026   4:14 PM                plans                                                                
+d-----         4/29/2026   4:14 PM                scripts                                                              
+d-----         4/29/2026   4:14 PM                specs                                                                
+d-----         4/29/2026   4:14 PM                src                                                                  
+d-----         4/29/2026   4:14 PM                tests                                                                
+-a----         4/29/2026   4:14 PM            147 .editorconfig                                                        
+-a----         4/29/2026   4:14 PM              3 .nvmrc                                                               
+-a----         4/29/2026   4:14 PM             45 .prettierignore                                                      
+-a----         4/29/2026   4:14 PM             89 .prettierrc.json                                                     
+-a----         4/29/2026   4:14 PM           6974 .semgrep.yml                                                         
+-a----         4/29/2026   4:14 PM             26 .spectral.yaml                                                       
+-a----         4/29/2026   4:14 PM            744 CLAUDE.md                                                            
+-a----         4/29/2026   4:14 PM           1449 eslint.config.mjs                                                    
+-a----         4/29/2026   4:14 PM            289 host.json                                                            
+-a----         4/29/2026   4:19 PM            570 local.settings.example.json                                          
+-a----         4/29/2026   4:21 PM          57119 openapi.json                                                         
+-a----         4/29/2026   4:14 PM         486778 package-lock.json                                                    
+-a----         4/29/2026   4:14 PM           1898 package.json                                                         
+-a----         4/29/2026   4:14 PM         280702 pnpm-lock.yaml                                                       
+-a----         4/29/2026   4:14 PM           3923 README.md                                                            
+-a----         4/29/2026   4:14 PM            469 tsconfig.json                                                        
+-a----         4/29/2026   4:14 PM            166 tsconfig.tests.json                                                  
+-a----         4/29/2026   4:14 PM           3948 vitest.config.ts                                                     
+
+
+
+2026-04-29T20:23:29.761186Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/pnpm-lock.yaml -Pattern '@growthbook/growthbook' -Context 0,3"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/pnpm-lock.yaml -Pattern '@growthbook/growthbook' -Context 0,3" in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/pnpm-lock.yaml -Pattern '@growthbook/growthbook' -Context 0,3"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-ChildItem api/node_modules/@growthbook/growthbook/dist' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 201ms:
+
+
+    Directory: C:\Alok\Business 
+    Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\node_modules\@growthbook\growthbook\dist
+
+
+Mode                 LastWriteTime         Length Name                                                                 
+----                 -------------         ------ ----                                                                 
+d-----         4/29/2026   4:18 PM                bundles                                                              
+d-----         4/29/2026   4:18 PM                cjs                                                                  
+d-----         4/29/2026   4:18 PM                esm                                                                  
+d-----         4/29/2026   4:18 PM                plugins                                                              
+d-----         4/29/2026   4:18 PM                types                                                                
+-a----         4/17/2026  10:59 PM           1143 auto-wrapper.d.ts                                                    
+-a----         4/17/2026  10:59 PM           1248 auto-wrapper.d.ts.map                                                
+-a----         4/17/2026  10:59 PM           1987 core.d.ts                                                            
+-a----         4/17/2026  10:59 PM           1786 core.d.ts.map                                                        
+-a----         4/17/2026  10:59 PM           1095 feature-repository.d.ts                                              
+-a----         4/17/2026  10:59 PM           1008 feature-repository.d.ts.map                                          
+-a----         4/17/2026  10:59 PM           6000 GrowthBook.d.ts                                                      
+-a----         4/17/2026  10:59 PM           4455 GrowthBook.d.ts.map                                                  
+-a----         4/17/2026  10:59 PM           4319 GrowthBookClient.d.ts                                                
+-a----         4/17/2026  10:59 PM           3743 GrowthBookClient.d.ts.map                                            
+-a----         4/17/2026  10:59 PM           1902 index.d.ts                                                           
+-a----         4/17/2026  10:59 PM           1385 index.d.ts.map                                                       
+-a----         4/17/2026  10:59 PM            288 mongrule.d.ts                                                        
+-a----         4/17/2026  10:59 PM            315 mongrule.d.ts.map                                                    
+-a----         4/17/2026  10:59 PM           5259 sticky-bucket-service.d.ts                                           
+-a----         4/17/2026  10:59 PM           3536 sticky-bucket-service.d.ts.map                                       
+-a----         4/17/2026  10:59 PM           1668 util.d.ts                                                            
+-a----         4/17/2026  10:59 PM           1561 util.d.ts.map                                                        
+
+
+
+2026-04-29T20:23:35.575155Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/node_modules/@growthbook/growthbook/dist/GrowthBook.d.ts -Pattern 'loadFeatures' -Context 1,2"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/node_modules/@growthbook/growthbook/dist/GrowthBook.d.ts -Pattern 'loadFeatures' -Context 1,2" in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/node_modules/@growthbook/growthbook/dist/GrowthBook.d.ts -Pattern 'loadFeatures' -Context 1,2"` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/GrowthBook.d.ts' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 150ms:
+import type { ApiHost, Attributes, AutoExperiment, AutoExperimentVariation, ClientKey, Options, Experiment, FeatureApiResponse, FeatureDefinition, FeatureResult, FeatureUsageCallback, LoadFeaturesOptions, RefreshFeaturesOptions, RenderFunction, Result, SubscriptionFunction, TrackingCallback, TrackingData, WidenPrimitives, InitOptions, InitResponse, InitSyncOptions, PrefetchOptions, StickyAssignmentsDocument, EventLogger, LogUnion, DestroyOptions } from "./types/growthbook";
+import { StickyBucketServiceSync } from "./sticky-bucket-service";
+export declare class GrowthBook<AppFeatures extends Record<string, any> = Record<string, any>> {
+    private context;
+    debug: boolean;
+    ready: boolean;
+    version: string;
+    logs: Array<LogUnion>;
+    private _options;
+    private _renderer;
+    private _redirectedUrl;
+    private _trackedExperiments;
+    private _completedChangeIds;
+    private _trackedFeatures;
+    private _subscriptions;
+    private _assigned;
+    private _activeAutoExperiments;
+    private _triggeredExpKeys;
+    private _initialized;
+    private _deferredTrackingCalls;
+    private _saveStickyBucketAssignmentDoc;
+    private _payload;
+    private _decryptedPayload;
+    private _destroyCallbacks;
+    private _autoExperimentsAllowed;
+    private _destroyed?;
+    constructor(options?: Options);
+    setPayload(payload: FeatureApiResponse): Promise<void>;
+    initSync(options: InitSyncOptions): GrowthBook;
+    init(options?: InitOptions): Promise<InitResponse>;
+    /** @deprecated Use {@link init} */
+    loadFeatures(options?: LoadFeaturesOptions): Promise<void>;
+    refreshFeatures(options?: RefreshFeaturesOptions): Promise<void>;
+    getApiInfo(): [ApiHost, ClientKey];
+    getApiHosts(): {
+        apiHost: string;
+        streamingHost: string;
+        apiRequestHeaders?: Record<string, string>;
+        streamingHostRequestHeaders?: Record<string, string>;
+    };
+    getClientKey(): string;
+    getPayload(): FeatureApiResponse;
+    getDecryptedPayload(): FeatureApiResponse;
+    isRemoteEval(): boolean;
+    getCacheKeyAttributes(): (keyof Attributes)[] | undefined;
+    private _refresh;
+    private _render;
+    /** @deprecated Use {@link setPayload} */
+    setFeatures(features: Record<string, FeatureDefinition>): void;
+    /** @deprecated Use {@link setPayload} */
+    setEncryptedFeatures(encryptedString: string, decryptionKey?: string, subtle?: SubtleCrypto): Promise<void>;
+    /** @deprecated Use {@link setPayload} */
+    setExperiments(experiments: AutoExperiment[]): void;
+    /** @deprecated Use {@link setPayload} */
+    setEncryptedExperiments(encryptedString: string, decryptionKey?: string, subtle?: SubtleCrypto): Promise<void>;
+    setAttributes(attributes: Attributes): Promise<void>;
+    updateAttributes(attributes: Attributes): Promise<void>;
+    setAttributeOverrides(overrides: Attributes): Promise<void>;
+    setForcedVariations(vars: Record<string, number>): Promise<void>;
+    setForcedFeatures(map: Map<string, any>): void;
+    setURL(url: string): Promise<void>;
+    getAttributes(): {
+        [x: string]: any;
+    };
+    getForcedVariations(): Record<string, number>;
+    getForcedFeatures(): Map<string, any>;
+    getStickyBucketAssignmentDocs(): Record<string, StickyAssignmentsDocument>;
+    getUrl(): string;
+    getFeatures(): Record<string, FeatureDefinition<any>>;
+    getExperiments(): AutoExperiment<AutoExperimentVariation>[];
+    getCompletedChangeIds(): string[];
+    subscribe(cb: SubscriptionFunction): () => void;
+    private _refreshForRemoteEval;
+    getAllResults(): Map<string, {
+        experiment: Experiment<any>;
+        result: Result<any>;
+    }>;
+    onDestroy(cb: () => void): void;
+    isDestroyed(): boolean;
+    destroy(options?: DestroyOptions): void;
+    setRenderer(renderer: null | RenderFunction): void;
+    forceVariation(key: string, variation: number): void;
+    run<T>(experiment: Experiment<T>): Result<T>;
+    triggerExperiment(key: string): Result<AutoExperimentVariation>[] | null;
+    triggerAutoExperiments(): void;
+    private _getEvalContext;
+    private _getUserContext;
+    private _getGlobalContext;
+    private _runAutoExperiment;
+    private _undoActiveAutoExperiment;
+    private _updateAllAutoExperiments;
+    private _onExperimentEval;
+    private _fireSubscriptions;
+    private _recordChangedId;
+    isOn<K extends string & keyof AppFeatures = string>(key: K): boolean;
+    isOff<K extends string & keyof AppFeatures = string>(key: K): boolean;
+    getFeatureValue<V extends AppFeatures[K], K extends string & keyof AppFeatures = string>(key: K, defaultValue: V): WidenPrimitives<V>;
+    /**
+     * @deprecated Use {@link evalFeature}
+     * @param id
+     */
+    feature<V extends AppFeatures[K], K extends string & keyof AppFeatures = string>(id: K): FeatureResult<V | null>;
+    evalFeature<V extends AppFeatures[K], K extends string & keyof AppFeatures = string>(id: K): FeatureResult<V | null>;
+    log(msg: string, ctx: Record<string, unknown>): void;
+    getDeferredTrackingCalls(): TrackingData[];
+    setDeferredTrackingCalls(calls: TrackingData[]): void;
+    fireDeferredTrackingCalls(): Promise<void>;
+    setTrackingCallback(callback: TrackingCallback): void;
+    setFeatureUsageCallback(callback: FeatureUsageCallback): void;
+    setEventLogger(logger: EventLogger): void;
+    logEvent(eventName: string, properties?: Record<string, unknown>): Promise<void>;
+    private _saveDeferredTrack;
+    private _getContextUrl;
+    private _isAutoExperimentBlockedByContext;
+    getRedirectUrl(): string;
+    private _getNavigateFunction;
+    private _applyDOMChanges;
+    refreshStickyBuckets(data?: FeatureApiResponse): Promise<void>;
+    generateStickyBucketAssignmentDocsSync(stickyBucketService: StickyBucketServiceSync, payload: FeatureApiResponse): Record<string, StickyAssignmentsDocument> | undefined;
+    inDevMode(): boolean;
+}
+export declare function prefetchPayload(options: PrefetchOptions): Promise<void>;
+//# sourceMappingURL=GrowthBook.d.ts.map
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/types/growthbook.d.ts | Select-Object -First 220' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 217ms:
+import type { GrowthBook, GrowthBookClient, StickyBucketService, UserScopedGrowthBook } from "..";
+import { ConditionInterface, ParentConditionInterface } from "./mongrule";
+declare global {
+    interface Window {
+        _growthbook?: GrowthBook;
+    }
+}
+export type VariationMeta = {
+    passthrough?: boolean;
+    key?: string;
+    name?: string;
+};
+export type FeatureRule<T = any> = {
+    id?: string;
+    condition?: ConditionInterface;
+    parentConditions?: ParentConditionInterface[];
+    force?: T;
+    variations?: T[];
+    weights?: number[];
+    key?: string;
+    hashAttribute?: string;
+    fallbackAttribute?: string;
+    hashVersion?: number;
+    disableStickyBucketing?: boolean;
+    bucketVersion?: number;
+    minBucketVersion?: number;
+    range?: VariationRange;
+    coverage?: number;
+    /** @deprecated */
+    namespace?: [string, number, number];
+    ranges?: VariationRange[];
+    meta?: VariationMeta[];
+    filters?: Filter[];
+    seed?: string;
+    name?: string;
+    phase?: string;
+    tracks?: Array<{
+        experiment: Experiment<T>;
+        result: Result<T>;
+    }>;
+};
+export interface FeatureDefinition<T = any> {
+    defaultValue?: T;
+    rules?: FeatureRule<T>[];
+}
+export type FeatureResultSource = "unknownFeature" | "defaultValue" | "force" | "override" | "experiment" | "prerequisite" | "cyclicPrerequisite";
+export interface FeatureResult<T = any> {
+    value: T | null;
+    source: FeatureResultSource;
+    on: boolean;
+    off: boolean;
+    ruleId: string;
+    experiment?: Experiment<T>;
+    experimentResult?: Result<T>;
+}
+/** @deprecated */
+export type ExperimentStatus = "draft" | "running" | "stopped";
+export type UrlTargetType = "regex" | "simple";
+export type UrlTarget = {
+    include: boolean;
+    type: UrlTargetType;
+    pattern: string;
+};
+export type Experiment<T> = {
+    key: string;
+    variations: [T, T, ...T[]];
+    ranges?: VariationRange[];
+    meta?: VariationMeta[];
+    filters?: Filter[];
+    seed?: string;
+    name?: string;
+    phase?: string;
+    urlPatterns?: UrlTarget[];
+    weights?: number[];
+    condition?: ConditionInterface;
+    parentConditions?: ParentConditionInterface[];
+    coverage?: number;
+    include?: () => boolean;
+    /** @deprecated */
+    namespace?: [string, number, number];
+    force?: number;
+    hashAttribute?: string;
+    fallbackAttribute?: string;
+    hashVersion?: number;
+    disableStickyBucketing?: boolean;
+    bucketVersion?: number;
+    minBucketVersion?: number;
+    active?: boolean;
+    persistQueryString?: boolean;
+    /** @deprecated */
+    status?: ExperimentStatus;
+    /** @deprecated */
+    url?: RegExp;
+    /** @deprecated */
+    groups?: string[];
+};
+export type AutoExperimentChangeType = "redirect" | "visual" | "unknown";
+export type AutoExperiment<T = AutoExperimentVariation> = Experiment<T> & {
+    changeId?: string;
+    manual?: boolean;
+};
+export type ExperimentOverride = {
+    condition?: ConditionInterface;
+    weights?: number[];
+    active?: boolean;
+    status?: ExperimentStatus;
+    force?: number;
+    coverage?: number;
+    groups?: string[];
+    namespace?: [string, number, number];
+    url?: RegExp | string;
+};
+export interface Result<T> {
+    value: T;
+    variationId: number;
+    key: string;
+    name?: string;
+    bucket?: number;
+    passthrough?: boolean;
+    inExperiment: boolean;
+    hashUsed?: boolean;
+    hashAttribute: string;
+    hashValue: string;
+    featureId: string | null;
+    stickyBucketUsed?: boolean;
+}
+export type Attributes = Record<string, any>;
+export interface TrackingData {
+    experiment: Experiment<any>;
+    result: Result<any>;
+}
+export interface TrackingDataWithUser {
+    experiment: Experiment<any>;
+    result: Result<any>;
+    user: UserContext;
+}
+export type TrackingCallback = (experiment: Experiment<any>, result: Result<any>) => Promise<void> | void;
+export type TrackingCallbackWithUser = (experiment: Experiment<any>, result: Result<any>, user: UserContext) => Promise<void> | void;
+export type FeatureUsageCallback = (key: string, result: FeatureResult<any>) => void;
+export type FeatureUsageCallbackWithUser = (key: string, result: FeatureResult<any>, user: UserContext) => void;
+export type Plugin = (gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient) => void;
+export type EventProperties = Record<string, unknown>;
+export type EventLogger = (eventName: string, properties: EventProperties, userContext: UserContext) => void | Promise<void>;
+export type NavigateCallback = (url: string) => void | Promise<void>;
+export type ApplyDomChangesCallback = (changes: AutoExperimentVariation) => () => void;
+export type RenderFunction = () => void;
+export type Options = {
+    enabled?: boolean;
+    attributes?: Attributes;
+    url?: string;
+    features?: Record<string, FeatureDefinition>;
+    experiments?: AutoExperiment[];
+    forcedVariations?: Record<string, number>;
+    forcedFeatureValues?: Map<string, any>;
+    attributeOverrides?: Attributes;
+    blockedChangeIds?: string[];
+    disableVisualExperiments?: boolean;
+    disableJsInjection?: boolean;
+    jsInjectionNonce?: string;
+    disableUrlRedirectExperiments?: boolean;
+    disableCrossOriginUrlRedirectExperiments?: boolean;
+    disableExperimentsOnLoad?: boolean;
+    stickyBucketAssignmentDocs?: Record<StickyAttributeKey, StickyAssignmentsDocument>;
+    stickyBucketService?: StickyBucketService;
+    debug?: boolean;
+    log?: (msg: string, ctx: any) => void;
+    qaMode?: boolean;
+    /** @deprecated */
+    backgroundSync?: boolean;
+    /** @deprecated */
+    subscribeToChanges?: boolean;
+    enableDevMode?: boolean;
+    disableCache?: boolean;
+    /** @deprecated */
+    disableDevTools?: boolean;
+    trackingCallback?: TrackingCallback;
+    onFeatureUsage?: FeatureUsageCallback;
+    eventLogger?: EventLogger;
+    cacheKeyAttributes?: (keyof Attributes)[];
+    /** @deprecated */
+    user?: {
+        id?: string;
+        anonId?: string;
+        [key: string]: string | undefined;
+    };
+    /** @deprecated */
+    overrides?: Record<string, ExperimentOverride>;
+    /** @deprecated */
+    groups?: Record<string, boolean>;
+    apiHost?: string;
+    streamingHost?: string;
+    apiHostRequestHeaders?: Record<string, string>;
+    streamingHostRequestHeaders?: Record<string, string>;
+    clientKey?: string;
+    renderer?: null | RenderFunction;
+    decryptionKey?: string;
+    remoteEval?: boolean;
+    navigate?: NavigateCallback;
+    navigateDelay?: number;
+    maxNavigateDelay?: number;
+    /** @deprecated */
+    antiFlicker?: boolean;
+    /** @deprecated */
+    antiFlickerTimeout?: number;
+    applyDomChangesCallback?: ApplyDomChangesCallback;
+    savedGroups?: SavedGroupsValues;
+    plugins?: Plugin[];
+};
+export type ClientOptions = {
+    enabled?: boolean;
+    debug?: boolean;
+    globalAttributes?: Attributes;
+    forcedVariations?: Record<string, number>;
+    forcedFeatureValues?: Map<string, any>;
+    log?: (msg: string, ctx: any) => void;
+    qaMode?: boolean;
+    disableCache?: boolean;
+    trackingCallback?: TrackingCallbackWithUser;
+    onFeatureUsage?: (key: string, result: FeatureResult<any>, user: UserContext) => void;
+    eventLogger?: EventLogger;
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/types/growthbook.d.ts | Select-Object -Skip 220 -First 180' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 215ms:
+    apiHost?: string;
+    streamingHost?: string;
+    apiHostRequestHeaders?: Record<string, string>;
+    streamingHostRequestHeaders?: Record<string, string>;
+    clientKey?: string;
+    decryptionKey?: string;
+    savedGroups?: SavedGroupsValues;
+    plugins?: Plugin[];
+};
+export type GlobalContext = {
+    log: (msg: string, ctx: any) => void;
+    features?: FeatureDefinitions;
+    experiments?: AutoExperiment[];
+    enabled?: boolean;
+    qaMode?: boolean;
+    savedGroups?: SavedGroupsValues;
+    forcedVariations?: Record<string, number>;
+    forcedFeatureValues?: Map<string, any>;
+    trackingCallback?: TrackingCallbackWithUser;
+    onFeatureUsage?: FeatureUsageCallbackWithUser;
+    onExperimentEval?: (experiment: Experiment<any>, result: Result<any>) => void;
+    saveDeferredTrack?: (data: TrackingData) => void;
+    recordChangeId?: (changeId: string) => void;
+    eventLogger?: EventLogger;
+    /** @deprecated */
+    overrides?: Record<string, ExperimentOverride>;
+    /** @deprecated */
+    groups?: Record<string, boolean>;
+    /** @deprecated */
+    user?: {
+        id?: string;
+        anonId?: string;
+        [key: string]: string | undefined;
+    };
+};
+export type UserContext = {
+    enabled?: boolean;
+    qaMode?: boolean;
+    enableDevMode?: boolean;
+    attributes?: Attributes;
+    url?: string;
+    blockedChangeIds?: string[];
+    stickyBucketAssignmentDocs?: Record<StickyAttributeKey, StickyAssignmentsDocument>;
+    saveStickyBucketAssignmentDoc?: (doc: StickyAssignmentsDocument) => Promise<unknown>;
+    forcedVariations?: Record<string, number>;
+    forcedFeatureValues?: Map<string, any>;
+    attributeOverrides?: Attributes;
+    trackingCallback?: TrackingCallback;
+    onFeatureUsage?: FeatureUsageCallback;
+    trackedExperiments?: Set<string>;
+    trackedFeatureUsage?: Record<string, string>;
+    devLogs?: LogUnion[];
+};
+export type StackContext = {
+    id?: string;
+    evaluatedFeatures: Set<string>;
+};
+export type EvalContext = {
+    global: GlobalContext;
+    user: UserContext;
+    stack: StackContext;
+};
+export type PrefetchOptions = Pick<Options, "decryptionKey" | "apiHost" | "apiHostRequestHeaders" | "streamingHost" | "streamingHostRequestHeaders"> & {
+    clientKey: string;
+    streaming?: boolean;
+    skipCache?: boolean;
+};
+export type SubscriptionFunction = (experiment: Experiment<any>, result: Result<any>) => void;
+export type VariationRange = [number, number];
+export interface InitResponse {
+    success: boolean;
+    source: "init" | "cache" | "network" | "error" | "timeout";
+    error?: Error;
+}
+export interface FetchResponse {
+    data: FeatureApiResponse | null;
+    success: boolean;
+    source: "cache" | "network" | "error" | "timeout";
+    error?: Error;
+}
+export type JSONValue = null | number | string | boolean | Array<JSONValue> | Record<string, unknown> | {
+    [key: string]: JSONValue;
+};
+export type WidenPrimitives<T> = T extends string ? string : T extends number ? number : T extends boolean ? boolean : T;
+export type DOMMutation = {
+    selector: string;
+    action: string;
+    attribute: string;
+    value?: string;
+    parentSelector?: string;
+    insertBeforeSelector?: string;
+};
+export type AutoExperimentVariation = {
+    domMutations?: DOMMutation[];
+    css?: string;
+    js?: string;
+    urlRedirect?: string;
+};
+export type FeatureDefinitions = Record<string, FeatureDefinition>;
+export type FeatureApiResponse = {
+    features?: FeatureDefinitions;
+    dateUpdated?: string;
+    encryptedFeatures?: string;
+    experiments?: AutoExperiment[];
+    encryptedExperiments?: string;
+    savedGroups?: SavedGroupsValues;
+    encryptedSavedGroups?: string;
+};
+export type GrowthBookPayload = FeatureApiResponse;
+export type Polyfills = {
+    fetch: any;
+    SubtleCrypto: any;
+    EventSource: any;
+    localStorage?: LocalStorageCompat;
+};
+export type Helpers = {
+    fetchFeaturesCall: ({ host, clientKey, headers, }: {
+        host: string;
+        clientKey: string;
+        headers?: Record<string, string>;
+    }) => Promise<Response>;
+    fetchRemoteEvalCall: ({ host, clientKey, payload, headers, }: {
+        host: string;
+        clientKey: string;
+        payload: any;
+        headers?: Record<string, string>;
+    }) => Promise<Response>;
+    eventSourceCall: ({ host, clientKey, headers, }: {
+        host: string;
+        clientKey: string;
+        headers?: Record<string, string>;
+    }) => EventSource;
+    startIdleListener: () => (() => void) | void;
+    stopIdleListener: () => void;
+};
+export interface LocalStorageCompat {
+    getItem(key: string): string | null | Promise<string | null>;
+    setItem(key: string, value: string): void | Promise<void>;
+}
+export type CacheSettings = {
+    backgroundSync: boolean;
+    cacheKey: string;
+    staleTTL: number;
+    maxAge: number;
+    maxEntries: number;
+    disableIdleStreams: boolean;
+    idleStreamInterval: number;
+    disableCache: boolean;
+};
+export type ApiHost = string;
+export type ClientKey = string;
+export type InitOptions = {
+    timeout?: number;
+    skipCache?: boolean;
+    payload?: FeatureApiResponse;
+    streaming?: boolean;
+    cacheSettings?: CacheSettings;
+};
+export type InitSyncOptions = {
+    payload: FeatureApiResponse;
+    streaming?: boolean;
+};
+export type LoadFeaturesOptions = {
+    /** @deprecated */
+    autoRefresh?: boolean;
+    timeout?: number;
+    skipCache?: boolean;
+};
+export type RefreshFeaturesOptions = {
+    timeout?: number;
+    skipCache?: boolean;
+};
+export type DestroyOptions = {
+    destroyAllStreams?: boolean;
+};
+export interface Filter {
+    attribute?: string;
+    seed: string;
+    hashVersion: number;
+    ranges: VariationRange[];
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/src/middleware/requireCustomer.ts; Get-Content api/src/types/*.ts' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 165ms:
+import type { HttpHandler, HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { verifyFirebaseIdToken } from '../services/firebaseAdmin.js';
+import type { CustomerContext } from '../types/customer.js';
+
+export type CustomerHttpHandler = (
+  req: HttpRequest,
+  ctx: InvocationContext,
+  customer: CustomerContext,
+) => Promise<HttpResponseInit>;
+
+export function requireCustomer(handler: CustomerHttpHandler): HttpHandler {
+  return async (req, ctx) => {
+    const auth = req.headers.get('authorization') ?? '';
+    if (!auth.startsWith('Bearer ')) return { status: 401, jsonBody: { code: 'UNAUTHENTICATED' } };
+    try {
+      const decoded = await verifyFirebaseIdToken(auth.slice(7));
+      return handler(req, ctx, { customerId: decoded.uid });
+    } catch {
+      return { status: 401, jsonBody: { code: 'TOKEN_INVALID' } };
+    }
+  };
+}
+export type AdminRole = 'super-admin' | 'ops-manager' | 'finance' | 'support-agent' | 'system';
+
+export type AuditAction =
+  | 'LOGIN'
+  | 'LOGOUT'
+  | 'TOTP_SETUP'
+  | 'ORDER_OVERRIDE'
+  | 'TECH_DEACTIVATE'
+  | 'REFUND_APPROVE'
+  | 'PAYOUT_APPROVE'
+  | 'COMPLAINT_RESOLVE'
+  | 'CATALOGUE_EDIT'
+  | 'ADMIN_USER_CHANGE'
+  | 'SSC_LEVY_TRANSFER'
+  | 'ROUTE_TRANSFER_ATTEMPT'
+  | 'ROUTE_TRANSFER_SUCCESS'
+  | 'ROUTE_TRANSFER_FAILED'
+  | 'RECON_RETRY_ATTEMPT'
+  | 'RECON_RETRY_SUCCESS'
+  | 'RECON_RETRY_FAILED'
+  | 'RECON_MISMATCH_ALERT';
+
+export interface AdminContext {
+  adminId: string;
+  role: AdminRole;
+  sessionId: string;
+}
+export interface CustomerContext {
+  customerId: string;
+}
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBook.js | Select-Object -First 220' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+2026-04-29T20:24:01.892864Z ERROR codex_core::tools::router: error=Exit code: 1
+Wall time: 0.2 seconds
+Output:
+Get-Content : Cannot find path 'C:\Alok\Business 
+Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\node_modules\@growthbook\growthbook\dist\esm\GrowthBook.js' 
+because it does not exist.
+At line:2 char:1
++ Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBo ...
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : ObjectNotFound: (C:\Alok\Busines...m\GrowthBook.js:String) [Get-Content], ItemNotFoundEx 
+   ception
+    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand
+ 
+
+ exited 1 in 241ms:
+Get-Content : Cannot find path 'C:\Alok\Business 
+Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\node_modules\@growthbook\growthbook\dist\esm\GrowthBook.js' 
+because it does not exist.
+At line:2 char:1
++ Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBo ...
++ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : ObjectNotFound: (C:\Alok\Busines...m\GrowthBook.js:String) [Get-Content], ItemNotFoundEx 
+   ception
+    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand
+ 
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-ChildItem api/node_modules/@growthbook/growthbook/dist/esm' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 202ms:
+
+
+    Directory: C:\Alok\Business 
+    Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\node_modules\@growthbook\growthbook\dist\esm
+
+
+Mode                 LastWriteTime         Length Name                                                                 
+----                 -------------         ------ ----                                                                 
+d-----         4/29/2026   4:18 PM                plugins                                                              
+d-----         4/29/2026   4:18 PM                types                                                                
+-a----         4/17/2026  10:59 PM          30540 core.mjs                                                             
+-a----         4/17/2026  10:59 PM          70656 core.mjs.map                                                         
+-a----         4/17/2026  10:59 PM          13664 feature-repository.mjs                                               
+-a----         4/17/2026  10:59 PM          32859 feature-repository.mjs.map                                           
+-a----         4/17/2026  10:59 PM          26161 GrowthBook.mjs                                                       
+-a----         4/17/2026  10:59 PM          63880 GrowthBook.mjs.map                                                   
+-a----         4/17/2026  10:59 PM           8990 GrowthBookClient.mjs                                                 
+-a----         4/17/2026  10:59 PM          24639 GrowthBookClient.mjs.map                                             
+-a----         4/17/2026  10:59 PM            789 index.mjs                                                            
+-a----         4/17/2026  10:59 PM           3213 index.mjs.map                                                        
+-a----         4/17/2026  10:59 PM           7849 mongrule.mjs                                                         
+-a----         4/17/2026  10:59 PM          18165 mongrule.mjs.map                                                     
+-a----         4/17/2026  10:59 PM           6878 sticky-bucket-service.mjs                                            
+-a----         4/17/2026  10:59 PM          17677 sticky-bucket-service.mjs.map                                        
+-a----         4/17/2026  10:59 PM           9941 util.mjs                                                             
+-a----         4/17/2026  10:59 PM          23798 util.mjs.map                                                         
+
+
+
+2026-04-29T20:24:10.656877Z ERROR codex_core::tools::router: error=`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBook.mjs | Select-String loadFeatures -Context 2,20'` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBook.mjs | Select-String loadFeatures -Context 2,20' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ declined in 0ms:
+`"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBook.mjs | Select-String loadFeatures -Context 2,20'` rejected: blocked by policy
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBook.mjs | Select-Object -First 180' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 201ms:
+import mutate from "dom-mutator";
+import { decrypt, getAutoExperimentChangeType, isURLTargeted, loadSDKVersion, mergeQueryStrings, promiseTimeout } from "./util.mjs";
+import { clearAutoRefresh, configureCache, refreshFeatures, startStreaming, unsubscribe } from "./feature-repository.mjs";
+import { runExperiment, evalFeature as _evalFeature, getExperimentResult, getAllStickyBucketAssignmentDocs, decryptPayload, getApiHosts, getExperimentDedupeKey, getStickyBucketAttributes } from "./core.mjs";
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+const SDK_VERSION = loadSDKVersion();
+export class GrowthBook {
+  // context is technically private, but some tools depend on it so we can't mangle the name
+
+  // Properties and methods that start with "_" are mangled by Terser (saves ~150 bytes)
+
+  constructor(options) {
+    options = options || {};
+    // These properties are all initialized in the constructor instead of above
+    // This saves ~80 bytes in the final output
+    this.version = SDK_VERSION;
+    this._options = this.context = options;
+    this._renderer = options.renderer || null;
+    this._trackedExperiments = new Set();
+    this._completedChangeIds = new Set();
+    this._trackedFeatures = {};
+    this.debug = !!options.debug;
+    this._subscriptions = new Set();
+    this.ready = false;
+    this._assigned = new Map();
+    this._activeAutoExperiments = new Map();
+    this._triggeredExpKeys = new Set();
+    this._initialized = false;
+    this._redirectedUrl = "";
+    this._deferredTrackingCalls = new Map();
+    this._autoExperimentsAllowed = !options.disableExperimentsOnLoad;
+    this._destroyCallbacks = [];
+    this.logs = [];
+    this.log = this.log.bind(this);
+    this._saveDeferredTrack = this._saveDeferredTrack.bind(this);
+    this._onExperimentEval = this._onExperimentEval.bind(this);
+    this._fireSubscriptions = this._fireSubscriptions.bind(this);
+    this._recordChangedId = this._recordChangedId.bind(this);
+    if (options.remoteEval) {
+      if (options.decryptionKey) {
+        throw new Error("Encryption is not available for remoteEval");
+      }
+      if (!options.clientKey) {
+        throw new Error("Missing clientKey");
+      }
+      let isGbHost = false;
+      try {
+        isGbHost = !!new URL(options.apiHost || "").hostname.match(/growthbook\.io$/i);
+      } catch (e) {
+        // ignore invalid URLs
+      }
+      if (isGbHost) {
+        throw new Error("Cannot use remoteEval on GrowthBook Cloud");
+      }
+    } else {
+      if (options.cacheKeyAttributes) {
+        throw new Error("cacheKeyAttributes are only used for remoteEval");
+      }
+    }
+    if (options.stickyBucketService) {
+      const s = options.stickyBucketService;
+      this._saveStickyBucketAssignmentDoc = doc => {
+        return s.saveAssignments(doc);
+      };
+    }
+    if (options.plugins) {
+      for (const plugin of options.plugins) {
+        plugin(this);
+      }
+    }
+    if (options.features) {
+      this.ready = true;
+    }
+    if (isBrowser && options.enableDevMode) {
+      window._growthbook = this;
+      document.dispatchEvent(new Event("gbloaded"));
+    }
+    if (options.experiments) {
+      this.ready = true;
+      this._updateAllAutoExperiments();
+    }
+
+    // Hydrate sticky bucket service
+    if (this._options.stickyBucketService && this._options.stickyBucketAssignmentDocs) {
+      for (const key in this._options.stickyBucketAssignmentDocs) {
+        const doc = this._options.stickyBucketAssignmentDocs[key];
+        if (doc) {
+          this._options.stickyBucketService.saveAssignments(doc).catch(() => {
+            // Ignore hydration errors
+          });
+        }
+      }
+    }
+
+    // Legacy - passing in features/experiments into the constructor instead of using init
+    if (this.ready) {
+      this.refreshStickyBuckets(this.getPayload());
+    }
+  }
+  async setPayload(payload) {
+    this._payload = payload;
+    const data = await decryptPayload(payload, this._options.decryptionKey);
+    this._decryptedPayload = data;
+    await this.refreshStickyBuckets(data);
+    if (data.features) {
+      this._options.features = data.features;
+    }
+    if (data.savedGroups) {
+      this._options.savedGroups = data.savedGroups;
+    }
+    if (data.experiments) {
+      this._options.experiments = data.experiments;
+      this._updateAllAutoExperiments();
+    }
+    this.ready = true;
+    this._render();
+  }
+  initSync(options) {
+    this._initialized = true;
+    const payload = options.payload;
+    if (payload.encryptedExperiments || payload.encryptedFeatures) {
+      throw new Error("initSync does not support encrypted payloads");
+    }
+    if (this._options.stickyBucketService && !this._options.stickyBucketAssignmentDocs) {
+      this._options.stickyBucketAssignmentDocs = this.generateStickyBucketAssignmentDocsSync(this._options.stickyBucketService, payload);
+    }
+    this._payload = payload;
+    this._decryptedPayload = payload;
+    if (payload.features) {
+      this._options.features = payload.features;
+    }
+    if (payload.experiments) {
+      this._options.experiments = payload.experiments;
+      this._updateAllAutoExperiments();
+    }
+    this.ready = true;
+    startStreaming(this, options);
+    return this;
+  }
+  async init(options) {
+    this._initialized = true;
+    options = options || {};
+    if (options.cacheSettings) {
+      configureCache(options.cacheSettings);
+    }
+    if (options.payload) {
+      await this.setPayload(options.payload);
+      startStreaming(this, options);
+      return {
+        success: true,
+        source: "init"
+      };
+    } else {
+      const {
+        data,
+        ...res
+      } = await this._refresh({
+        ...options,
+        allowStale: true
+      });
+      startStreaming(this, options);
+      await this.setPayload(data || {});
+      return res;
+    }
+  }
+
+  /** @deprecated Use {@link init} */
+  async loadFeatures(options) {
+    options = options || {};
+    await this.init({
+      skipCache: options.skipCache,
+      timeout: options.timeout,
+      streaming: (this._options.backgroundSync ?? true) && (options.autoRefresh || this._options.subscribeToChanges)
+    });
+  }
+  async refreshFeatures(options) {
+    const res = await this._refresh({
+      ...(options || {}),
+      allowStale: false
+    });
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/GrowthBook.mjs | Select-Object -Skip 180 -First 120' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 186ms:
+    if (res.data) {
+      await this.setPayload(res.data);
+    }
+  }
+  getApiInfo() {
+    return [this.getApiHosts().apiHost, this.getClientKey()];
+  }
+  getApiHosts() {
+    return getApiHosts(this._options);
+  }
+  getClientKey() {
+    return this._options.clientKey || "";
+  }
+  getPayload() {
+    return this._payload || {
+      features: this.getFeatures(),
+      experiments: this.getExperiments()
+    };
+  }
+  getDecryptedPayload() {
+    return this._decryptedPayload || this.getPayload();
+  }
+  isRemoteEval() {
+    return this._options.remoteEval || false;
+  }
+  getCacheKeyAttributes() {
+    return this._options.cacheKeyAttributes;
+  }
+  async _refresh({
+    timeout,
+    skipCache,
+    allowStale,
+    streaming
+  }) {
+    if (!this._options.clientKey) {
+      throw new Error("Missing clientKey");
+    }
+    // Trigger refresh in feature repository
+    return refreshFeatures({
+      instance: this,
+      timeout,
+      skipCache: skipCache || this._options.disableCache,
+      allowStale,
+      backgroundSync: streaming ?? this._options.backgroundSync ?? true
+    });
+  }
+  _render() {
+    if (this._renderer) {
+      try {
+        this._renderer();
+      } catch (e) {
+        console.error("Failed to render", e);
+      }
+    }
+  }
+
+  /** @deprecated Use {@link setPayload} */
+  setFeatures(features) {
+    this._options.features = features;
+    this.ready = true;
+    this._render();
+  }
+
+  /** @deprecated Use {@link setPayload} */
+  async setEncryptedFeatures(encryptedString, decryptionKey, subtle) {
+    const featuresJSON = await decrypt(encryptedString, decryptionKey || this._options.decryptionKey, subtle);
+    this.setFeatures(JSON.parse(featuresJSON));
+  }
+
+  /** @deprecated Use {@link setPayload} */
+  setExperiments(experiments) {
+    this._options.experiments = experiments;
+    this.ready = true;
+    this._updateAllAutoExperiments();
+  }
+
+  /** @deprecated Use {@link setPayload} */
+  async setEncryptedExperiments(encryptedString, decryptionKey, subtle) {
+    const experimentsJSON = await decrypt(encryptedString, decryptionKey || this._options.decryptionKey, subtle);
+    this.setExperiments(JSON.parse(experimentsJSON));
+  }
+  async setAttributes(attributes) {
+    this._options.attributes = attributes;
+    if (this._options.stickyBucketService) {
+      await this.refreshStickyBuckets();
+    }
+    if (this._options.remoteEval) {
+      await this._refreshForRemoteEval();
+      return;
+    }
+    this._render();
+    this._updateAllAutoExperiments();
+  }
+  async updateAttributes(attributes) {
+    return this.setAttributes({
+      ...this._options.attributes,
+      ...attributes
+    });
+  }
+  async setAttributeOverrides(overrides) {
+    this._options.attributeOverrides = overrides;
+    if (this._options.stickyBucketService) {
+      await this.refreshStickyBuckets();
+    }
+    if (this._options.remoteEval) {
+      await this._refreshForRemoteEval();
+      return;
+    }
+    this._render();
+    this._updateAllAutoExperiments();
+  }
+  async setForcedVariations(vars) {
+    this._options.forcedVariations = vars || {};
+    if (this._options.remoteEval) {
+      await this._refreshForRemoteEval();
+      return;
+    }
+    this._render();
+    this._updateAllAutoExperiments();
+  }
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/feature-repository.mjs | Select-Object -First 220' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 192ms:
+import { getPolyfills, promiseTimeout } from "./util.mjs";
+// Config settings
+const cacheSettings = {
+  // Consider a fetch stale after 1 minute
+  staleTTL: 1000 * 60,
+  // Max time to keep a fetch in cache (4 hours default)
+  maxAge: 1000 * 60 * 60 * 4,
+  cacheKey: "gbFeaturesCache",
+  backgroundSync: true,
+  maxEntries: 10,
+  disableIdleStreams: false,
+  idleStreamInterval: 20000,
+  disableCache: false
+};
+const polyfills = getPolyfills();
+export const helpers = {
+  fetchFeaturesCall: ({
+    host,
+    clientKey,
+    headers
+  }) => {
+    return polyfills.fetch(`${host}/api/features/${clientKey}`, {
+      headers
+    });
+  },
+  fetchRemoteEvalCall: ({
+    host,
+    clientKey,
+    payload,
+    headers
+  }) => {
+    const options = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...headers
+      },
+      body: JSON.stringify(payload)
+    };
+    return polyfills.fetch(`${host}/api/eval/${clientKey}`, options);
+  },
+  eventSourceCall: ({
+    host,
+    clientKey,
+    headers
+  }) => {
+    if (headers) {
+      return new polyfills.EventSource(`${host}/sub/${clientKey}`, {
+        headers
+      });
+    }
+    return new polyfills.EventSource(`${host}/sub/${clientKey}`);
+  },
+  startIdleListener: () => {
+    let idleTimeout;
+    const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+    if (!isBrowser) return;
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        window.clearTimeout(idleTimeout);
+        onVisible();
+      } else if (document.visibilityState === "hidden") {
+        idleTimeout = window.setTimeout(onHidden, cacheSettings.idleStreamInterval);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  },
+  stopIdleListener: () => {
+    // No-op, replaced by startIdleListener
+  }
+};
+try {
+  if (globalThis.localStorage) {
+    polyfills.localStorage = globalThis.localStorage;
+  }
+} catch (e) {
+  // Ignore localStorage errors
+}
+
+// Global state
+const subscribedInstances = new Map();
+let cacheInitialized = false;
+const cache = new Map();
+const activeFetches = new Map();
+const streams = new Map();
+const supportsSSE = new Set();
+
+// Public functions
+export function setPolyfills(overrides) {
+  Object.assign(polyfills, overrides);
+}
+export function configureCache(overrides) {
+  Object.assign(cacheSettings, overrides);
+  if (!cacheSettings.backgroundSync) {
+    clearAutoRefresh();
+  }
+}
+export async function clearCache() {
+  cache.clear();
+  activeFetches.clear();
+  clearAutoRefresh();
+  cacheInitialized = false;
+  await updatePersistentCache();
+}
+
+// Get or fetch features and refresh the SDK instance
+export async function refreshFeatures({
+  instance,
+  timeout,
+  skipCache,
+  allowStale,
+  backgroundSync
+}) {
+  if (!backgroundSync) {
+    cacheSettings.backgroundSync = false;
+  }
+  return fetchFeaturesWithCache({
+    instance,
+    allowStale,
+    timeout,
+    skipCache
+  });
+}
+
+// Subscribe a GrowthBook instance to feature changes
+function subscribe(instance) {
+  const key = getKey(instance);
+  const subs = subscribedInstances.get(key) || new Set();
+  subs.add(instance);
+  subscribedInstances.set(key, subs);
+}
+export function unsubscribe(instance) {
+  subscribedInstances.forEach(s => s.delete(instance));
+}
+export function onHidden() {
+  streams.forEach(channel => {
+    if (!channel) return;
+    channel.state = "idle";
+    disableChannel(channel);
+  });
+}
+export function onVisible() {
+  streams.forEach(channel => {
+    if (!channel) return;
+    if (channel.state !== "idle") return;
+    enableChannel(channel);
+  });
+}
+
+// Private functions
+
+async function updatePersistentCache() {
+  try {
+    if (!polyfills.localStorage) return;
+    await polyfills.localStorage.setItem(cacheSettings.cacheKey, JSON.stringify(Array.from(cache.entries())));
+  } catch (e) {
+    // Ignore localStorage errors
+  }
+}
+
+// SWR wrapper for fetching features. May indirectly or directly start SSE streaming.
+async function fetchFeaturesWithCache({
+  instance,
+  allowStale,
+  timeout,
+  skipCache
+}) {
+  const key = getKey(instance);
+  const cacheKey = getCacheKey(instance);
+  const now = new Date();
+  const minStaleAt = new Date(now.getTime() - cacheSettings.maxAge + cacheSettings.staleTTL);
+  await initializeCache();
+  const existing = !cacheSettings.disableCache && !skipCache ? cache.get(cacheKey) : undefined;
+  if (existing && (allowStale || existing.staleAt > now) && existing.staleAt > minStaleAt) {
+    // Restore from cache whether SSE is supported
+    if (existing.sse) supportsSSE.add(key);
+
+    // Reload features in the background if stale
+    if (existing.staleAt < now) {
+      fetchFeatures(instance);
+    }
+    // Otherwise, if we don't need to refresh now, start a background sync
+    else {
+      startAutoRefresh(instance);
+    }
+    return {
+      data: existing.data,
+      success: true,
+      source: "cache"
+    };
+  } else {
+    const res = await promiseTimeout(fetchFeatures(instance), timeout);
+    return res || {
+      data: null,
+      success: false,
+      source: "timeout",
+      error: new Error("Timeout")
+    };
+  }
+}
+function getKey(instance) {
+  const [apiHost, clientKey] = instance.getApiInfo();
+  return `${apiHost}||${clientKey}`;
+}
+function getCacheKey(instance) {
+  const baseKey = getKey(instance);
+  if (!("isRemoteEval" in instance) || !instance.isRemoteEval()) return baseKey;
+  const attributes = instance.getAttributes();
+  const cacheKeyAttributes = instance.getCacheKeyAttributes() || Object.keys(instance.getAttributes());
+  const ca = {};
+  cacheKeyAttributes.forEach(key => {
+    ca[key] = attributes[key];
+  });
+  const fv = instance.getForcedVariations();
+  const url = instance.getUrl();
+  return `${baseKey}||${JSON.stringify({
+    ca,
+    fv,
+    url
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@growthbook/growthbook/dist/esm/feature-repository.mjs | Select-Object -Skip 220 -First 180' in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 194ms:
+  })}`;
+}
+
+// Populate cache from localStorage (if available)
+async function initializeCache() {
+  if (cacheInitialized) return;
+  cacheInitialized = true;
+  try {
+    if (polyfills.localStorage) {
+      const value = await polyfills.localStorage.getItem(cacheSettings.cacheKey);
+      if (!cacheSettings.disableCache && value) {
+        const parsed = JSON.parse(value);
+        if (parsed && Array.isArray(parsed)) {
+          parsed.forEach(([key, data]) => {
+            cache.set(key, {
+              ...data,
+              staleAt: new Date(data.staleAt)
+            });
+          });
+        }
+        cleanupCache();
+      }
+    }
+  } catch (e) {
+    // Ignore localStorage errors
+  }
+  if (!cacheSettings.disableIdleStreams) {
+    const cleanupFn = helpers.startIdleListener();
+    if (cleanupFn) {
+      helpers.stopIdleListener = cleanupFn;
+    }
+  }
+}
+
+// Enforce the maxEntries limit
+function cleanupCache() {
+  const entriesWithTimestamps = Array.from(cache.entries()).map(([key, value]) => ({
+    key,
+    staleAt: value.staleAt.getTime()
+  })).sort((a, b) => a.staleAt - b.staleAt);
+  const entriesToRemoveCount = Math.min(Math.max(0, cache.size - cacheSettings.maxEntries), cache.size);
+  for (let i = 0; i < entriesToRemoveCount; i++) {
+    cache.delete(entriesWithTimestamps[i].key);
+  }
+}
+
+// Called whenever new features are fetched from the API
+function onNewFeatureData(key, cacheKey, data) {
+  // If contents haven't changed, ignore the update, extend the stale TTL
+  const version = data.dateUpdated || "";
+  const staleAt = new Date(Date.now() + cacheSettings.staleTTL);
+  const existing = !cacheSettings.disableCache ? cache.get(cacheKey) : undefined;
+  if (existing && version && existing.version === version) {
+    existing.staleAt = staleAt;
+    updatePersistentCache();
+    return;
+  }
+  if (!cacheSettings.disableCache) {
+    // Update in-memory cache
+    cache.set(cacheKey, {
+      data,
+      version,
+      staleAt,
+      sse: supportsSSE.has(key)
+    });
+    cleanupCache();
+  }
+  // Update local storage (don't await this, just update asynchronously)
+  updatePersistentCache();
+
+  // Update features for all subscribed GrowthBook instances
+  const instances = subscribedInstances.get(key);
+  instances && instances.forEach(instance => refreshInstance(instance, data));
+}
+async function refreshInstance(instance, data) {
+  await instance.setPayload(data || instance.getPayload());
+}
+
+// Fetch the features payload from helper function or from in-mem injected payload
+async function fetchFeatures(instance) {
+  const {
+    apiHost,
+    apiRequestHeaders
+  } = instance.getApiHosts();
+  const clientKey = instance.getClientKey();
+  const remoteEval = "isRemoteEval" in instance && instance.isRemoteEval();
+  const key = getKey(instance);
+  const cacheKey = getCacheKey(instance);
+  let promise = activeFetches.get(cacheKey);
+  if (!promise) {
+    const fetcher = remoteEval ? helpers.fetchRemoteEvalCall({
+      host: apiHost,
+      clientKey,
+      payload: {
+        attributes: instance.getAttributes(),
+        forcedVariations: instance.getForcedVariations(),
+        forcedFeatures: Array.from(instance.getForcedFeatures().entries()),
+        url: instance.getUrl()
+      },
+      headers: apiRequestHeaders
+    }) : helpers.fetchFeaturesCall({
+      host: apiHost,
+      clientKey,
+      headers: apiRequestHeaders
+    });
+
+    // TODO: auto-retry if status code indicates a temporary error
+    promise = fetcher.then(res => {
+      if (!res.ok) {
+        throw new Error(`HTTP error: ${res.status}`);
+      }
+      if (res.headers.get("x-sse-support") === "enabled") {
+        supportsSSE.add(key);
+      }
+      return res.json();
+    }).then(data => {
+      onNewFeatureData(key, cacheKey, data);
+      startAutoRefresh(instance);
+      activeFetches.delete(cacheKey);
+      return {
+        data,
+        success: true,
+        source: "network"
+      };
+    }).catch(e => {
+      process.env.NODE_ENV !== "production" && instance.log("Error fetching features", {
+        apiHost,
+        clientKey,
+        error: e ? e.message : null
+      });
+      activeFetches.delete(cacheKey);
+      return {
+        data: null,
+        source: "error",
+        success: false,
+        error: e
+      };
+    });
+    activeFetches.set(cacheKey, promise);
+  }
+  return promise;
+}
+
+// Start SSE streaming, listens to feature payload changes and triggers a refresh or re-fetch
+function startAutoRefresh(instance, forceSSE = false) {
+  const key = getKey(instance);
+  const cacheKey = getCacheKey(instance);
+  const {
+    streamingHost,
+    streamingHostRequestHeaders
+  } = instance.getApiHosts();
+  const clientKey = instance.getClientKey();
+  if (forceSSE) {
+    supportsSSE.add(key);
+  }
+  if (cacheSettings.backgroundSync && supportsSSE.has(key) && polyfills.EventSource) {
+    if (streams.has(key)) return;
+    const channel = {
+      src: null,
+      host: streamingHost,
+      clientKey,
+      headers: streamingHostRequestHeaders,
+      cb: event => {
+        try {
+          if (event.type === "features-updated") {
+            const instances = subscribedInstances.get(key);
+            instances && instances.forEach(instance => {
+              fetchFeatures(instance);
+            });
+          } else if (event.type === "features") {
+            const json = JSON.parse(event.data);
+            onNewFeatureData(key, cacheKey, json);
+          }
+          // Reset error count on success
+          channel.errors = 0;
+        } catch (e) {
+          process.env.NODE_ENV !== "production" && instance.log("SSE Error", {
+            streamingHost,
+            clientKey,
+            error: e ? e.message : null
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command Get-Location in C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+ succeeded in 157ms:
+
+Path                                                                  
+----                                                                  
+C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate
+
+
+
+codex
+The launch gate does not actually fail open on real GrowthBook load failures, and it cannot enforce the intended per-customer F&F targeting because no customer attributes are supplied. These are functional issues in the new launch-readiness behavior.
+
+Full review comments:
+
+- [P1] Fail open on GrowthBook timeouts — C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\src\services\featureFlags.service.ts:30-31
+  When GrowthBook is unreachable or `loadFeatures({ timeout })` times out, the real SDK resolves with an empty payload/result rather than rejecting, so this `catch` is not entered and `gb.isOn('soft_launch_enabled')` returns `false`. In that outage scenario every create-booking request gets the 503 gate, contrary to the fail-open contract; use an API that exposes the load result (for example `init`) and return `true` when the load was not successful.
+
+- [P2] Evaluate the soft-launch flag per customer — C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\src\functions\bookings.ts:17-17
+  When `soft_launch_enabled` is configured to target the 100 F&F users, this call evaluates the flag without any `customer.customerId` or other per-request attributes, so GrowthBook can only return a single global value for all authenticated customers. Once the flag is opened for the F&F segment, non-F&F customers will receive the same result and can create bookings too; pass customer attributes into the flag evaluation instead of using an attribute-less singleton.
+2026-04-29T20:24:48.469988Z ERROR codex_core::session: failed to record rollout items: thread 019ddae8-6431-75a1-85d9-816ef7416cb8 not found
+2026-04-29T20:24:48.521134Z ERROR codex_core::session: failed to record rollout items: thread 019ddae8-636d-77b3-8698-de95c82fc4e8 not found
+The launch gate does not actually fail open on real GrowthBook load failures, and it cannot enforce the intended per-customer F&F targeting because no customer attributes are supplied. These are functional issues in the new launch-readiness behavior.
+
+Full review comments:
+
+- [P1] Fail open on GrowthBook timeouts — C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\src\services\featureFlags.service.ts:30-31
+  When GrowthBook is unreachable or `loadFeatures({ timeout })` times out, the real SDK resolves with an empty payload/result rather than rejecting, so this `catch` is not entered and `gb.isOn('soft_launch_enabled')` returns `false`. In that outage scenario every create-booking request gets the 503 gate, contrary to the fail-open contract; use an API that exposes the load result (for example `init`) and return `true` when the load was not successful.
+
+- [P2] Evaluate the soft-launch flag per customer — C:\Alok\Business Projects\Urbanclap-dup\.worktrees\E10-S04-launch-gate\api\src\functions\bookings.ts:17-17
+  When `soft_launch_enabled` is configured to target the 100 F&F users, this call evaluates the flag without any `customer.customerId` or other per-request attributes, so GrowthBook can only return a single global value for all authenticated customers. Once the flag is opened for the F&F segment, non-F&F customers will receive the same result and can create bookings too; pass customer attributes into the flag evaluation instead of using an attribute-less singleton.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -465,5 +465,145 @@ After enrollment is confirmed:
 | `409 ALREADY_ENROLLED` | Owner already completed setup | Setup is done — no action needed |
 | `401 SETUP_TOKEN_INVALID` | Setup JWT expired (15 min TTL) | Re-login to get a new setup token |
 
-**Runbook v1.1 complete (DPDP §10 breach playbook + admin setup procedure).**
+---
+
+## Emergency Rollback
+
+**Trigger:** Sentry error rate > 5%, payment webhook failures > 2/10 min, FCM delivery < 80%/30 min, or any unhandled first-time exception in production.
+
+**Estimated time: < 15 minutes from detection to user impact ended.**
+
+### Step 1 — Disable soft_launch_enabled (immediate user impact ended)
+
+In GrowthBook dashboard → Feature Flags → `soft_launch_enabled` → set to `false`.
+
+All new booking creation attempts immediately return:
+```json
+{ "code": "SERVICE_UNAVAILABLE", "message": "Launch coming soon" }
+```
+Customers see "coming soon" instead of an error. No data is written.
+
+### Step 2 — Triage in-flight bookings
+
+For any bookings currently in `PAID` or `SEARCHING` state:
+- Open admin-web → Orders → filter by status `SEARCHING`
+- Owner manually closes or refunds via admin override panel
+- Razorpay Route payouts for `COMPLETED` bookings continue automatically (unaffected)
+
+### Step 3 — Revert the bad commit (if code regression)
+
+```bash
+git log --oneline origin/main | head -5    # identify the bad SHA
+git revert -m 1 <sha>                      # creates a revert commit
+git push origin HEAD:feature/revert-<sha>  # push to a new branch
+# Open PR → CI green → merge
+```
+
+Do NOT force-push to main. Use revert + PR.
+
+### Step 4 — Re-enable after root cause fixed
+
+Once the fix is deployed and smoke-tested:
+- GrowthBook → `soft_launch_enabled` → set to `true`
+- Monitor Sentry for 10 minutes
+- Notify F&F users via admin FCM broadcast (topic: `all_customers`)
+
+---
+
+## Launch Checklist
+
+Required env vars before enabling `soft_launch_enabled`:
+
+| Env var | Where set | Note |
+|---|---|---|
+| `GROWTHBOOK_CLIENT_KEY` | Azure Functions app settings | Required for soft-launch flag to work |
+| `GROWTHBOOK_API_HOST` | Azure Functions app settings | Default: `https://cdn.growthbook.io` |
+| `RAZORPAY_KEY_ID` | Azure Functions app settings | Production key (not test) |
+| `RAZORPAY_KEY_SECRET` | Azure Functions app settings | Production key (not test) |
+| `RAZORPAY_WEBHOOK_SECRET` | Azure Functions app settings | For webhook signature validation |
+| `COSMOS_PAN_ENCRYPTION_KEY` | Azure Functions app settings | `openssl rand -base64 32` |
+| `ADMIN_SETUP_SECRET` | Azure Functions app settings | First-run only — remove after TOTP enrollment |
+
+See `docs/launch-checklist.md` for the full pre-launch checklist.
+
+---
+
+## Disaster Recovery Drill
+
+**Run this drill 1–2 weeks before launch to confirm recovery procedures work.**
+
+### 1. Cosmos DB restore (point-in-time)
+
+Azure Cosmos DB Serverless has continuous backup enabled by default.
+
+**Procedure:**
+1. Azure Portal → Cosmos DB account → Backups → Restore
+2. Select timestamp (up to 30 days back)
+3. Restore to a new account (restoration is non-destructive — original account remains)
+4. Verify document counts and spot-check data integrity
+5. DNS/connection string cutover: Azure Functions → Configuration → `COSMOS_CONNECTION_STRING` → update to new account endpoint
+6. Restart Function App to pick up new connection string
+
+**Estimated RTO:**
+- Full restore: 2–4 hours (depends on data volume)
+- Connection string cutover: 30 minutes (if restore already complete)
+
+**Drill:** Restore to a test Cosmos account, verify 5 sample bookings match production, then delete the test account.
+
+### 2. Azure Functions cold-start recovery
+
+If Functions are unresponsive (HTTP 5xx or no response):
+
+```bash
+# Portal path:
+# Azure Portal → Function App → Overview → Restart
+
+# CLI (faster):
+az functionapp restart --name <app-name> --resource-group <resource-group>
+```
+
+**Estimated RTO:** < 5 minutes (Functions restart and warm up within 2–3 cold-start invocations)
+
+**Drill:** Restart the staging Function App and verify `GET /api/health` returns 200 within 60 seconds.
+
+### 3. Firebase Auth outage
+
+Firebase Phone Auth is Google-managed infrastructure.
+
+**During outage:**
+- Existing sessions (Firebase JWT / persistent token) continue to work — customers mid-flow are unaffected
+- New logins fail with `auth/network-request-failed` → customer-app shows "Please try again later" message
+- No owner action needed
+
+**Resolution:** Monitor [Firebase Status](https://status.firebase.google.com). Firebase has 99.9% monthly uptime SLA.
+
+**Owner action:** None. If outage > 1 hour, post in-app maintenance banner via admin FCM broadcast.
+
+### 4. FCM outage
+
+FCM is Google-managed infrastructure.
+
+**During outage:**
+- Job offers not delivered via push → technicians must manually check the app for new jobs
+- Owner FCM alerts not delivered → owner monitors admin dashboard directly
+- `dispatcher.service.ts` logs `FCM_DELIVERY_FAILED` to Sentry — confirms outage is FCM-side
+
+**Resolution:** None needed. FCM has 99.9% SLA. Bookings and payments are unaffected.
+
+**Owner action:** Notify active technicians via SMS (manual, out-of-band) if outage > 30 minutes.
+
+### 5. Razorpay Route outage
+
+**During outage:**
+- Payout disbursements via Route will fail
+- `trigger-booking-completed.ts` captures Route errors to Sentry (`RazorpayRoutePayoutFailed`)
+- Settled amounts stay in `PENDING` state in `wallet_ledger` entries — **idempotent and safe to retry**
+
+**Resolution:** When Route recovers, `trigger-reconcile-payouts.ts` automatically retries all `FAILED` ledger entries on its next scheduled run (every 6 hours).
+
+**Owner action:**
+- Monitor `/v1/admin/finance/payout-queue` for stuck `PENDING` entries
+- If entries remain stuck > 24 hours after Route recovery, manually trigger `trigger-reconcile-payouts` from Azure Portal → Functions → Run
+
+**Runbook v1.2 complete (E10-S04: Emergency rollback + DR drill + launch checklist).**
 Living document — update after every incident and every significant architectural change.

--- a/docs/stories/E10-S04-launch-readiness-gate.md
+++ b/docs/stories/E10-S04-launch-readiness-gate.md
@@ -1,0 +1,91 @@
+# E10-S04 — Launch Readiness Gate
+
+**Epic:** E10 — Compliance & Launch Hardening
+**Story ID:** E10-S04
+**Ceremony tier:** Foundation
+**Status:** Implemented (2026-04-29)
+**Branch:** `feature/E10-S04-launch-gate`
+
+---
+
+## User Story
+
+As the platform owner,
+I want a soft-launch gate that limits bookings to 100 F&F users, a marketing-pause
+toggle, and a tested rollback procedure,
+so that I can launch confidently, catch issues early, and reverse course without
+data loss if something goes wrong.
+
+---
+
+## Acceptance Criteria
+
+| AC | Description | Status |
+|---|---|---|
+| AC-1 | GrowthBook `soft_launch_enabled` flag gates `createBooking`; fail-open on SDK error | ✅ |
+| AC-2 | `marketing_pause_enabled` flag for owner-controlled booking pause (checked after AC-1) | ✅ |
+| AC-3 | Emergency rollback playbook in `docs/runbook.md` + automated test for flag=false → 503 | ✅ |
+| AC-4 | DR drill documentation in `docs/runbook.md` (Cosmos, Functions, Firebase, FCM, Razorpay) | ✅ |
+| AC-5 | `docs/launch-checklist.md` with env-var checklist, pre-launch smoke, go-live, and rollback triggers | ✅ |
+| AC-6 | `api-ship.yml` warning step if `GROWTHBOOK_CLIENT_KEY` secret is missing | ✅ |
+
+---
+
+## Files Created
+
+| File | Purpose |
+|---|---|
+| `api/src/services/featureFlags.service.ts` | GrowthBook wrapper: `isSoftLaunchEnabled`, `isMarketingPaused` |
+| `api/tests/unit/launch-gate.test.ts` | 8 unit tests (TDD-first, all green) |
+| `docs/launch-checklist.md` | Full pre-launch checklist for go-live day |
+| `docs/stories/E10-S04-launch-readiness-gate.md` | This file |
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `api/src/functions/bookings.ts` | Added flag checks at top of `createHandler` |
+| `api/local.settings.example.json` | Added `GROWTHBOOK_API_HOST` + `GROWTHBOOK_CLIENT_KEY` placeholders |
+| `docs/runbook.md` | Added § Emergency Rollback + § Launch Checklist + § Disaster Recovery Drill |
+| `.github/workflows/api-ship.yml` | Added env-var warning step (AC-6) |
+
+---
+
+## Key Design Decisions
+
+### Fail-open contract
+
+`isSoftLaunchEnabled()` returns `true` (allow booking) on:
+- GrowthBook SDK timeout or throw
+- Empty `GROWTHBOOK_CLIENT_KEY` (local dev)
+
+This means a broken flags SDK never blocks the platform.
+
+### marketing_pause checked AFTER soft_launch
+
+Order matters: `soft_launch_enabled = false` takes precedence with a "coming soon" message. `marketing_pause_enabled = true` overrides an open soft launch with a "pausing briefly" message. The owner can always close the gate harder (via soft_launch) or softer (via marketing_pause).
+
+### DI pattern for testability
+
+`isSoftLaunchEnabled(client?)` and `isMarketingPaused(client?)` accept an optional `FeatureFlagClient` for dependency injection in tests, defaulting to the module singleton. No `vi.mock` of `@growthbook/growthbook` required — tests pass a mock client directly.
+
+### local.settings.json is gitignored
+
+`api/local.settings.json` is in `.gitignore` (Azure Functions convention). The new env vars are documented in `api/local.settings.example.json`. Local dev with empty `GROWTHBOOK_CLIENT_KEY` automatically fails open (never calls GrowthBook, never blocks bookings).
+
+---
+
+## TDD Summary
+
+Tests written first (`launch-gate.test.ts`) → service implemented → all 8 tests green → bookings.ts wired → full suite re-run.
+
+```
+✓ isSoftLaunchEnabled > returns false when soft_launch_enabled = false
+✓ isSoftLaunchEnabled > returns true when soft_launch_enabled = true
+✓ isSoftLaunchEnabled > fails open when GrowthBook SDK throws
+✓ isSoftLaunchEnabled > returns true when GROWTHBOOK_CLIENT_KEY is empty
+✓ isMarketingPaused > returns true when marketing_pause_enabled = true
+✓ isMarketingPaused > returns false when marketing_pause_enabled = false
+✓ isMarketingPaused > fails open (returns false) when GrowthBook SDK throws
+✓ isMarketingPaused > returns false when GROWTHBOOK_CLIENT_KEY is empty
+```


### PR DESCRIPTION
## Summary

- **AC-1**: `soft_launch_enabled` GrowthBook flag gates `createBooking`; correctly fails open using `init()` result check (SDK resolves, not rejects, on timeout — `catch` alone was insufficient)
- **AC-2**: `marketing_pause_enabled` toggle for owner-controlled booking pause; evaluated after AC-1, with per-customer GrowthBook attributes for F&F targeting correctness
- **AC-3**: Emergency rollback playbook in `docs/runbook.md` + 10 TDD tests covering all flag states and the real SDK timeout behavior
- **AC-4**: DR drill docs — Cosmos restore, Azure Functions restart, Firebase/FCM/Razorpay outage procedures
- **AC-5**: `docs/launch-checklist.md` — env vars, pre-launch smoke, go-live steps, rollback trigger criteria
- **AC-6**: `api-ship.yml` warning step for missing `GROWTHBOOK_CLIENT_KEY` secret

## Codex review findings (both fixed pre-merge)

- **P1 (fixed)**: `loadFeatures()` delegates to `init()` which resolves `{success:false}` on timeout instead of rejecting. Switched to `init()` + `result.success` check — fail-open now actually works.
- **P2 (fixed)**: No customer attributes on GrowthBook instance meant per-user F&F targeting rules never evaluated. Now creates per-request `GrowthBook({ attributes: { id: userId } })` instances; GrowthBook's module-level feature cache deduplicates network fetches.

## Test plan

- [ ] 880 tests passing (117 test files, zero regressions)
- [ ] `bash tools/pre-codex-smoke-api.sh` → exit 0
- [ ] `.codex-review-passed` marker present at HEAD
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)