### PR TITLE
docs(e11): durable screen hooks spec + codex briefings + S01a plan trio

### DIFF
--- a/docs/superpowers/specs/.codex-briefings/2026-05-01-e11-decomposition-review.md
+++ b/docs/superpowers/specs/.codex-briefings/2026-05-01-e11-decomposition-review.md
@@ -1,0 +1,142 @@
+# Codex Adversarial Review — E11 (Durable Screen Hooks) Decomposition
+
+**Reviewer:** OpenAI Codex CLI
+**Author:** Claude Opus 4.7 (mid-brainstorm with project owner)
+**Date:** 2026-05-01
+
+You are being consulted as an independent senior staff engineer for adversarial review on a story decomposition I (Claude) have proposed to the project owner. The owner has explicitly delegated the open questions to your judgement.
+
+**Don't redesign — attack what's wrong, missing, or under-thought.** Be blunt. Where am I rationalizing? What would a senior staff engineer reading this proposal flag?
+
+You have full repo access — verify any claim against the code (e.g., grep `api/src/functions/` to confirm which endpoints exist).
+
+---
+
+## Project Context
+
+- Monorepo: `customer-app/` (Kotlin + Compose), `technician-app/` (Kotlin + Compose), `api/` (Node 22 + Fastify on Azure Functions + Cosmos DB serverless), `admin-web/` (Next.js).
+- **Hard constraint:** ₹0/month operational infra at pilot scale (≤5k bookings/mo). Cosmos serverless cap 1000 RU/s.
+- 26/45 stories already shipped across E01–E10. This is proposed **E11 — Durable Screen Hooks**.
+- Branch convention: feature branches → Codex review → CI → main.
+
+## Design Goal (owner's framing)
+
+> "Every screen needs durable entry points: workflow path, event/push/deep-link, resume/fallback from normal UI, app-start backend state reconciliation. Events only wake the app — backend state decides reachability."
+
+## Locked Decisions (do not relitigate)
+
+1. **Pending actions are a durable action *index*, not entity source-of-truth.** Persisted Cosmos collection `pending_actions` (partition key `/userId`, deterministic id `<TYPE>:<role>:<userId>:<entityType>:<entityId>`). Source entity always re-fetched on screen entry.
+2. **Local store:** Room with `pending_actions` table (per-app). DAO: `upsertAll`, `deleteMissingFromServer`, `observeActive`, `markResolved`, `purgeExpired`.
+3. **Routes:** sealed `AppRoute` catalog (per-app) + Compose Nav 2.8 `@Serializable` + `kotlinx-serialization`. New `core-nav` Gradle module holds shared contracts only (`RouteSpec`, `PendingActionType`, `PendingAction`, `NotificationIntent`, URI helpers); Room stays per-app.
+4. **Reconciliation triggers:** cold-start-after-auth, home/dashboard `onResume`, FCM receipt, pull-to-refresh.
+5. **Deep links:** FCM data-message extras + `homeservices://action/<TYPE>?<args>`. HTTPS App Links deferred (no domain yet).
+6. **Initial-route priority ladder (6 tiers):**
+   - T0 GATE — unauthenticated → AuthRoute
+   - T1 BLOCKING — tech KYC NOT_STARTED/INCOMPLETE → KycRoute
+   - T2 LIVE_OPS — tech active job in {ASSIGNED, EN_ROUTE, REACHED, IN_PROGRESS}; customer booking AWAITING_PRICE_APPROVAL
+   - T3 HIGH_ACTION — JOB_OFFER_ACTIVE (unexpired), SAFETY_SOS_FOLLOWUP
+   - T4 NORMAL_ACTION — KYC_RESUME, COMPLAINT_UPDATE, SUPPORT_FOLLOWUP
+   - T5 LOW_ACTION — RATING_PROMPT, REVIEW_REVEAL, EARNINGS_UPDATE
+   - T6 DEFAULT — role-specific home/dashboard
+   - Tie-break within tier: earliest expiresAt → oldest createdAt → lexicographic id.
+7. **Foreground FCM never auto-navigates.** If current top route IS the target for the action AND entityId matches → silent `SourceRefreshNeeded`. Else if HIGH priority → persistent banner. Else cards-only update.
+8. **Customer ServiceTracking is NOT Tier 2** — surfaces as home card; tap-driven only. (Tech is contractually obligated; customer is not.)
+9. **Component split:** `NotificationRouter` parses; `PendingActionStore` persists; `PendingActionIngestor` orchestrates (parse → upsert → emit foreground event / build tray notification).
+10. **Strict ordering invariant:** every projector path MUST be `upsert(action) → emit(fcm)`, enforced via Semgrep rule + tests.
+
+## Proposed Story Decomposition
+
+| ID | Title | Tier | Depends on | Plan model |
+|---|---|---|---|---|
+| **S01** | Android infra: `core-nav` + Room + Router + Ingestor + Coordinator + spike + route migration | Foundation | — | Opus |
+| **S02** | Backend: `pending_actions` collection + projector + read API + dashboard endpoints | Feature | — | Sonnet |
+| **S03** | Customer home — pending actions + active booking + recent bookings | Feature | S01 + S02 | Sonnet |
+| **S04** | Tech dashboard — availability + KYC + assignment + offer + rating + earnings + ratings + support | Feature | S01 + S02 | Sonnet |
+| **S05a** | Tech job hooks — add-on request CTA + complaint entry from active/closed job | Feature | S01 + S04 | Sonnet |
+| **S05b** | Customer trust truth-up — SOS audio + trust dossier conditional + confidence score conditional | Feature | S01 + S03 | Sonnet |
+| **S05c** | Onboarding placement — first-run gate before KYC + persist `onboardingShownAt` | Feature | S01 | Sonnet |
+| **S06** | Static reachability CI gate | Foundation (codemod) | S01–S05c | Sonnet |
+
+**Dependency graph:** S01 + S02 (parallel) → S03 + S04 (parallel) → S05a + S05b + S05c (parallel) → S06.
+
+### S01 detail
+
+- Work streams: WS-A core-nav module + tier-ladder pure logic + URI helpers; WS-B per-app Room layer (parallel to WS-A); WS-C per-app NotificationRouter adapter + Ingestor + FCM service wiring; WS-D spike (kotlinx-serialization plugin + 1 simple route + 1 arg route + Paparazzi smoke) + AppRoute catalog seed + **route migration of all existing customer-app + tech-app routes** (Haiku codemod); WS-E cold-start integration (MainActivity → auth → reconcile → tier ladder → coordinator); WS-F smoke + Codex.
+- **Risk:** plan length may exceed Foundation 1500-line gate. If so, pre-planned split: **S01a** = core-nav + Room + tier ladder + spike; **S01b** = NotificationRouter + Ingestor + FCM services + cold-start + route migration. Decision deferred to plan-write.
+
+### S02 detail
+
+- Endpoints (some may already exist — first plan task is to grep `api/src/functions/`):
+  - `GET /v1/customers/me/pending-actions` (new)
+  - `GET /v1/technicians/me/pending-actions` (new)
+  - `GET /v1/customers/me/bookings?status=...` (likely partial)
+  - `GET /v1/technicians/me/dashboard` (new aggregator)
+  - `GET /v1/technicians/me/active-job` (likely exists in `active-job.ts`)
+  - `PATCH /v1/technicians/me/availability` (likely missing)
+- Cosmos collection + indexes + Zod schema + 5 projector triggers (bookings, ratings, kyc, job_offers, complaints).
+
+### S05a detail
+
+- IN_PROGRESS active-job screen gains "Request add-on" CTA → `POST /v1/bookings/{id}/request-addon` → screen shows "Waiting for customer approval" (new source state `ADDON_PENDING_CUSTOMER_APPROVAL` projected into customer's pending actions).
+- Complaint entry from active-job + rating-receive screen → new `ReportIssueRoute`.
+
+### S05b detail
+
+- **SOS audio decision (ADR-required):** A) wire local recording to upload via Firebase Storage (booking-scoped, encrypt-at-rest, 7-day TTL); B) change UI copy to "local recording only — replay on this device." Owner picks.
+- Trust dossier conditional render (PlatformTrustCard before assignment).
+- Confidence score conditional load (only after technicianId assigned).
+
+### S06 detail
+
+- Gradle task `:reachabilityCheck` reflects on `AppRoute` sealed hierarchy + manifest deep-links + `PendingActionType` enum + NavGraph composable bindings + per-app `WorkflowEntries.kt`.
+- **Asserts:** every AppRoute leaf has ≥1 of {workflow entry, FCM type → routeFor, deep-link filter, dashboard pending-action mapping}. CI gate.
+- **Out of scope:** runtime "fetch backend state before sensitive action" — code-review checklist only.
+
+---
+
+## Open Questions for You to Answer Authoritatively
+
+**Q-A. S01 split contingency.** Defer split decision to plan-write time, or pre-commit to splitting into S01a (infra + spike) + S01b (FCM services + cold-start + route migration) regardless of size?
+
+**Q-B. S02 endpoint confirmation.** Defer endpoint-existence verification to plan-write, or grep `api/src/functions/` now and amend S02's scope before writing the spec?
+
+**Q-C. S05b SOS audio decision.** Block S05b execution until owner picks A vs B, or carve out the SOS sub-task into its own micro-story (S05b-1 SOS, S05b-2 trust dossier + confidence) so the trust/confidence work is unblocked?
+
+---
+
+## Adversarial Challenges (be blunt)
+
+**C-1. Decomposition completeness.** Is any story missing? Specifically:
+- Do we need a separate observability/instrumentation story (e.g., metric: "% of FCM deliveries that result in a `pending_actions` row write within N seconds")? Or is that a per-story acceptance criterion?
+- Do we need a dedicated "logout / cross-user residue cleanup" story (Room.clearAll on logout, FCM token rotation, projector idempotency on user-id reuse)? Or does that fold into S01?
+- Should there be an explicit "kill the in-memory event bus" cleanup story for the existing fragile paths in E04-S03 / E06-S03 / E07-S01 / E08-S03? Or does that fold into S03 / S04 amendment scope?
+
+**C-2. S01 spike + route migration in one story.** Is bundling the right call, or should the spike be its own micro-story (S00) ahead of S01? My instinct: bundle to avoid coordinating two ceremony tiers, but if the spike fails I'd be mid-story with no fallback path. Codex: spike-as-its-own-story Y/N?
+
+**C-3. S06 placement at the end.** Should the static reachability gate be S01-adjacent (warn-only mode early; fail mode after S05c) so it grows with the codebase, or is end-of-epic placement correct? My fear of placing it earlier: noise from legitimately-unreachable-yet routes during S03/S04/S05* development. But maybe warn-only + fail-late is better than no gate during development?
+
+**C-4. S05a depending on S04 (not S01 directly).** S05a's add-on CTA lives on the active-job screen, which exists today (E06-S01). The pending-action wire-up that S05a creates lands a new `PendingActionType.ADDON_PENDING_CUSTOMER_APPROVAL`. Does S05a need S04's dashboard scaffolding, or only S01's infra? If only S01: S05a can ship in parallel with S03/S04, shortening the critical path by ~2 days.
+
+**C-5. S02 projector source coverage.** The 5 projectors are bookings, ratings, kyc, job_offers, complaints. The `complaints` collection assumes E07-S03 has shipped — has it? If not, that projector is no-op until E07-S03 lands. Verify by reading repo state. Same for `job_offers` (E05-S03/S04).
+
+**C-6. Bundling all 5 projectors into S02.** Right call, or should I split per-source? My case for one story: shared upsert-before-FCM invariant, shared Semgrep rule, shared idempotency tests, shared Cosmos schema. Splitting = 5 stories with mostly-duplicated test scaffolding. Codex: 1 story or 5?
+
+**C-7. The cross-app RouteSpec enum drift risk.** core-nav holds the canonical `RouteSpec` enum; both apps consume it. Customer-app and tech-app have largely disjoint route inventories — only PRICE_APPROVAL_REQUIRED + ADDON_PENDING_CUSTOMER_APPROVAL are cross-cutting. Does shoving ALL route specs into one shared enum create unnecessary coupling? Or is one-enum-per-namespace (customer routes / tech routes / shared) cleaner? Trade-off: shared enum simplifies S06's reachability gate; namespaced enums prevent accidental cross-app references.
+
+**C-8. The `PATCH /v1/technicians/me/availability` claim.** I've assumed it doesn't exist and is a net-new endpoint. The owner's design called it "real backend toggle, not local-only state." Verify by reading `api/src/functions/technicians.ts` and tell me if I'm wrong.
+
+**C-9. Foreground FCM banner suppression.** "If current top route IS the target → silent SourceRefreshNeeded" — what if the screen has unsaved user input (e.g., customer is mid-rating draft when ADDON_PENDING_CUSTOMER_APPROVAL fires for the same booking)? The silent refresh might wipe state. Is there a missing "preserve dirty state" rule, or is this a non-issue because the rating screen and price-approval screen are different routes for different `entityId`s?
+
+**C-10. Tier-ladder live-ops asymmetry.** Tier 2 force-routes tech to active job but NOT customer to tracking. Defensible UX, but it creates an asymmetry that future contributors will be tempted to "fix." Should the spec explicitly document the asymmetry as a deliberate UX rule with the rationale, or just leave it as the tier-ladder definition?
+
+---
+
+## What I Need From You
+
+For each Q-A / Q-B / Q-C — **a one-paragraph answer with your recommendation**.
+
+For each C-1 through C-10 — **flag if I'm wrong, dismiss if I'm right, suggest a concrete fix if there's a better answer**.
+
+Then a final paragraph: **"What would a senior staff engineer reading this proposal flag that I haven't asked about?"**
+
+Be terse. No essays. No diplomatic hedging. If I'm rationalizing, say so.

--- a/docs/superpowers/specs/.codex-briefings/2026-05-01-e11-final-verify.md
+++ b/docs/superpowers/specs/.codex-briefings/2026-05-01-e11-final-verify.md
@@ -1,0 +1,53 @@
+# Codex Verify Pass — E11 Final Spec
+
+**Reviewer:** OpenAI Codex CLI
+**Date:** 2026-05-01
+**Prior round:** `docs/superpowers/specs/.codex-briefings/2026-05-01-e11-decomposition-review.md`
+**Artifact under review:** `docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md`
+
+You previously did an adversarial first pass on Claude's E11 proposal. Claude integrated your corrections into a final spec at the path above. **Read it.** This is a verify pass.
+
+The owner asked a binary question: "do you and Claude both agree with the plan?" Don't pretend agreement. Don't hedge.
+
+## What to check
+
+### 1. Faithful integration of first-pass corrections
+
+For each, confirm whether the spec reflects your earlier guidance — point to file line numbers or flag if missing/incorrect:
+
+- Stale-event resurrection: `version` + monotonic `updatedAt` + ingest drops older payloads.
+- Dirty-state merge contract: per-screen `DirtyStateMerger`, banner instead of silent reload when unsafe.
+- RouteSpec decoupling: shared `RouteSpec` interface + per-app `CustomerRouteSpec` / `TechnicianRouteSpec` enums.
+- Event-bus removal listed explicitly (the 6 buses you grepped).
+- Logout cleanup explicit (Room.clearAll + FCM token delete + topic unsubscribe).
+- S05a source state correction: `AWAITING_PRICE_APPROVAL` stays as source state; `ADDON_APPROVAL_REQUESTED` is the pending-action TYPE only.
+- `ActiveJobResponse.id` mismatch flagged as S04 pre-req hygiene.
+- `dispatch_attempts` naming (not `job_offers`).
+- Observability as S02 acceptance criteria, not a separate story.
+- S01 split into S01a/S01b pre-committed.
+- S06 split into S06-warn (after S01b) + S06-fail (after S05c).
+- S05b split into S05b-1 (trust+confidence, unblocked) + S05b-2 (SOS, owner-blocked).
+- Existing FCM wire types reused; no invented type names.
+- Storage rules + TTL flagged for S05b-2 Option A.
+
+### 2. Did the integration introduce new errors?
+
+Look for over-corrections, contradictions, or sloppy translations between sections.
+
+### 3. Claude's own residual concerns
+
+Claude flagged these. Validate or push back:
+
+a. **S01b still big.** Pre-commit S01b-1 / S01b-2 split now? Or keep "split if exceeds 1500 lines" deferral?
+b. **`version` server-side semantics underspecified.** Cosmos `_etag` optimistic concurrency? Read-then-write transaction? Where does the bump happen — projector code or stored procedure?
+c. **S06-warn suppression workflow hand-wavy.** Who adds entries, who reviews, what's the expiry default during active development?
+d. **Android 13+ POST_NOTIFICATIONS runtime permission** not enumerated in the spec. Where does it belong?
+e. **S01a spike fallback** under-specified. If kotlinx-serialization spike fails, does S01b mid-pivot or replan?
+
+### 4. Anything still missing
+
+What would a senior staff engineer reading this spec flag that neither you nor Claude has surfaced?
+
+## Output format
+
+Bullet form. Under 400 words. Lead with the binary: **"Agree" or "Don't agree, here's what to fix."** Then point-by-point.

--- a/docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md
+++ b/docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md
@@ -1,0 +1,903 @@
+# E11 — Durable Screen Hooks (Epic Spec)
+
+**Status:** Brainstorm complete · awaiting owner spec-review · awaits writing-plans
+**Date:** 2026-05-01
+**Owner:** Alok Tiwari
+**Review trail:** Brainstorm with Claude Opus 4.7 → adversarial review by OpenAI Codex CLI 0.125.0 (briefing: `docs/superpowers/specs/.codex-briefings/2026-05-01-e11-decomposition-review.md`)
+**Touches:** `customer-app/`, `technician-app/`, `api/`
+
+---
+
+## 1. Design Goal
+
+> Every implemented screen must have at least one durable entry point. **Events only wake the app. Backend state decides which screen the user can reach.**
+
+The four entry-path categories that satisfy "durable":
+
+1. **Workflow path** — a normal-UI navigation lineage from home/dashboard.
+2. **Event/push/deep-link path** — FCM data message → tray notification → typed deep-link URI.
+3. **Resume/fallback path** — a card on home/dashboard surfaces unresolved state if the user missed the push.
+4. **App-start reconciliation** — backend `/me/pending-actions` rebuilds the local view on cold start.
+
+A screen counts as **hooked** iff: reachable in foreground, after app restart, from a normal UI state if push was missed, and it fetches current backend state before sensitive actions.
+
+---
+
+## 2. Locked Architectural Decisions
+
+### 2.1 Pending actions are a *durable action index*, not entity source-of-truth
+
+- Persisted Cosmos collection `pending_actions`, partition key `/userId`.
+- Deterministic id: `<TYPE>:<role>:<userId>:<entityType>:<entityId>` — idempotent upserts.
+- **Source entity is always re-fetched on screen entry.** The action row is a discovery/reachability handle, not the truth about the booking/job/rating itself.
+- Dashboard counters and recent-bookings lists stay computed-on-read from source collections; promotion to denormalized only if RU budget forces it.
+
+### 2.2 Local store: Room (per-app)
+
+- `pending_actions` table mirrors the API row plus `lastFetchedAt` and `version`.
+- Indexes on `status`, `type`, `expiresAt`, `priority`, `createdAt`.
+- DAO methods: `upsertAll`, `markMissingAsResolved` (tombstones), `observeActive`, `findById`, `markResolved`, `purgeExpired`, `purgeTombstones` (30d), `clearAll` (logout).
+
+### 2.3 Routes: sealed `AppRoute` + Compose Nav 2.8 typed serialization
+
+- Compose Navigation 2.8.9 already on classpath in both apps — no version bump needed.
+- `kotlinx-serialization` plugin added in S01a as a spike with rollback path.
+- Per-app `AppRoute` sealed hierarchy with `@Serializable` data classes; spec returns app-local `RouteSpec` enum implementing shared `RouteSpec` interface.
+
+### 2.4 Reconciliation triggers (4)
+
+1. Cold start after auth.
+2. Home/dashboard `onResume`.
+3. FCM data-message receipt.
+4. Pull-to-refresh on home/dashboard.
+
+Server response evicts local rows missing from response. Local store is a cache + notification bridge — never authority.
+
+### 2.5 Deep links
+
+- FCM data-message extras → `homeservices://action/<TYPE>?<args>` URI.
+- HTTPS App Links (Digital Asset Links) deferred — no domain ownership yet.
+
+### 2.6 Initial-route priority ladder (6 tiers)
+
+```
+T0 GATE          unauthenticated → AuthRoute
+T1 BLOCKING      tech KYC ∈ {NOT_STARTED, INCOMPLETE} → KycRoute
+                 (KYC ∈ {SUBMITTED, MANUAL_REVIEW, COMPLETE} → dashboard with KYC card; not blocked)
+T2 LIVE_OPS      tech active job ∈ {ASSIGNED, EN_ROUTE, REACHED, IN_PROGRESS} → ActiveJobRoute
+                 customer booking AWAITING_PRICE_APPROVAL → PriceApprovalRoute
+                 (Asymmetry: tech is contractually obligated; customer is not.
+                  Customer ServiceTracking is NOT T2 — surfaces as home card; tap-driven only.)
+T3 HIGH_ACTION   JOB_OFFER (unexpired), SAFETY_SOS_FOLLOWUP (future)
+T4 NORMAL_ACTION KYC_RESUME, COMPLAINT_UPDATE, SUPPORT_FOLLOWUP
+T5 LOW_ACTION    RATING_PROMPT_CUSTOMER, RATING_PROMPT_TECHNICIAN, RATING_RECEIVED, EARNINGS_UPDATE
+T6 DEFAULT       role-specific home/dashboard
+```
+
+Tie-break within tier: earliest non-null `expiresAt` → oldest `createdAt` → lexicographic `id`.
+
+### 2.7 Foreground FCM never auto-navigates
+
+```
+on FCM receipt while foreground:
+    parse → ingest (upsert + version check)
+    if currentTopRoute.spec == route(intent).spec && currentTopRoute.entityId == intent.entityId:
+        if screen.isDirty && !screen.canSilentMerge:
+            → emit IngestEvent.RefreshAvailable (banner)
+        else:
+            → emit IngestEvent.SourceRefreshNeeded (silent)
+    else if action.priority == HIGH:
+        → persistent banner with "View now" CTA
+    else:
+        → home/dashboard cards observe Flow; no banner
+```
+
+User tap is the only navigation trigger from foreground FCM.
+
+### 2.8 Component split (single responsibility)
+
+- **`NotificationRouter`** — parses FCM data + deep-link URIs into `NotificationIntent`. Pure parser. Builds `PendingIntent` for tray notifications.
+- **`PendingActionStore`** — Room persistence. No network, no parse.
+- **`PendingActionIngestor`** — orchestrator: receives `NotificationIntent`, fetches source if payload incomplete, **performs version-aware upsert**, emits foreground events.
+
+### 2.9 Strict ordering invariant — projector
+
+Every projector path: `upsert(action) → emit(fcm)`. Never emit FCM without a successful upsert. Enforced via Semgrep rule + tests.
+
+### 2.10 Stale-event resurrection rule (Codex flag — strengthened in verify pass)
+
+**Two mechanisms together:**
+
+**(a) Version comparison.** Every `pending_actions` row carries `version: long` + `updatedAt: long`. Server bumps `version` monotonically. Ingestor compares incoming payload's `version` against existing row's `version`:
+- `incoming.version > existing.version` → upsert.
+- `incoming.version <= existing.version` → drop (idempotent no-op + `pending_action_stale_drop` log).
+
+**(b) Tombstones.** RESOLVED rows are NOT deleted from the local store on reconcile. Reconcile renames `deleteMissingFromServer` → `markMissingAsResolved`: rows present locally but missing from server response are flagged `status = RESOLVED`, `resolvedAt = now`. RESOLVED rows are purged by **`purgeTombstones`** only after `30 days` (TTL > FCM max delivery TTL of 28 days). `purgeExpired` is a separate method that handles ACTIVE rows whose `expiresAt` has passed (e.g., `JOB_OFFER` TTL).
+
+**Why both:**
+- A late-arriving FCM with the SAME id as an existing-but-resolved tombstone hits the `existing.status == RESOLVED → drop` rule.
+- A late-arriving FCM with a NEW id (no existing row) — would otherwise upsert via mechanism (a)'s `existing == null` path. The 30-day tombstone window means there can never be a "new id" arrival for an action older than 30 days.
+- For belt-and-suspenders: when `existing == null`, ingestor calls `api.confirmActive(id)` before upsert. 404 → drop + log.
+
+**Combined ingestor rule:**
+```
+if existing != null && existing.status == RESOLVED → drop
+if existing != null && incoming.version <= existing.version → drop
+if existing == null:
+    if not api.confirmActive(incoming.id) → drop
+    upsert
+else upsert
+```
+
+Without all three checks, a late FCM after the row was server-resolved would resurrect a resolved action. **Critical for correctness.**
+
+### 2.11 Dirty-state merge contract (Codex flag)
+
+Every screen that consumes `IngestEvent.SourceRefreshNeeded` must implement `DirtyStateMerger`:
+
+```kotlin
+interface DirtyStateMerger {
+    fun isDirty(): Boolean
+    fun canSilentMerge(freshSource: SourceEntity): Boolean  // false if user input would be wiped
+}
+```
+
+Coordinator's silent-vs-banner decision (§2.7) consults this. If unsafe to merge silently, show "Refresh available" banner with explicit user tap.
+
+---
+
+## 3. Shared Contracts
+
+### 3.1 `core-nav` module (pure Kotlin, no Android dependencies)
+
+```kotlin
+// shared across both apps
+interface RouteSpec { val name: String }
+
+enum class PendingActionType {
+    ADDON_APPROVAL_REQUESTED,    // existing FCM type — customer
+    RATING_PROMPT_CUSTOMER,       // existing — customer
+    RATING_PROMPT_TECHNICIAN,     // existing — tech
+    RATING_RECEIVED,              // existing — tech
+    EARNINGS_UPDATE,              // existing — tech
+    JOB_OFFER,                    // existing — tech
+    KYC_RESUME,                   // new — tech
+    COMPLAINT_UPDATE,             // new — both
+    SUPPORT_FOLLOWUP,             // new — both
+    SAFETY_SOS_FOLLOWUP           // future
+}
+
+enum class PendingActionStatus { ACTIVE, RESOLVED, EXPIRED }
+enum class PendingActionPriority { HIGH, NORMAL, LOW }
+
+data class PendingAction(
+    val id: String,
+    val userId: String,
+    val role: String,                       // "customer" | "technician"
+    val type: PendingActionType,
+    val entityType: String,
+    val entityId: String,
+    val routeUri: String,                   // homeservices://action/...
+    val priority: PendingActionPriority,
+    val status: PendingActionStatus,
+    val sourceStatus: String?,
+    val version: Long,                      // monotonic; for stale-drop check
+    val createdAt: Long,
+    val updatedAt: Long,
+    val expiresAt: Long?,
+    val resolvedAt: Long?
+)
+
+data class NotificationIntent(
+    val type: PendingActionType,
+    val entityId: String,
+    val rawArgs: Map<String, String>
+)
+
+object DeepLinkUri {
+    fun build(intent: NotificationIntent): String
+    fun parse(uri: String): NotificationIntent?
+}
+
+interface NotificationRouter {
+    fun parseFcmData(data: Map<String, String>): NotificationIntent?
+    fun parseDeepLink(uri: String): NotificationIntent?
+}
+
+interface RouteResolver {
+    suspend fun decideInitialRoute(ctx: RouteContext): RouteSpec
+    fun routeFor(action: PendingAction): RouteSpec
+    fun routeFor(intent: NotificationIntent): RouteSpec
+}
+
+data class RouteContext(
+    val authState: AuthState,
+    val role: String,
+    val activeActions: List<PendingAction>,
+    val techKycStatus: String?,
+    val techActiveJob: ActiveJobSummary?,
+    val customerActiveBookings: List<BookingSummary>
+)
+
+// pure tier-ladder logic — unit-testable, no Android deps
+object TierLadder {
+    fun resolve(ctx: RouteContext): RouteSpec
+}
+```
+
+### 3.2 Per-app — customer-app
+
+```kotlin
+enum class CustomerRouteSpec : RouteSpec {
+    Home, Auth, ServiceTracking, BookingPriceApproval, Rating, Complaint, /*…*/
+}
+
+sealed interface CustomerRoute { val spec: CustomerRouteSpec }
+
+@Serializable
+data class BookingPriceApprovalRoute(val bookingId: String) : CustomerRoute {
+    override val spec get() = CustomerRouteSpec.BookingPriceApproval
+}
+// … one @Serializable per route
+```
+
+### 3.3 Per-app — technician-app
+
+```kotlin
+enum class TechnicianRouteSpec : RouteSpec {
+    Dashboard, Auth, Onboarding, Kyc, JobOffer, ActiveJob, MyRatings, Earnings, Complaint, /*…*/
+}
+
+sealed interface TechnicianRoute { val spec: TechnicianRouteSpec }
+// … one @Serializable per route
+```
+
+### 3.4 Per-app Room schema
+
+```kotlin
+@Entity(
+    tableName = "pending_actions",
+    indices = [Index("status"), Index("type"), Index("expiresAt"), Index("priority"), Index("createdAt")]
+)
+data class PendingActionEntity(
+    @PrimaryKey val id: String,
+    val userId: String,
+    val role: String,
+    val type: String,
+    val entityType: String,
+    val entityId: String,
+    val routeUri: String,
+    val priority: String,
+    val status: String,
+    val sourceStatus: String?,
+    val version: Long,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val expiresAt: Long?,
+    val resolvedAt: Long?,
+    val lastFetchedAt: Long
+)
+
+@Dao interface PendingActionDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(rows: List<PendingActionEntity>)
+
+    @Query("UPDATE pending_actions SET status = 'RESOLVED', resolvedAt = :now WHERE id NOT IN (:keep) AND userId = :userId AND status = 'ACTIVE'")
+    suspend fun markMissingAsResolved(userId: String, keep: Set<String>, now: Long)
+
+    @Query("SELECT * FROM pending_actions WHERE userId = :userId AND status = 'ACTIVE' ORDER BY priority DESC, createdAt ASC")
+    fun observeActive(userId: String): Flow<List<PendingActionEntity>>
+
+    @Query("SELECT * FROM pending_actions WHERE id = :id LIMIT 1")
+    suspend fun findById(id: String): PendingActionEntity?
+
+    @Query("UPDATE pending_actions SET status = 'RESOLVED', resolvedAt = :now WHERE id = :id")
+    suspend fun markResolved(id: String, now: Long)
+
+    /** Purge ACTIVE rows whose TTL has passed (e.g., JOB_OFFER). RESOLVED tombstones are protected — see purgeTombstones. */
+    @Query("DELETE FROM pending_actions WHERE status = 'ACTIVE' AND expiresAt IS NOT NULL AND expiresAt < :now")
+    suspend fun purgeExpired(now: Long)
+
+    /** Tombstone purge: RESOLVED rows older than 30 days. TTL > FCM max delivery TTL (28d). */
+    @Query("DELETE FROM pending_actions WHERE status = 'RESOLVED' AND resolvedAt IS NOT NULL AND resolvedAt < :cutoff")
+    suspend fun purgeTombstones(cutoff: Long)
+
+    @Query("DELETE FROM pending_actions")
+    suspend fun clearAll()
+}
+```
+
+### 3.5 Per-app `PendingActionIngestor`
+
+```kotlin
+class PendingActionIngestor(
+    private val store: PendingActionStore,
+    private val api: PendingActionApi,
+    private val events: MutableSharedFlow<IngestEvent>
+) {
+    suspend fun ingest(intent: NotificationIntent) {
+        val incoming = if (intent.hasFullPayload()) intent.toAction()
+                       else api.fetchById(idFor(intent)) ?: return
+        val existing = store.findById(incoming.id)
+        when {
+            existing != null && existing.status == "RESOLVED" -> {
+                log("pending_action_resolved_drop", incoming.id); return
+            }
+            existing != null && incoming.version <= existing.version -> {
+                log("pending_action_stale_drop", incoming.id, existing.version, incoming.version); return
+            }
+            existing == null && !api.confirmActive(incoming.id) -> {
+                log("pending_action_unknown_drop", incoming.id); return
+            }
+        }
+        store.upsert(incoming)
+        events.emit(IngestEvent.Inserted(incoming))
+    }
+
+    suspend fun reconcile(userId: String) {
+        val server = api.list(userId)
+        store.upsertAll(server)
+        store.markMissingAsResolved(userId, server.map { it.id }.toSet(), now = clock.now())
+        store.purgeExpired(now = clock.now())
+        store.purgeTombstones(cutoff = clock.now() - 30.days.inWholeMillis)
+    }
+
+    suspend fun markResolvedFromFcm(id: String) = store.markResolved(id)
+}
+
+sealed class IngestEvent {
+    data class Inserted(val action: PendingAction) : IngestEvent()
+    data class SourceRefreshNeeded(val entityId: String) : IngestEvent()
+    data class RefreshAvailable(val entityId: String) : IngestEvent()
+}
+```
+
+---
+
+## 4. Data Flow
+
+### 4.1 Cold start
+
+```
+1. MainActivity.onCreate
+2. AuthSession.getCurrent()
+   ├─ null → AuthRoute (T0). STOP.
+   └─ valid → continue
+3. PendingActionIngestor.reconcile(userId)
+4. Source-state probes (parallel; only what T1–T2 need):
+   ├─ tech: GET /v1/technicians/me/kyc/status
+   ├─ tech: GET /v1/technicians/active-job/* (try by current booking if known)
+   └─ customer: GET /v1/customers/me/bookings?status=active
+5. RouteResolver.decideInitialRoute(ctx) — pure TierLadder.resolve
+6. NavigationCoordinator.navigateTo(route, popUpToHome = true)
+```
+
+Offline at step 3 → skip server reconcile, decide route from local Room snapshot, banner indicates stale.
+
+### 4.2 FCM data message — foreground
+
+```
+1. AppFirebaseMessagingService.onMessageReceived(msg)
+2. NotificationRouter.parseFcmData(msg.data) → NotificationIntent
+3. PendingActionIngestor.ingest(intent)        // includes version check
+4. IngestEvent emitted (per §2.7 rule):
+   - if top route matches and screen is dirty + can't merge → RefreshAvailable banner
+   - if top route matches and screen can merge → SourceRefreshNeeded silent
+   - if HIGH priority → persistent banner
+   - else → cards observe Flow; no banner
+5. Never auto-navigate from FCM in foreground.
+```
+
+### 4.3 FCM data message — background
+
+```
+1. AppFirebaseMessagingService.onMessageReceived(msg)
+2. NotificationRouter.parseFcmData → NotificationIntent
+3. PendingActionIngestor.ingest        // upsert into Room
+4. NotificationRouter.buildPendingIntent(intent) → PendingIntent
+   (deep-link URI: homeservices://action/<TYPE>?<args>)
+5. NotificationManagerCompat.notify(channelForType(intent.type), notification)
+```
+
+### 4.4 Notification tap — cold launch
+
+```
+1. PendingIntent fires → MainActivity.onCreate(savedInstanceState=null) with deep-link Uri
+2. Run normal cold-start steps 1–5 (§4.1)
+3. NavigationCoordinator.handleColdStartIntent(intent):
+   ├─ NotificationRouter.parseDeepLink(uri) → NotificationIntent
+   ├─ T0/T1 still apply — auth + KYC blocking gates win even on tap
+   └─ navigate to RouteResolver.routeFor(intent)
+```
+
+### 4.5 Notification tap — hot
+
+```
+1. NewIntent → MainActivity (singleTask launchMode)
+2. NavigationCoordinator.handleHotIntent(intent):
+   ├─ parse deep link
+   ├─ if currentTopRoute interruptibility = LOW (mid-payment/photo-upload) → defer + show banner
+   └─ else navigate
+```
+
+### 4.6 User resolves the action
+
+```
+1. Screen submits to source endpoint
+2. API mutates source entity → change feed → projector → row resolved server-side via ETag/IfMatch (§S02)
+3. Two reconciliation paths:
+   a. FCM "action_resolved" data message → Ingestor.markResolvedFromFcm(id)
+   b. Next reconcile() — server omits resolved rows; markMissingAsResolved tombstones the local row
+   c. Tombstones (status=RESOLVED) are kept locally for 30 days, then purgeTombstones drops them
+```
+
+### 4.7 Logout / cross-user residue cleanup (Codex flag)
+
+```
+on logout:
+    1. PendingActionStore.clearAll()
+    2. FirebaseMessaging.deleteToken()
+    3. FcmTopicSubscriber.unsubscribeAll()
+    4. PendingActionIngestor cancel any in-flight reconcile()
+    5. AuthSession.clear()
+on next login as different user:
+    fresh reconcile() rebuilds local store
+```
+
+---
+
+## 5. Story-by-story Scope
+
+### E11-S01a — Android infra contracts (Foundation, Opus plan)
+
+**Scope:**
+- New `core-nav` Gradle module (pure Kotlin): `RouteSpec` interface, `PendingActionType`, `PendingActionStatus`, `PendingActionPriority`, `PendingAction`, `NotificationIntent`, `DeepLinkUri` builder/parser, `NotificationRouter` interface, `RouteResolver` interface, `RouteContext`, `TierLadder` pure-function ladder logic.
+- Per-app: `PendingActionEntity` + DAO + Room database + `PendingActionStore` impl + Hilt module.
+- **Spike sub-task (first thing in plan):** add `kotlinx-serialization` plugin to both apps' `libs.versions.toml`; convert 1 simple route + 1 arg route per app to `@Serializable`; verify `composable<T>()` + `entry.toRoute<T>()`; run Paparazzi smoke.
+
+**Hard go/no-go on the spike (Codex):**
+- Spike completes with **explicit owner-visible go/no-go decision** at end of S01a plan execution.
+- **If go:** S01b plan is written using typed `@Serializable` routes.
+- **If no-go:** S01b is **frozen**. A fallback ADR is written (`docs/adr/00XX-route-contract-fallback.md`) choosing sealed-class string routes. **No mid-story pivot during S01b.** S01b plan-write does not begin until the fallback ADR is committed.
+
+**Work streams:**
+- WS-A `core-nav` contracts + `TierLadder` (parallel to WS-B; pure Kotlin; Sonnet subagent OK after Opus plan).
+- WS-B per-app Room layer (parallel to WS-A; both apps in parallel via 2 Sonnet subagents).
+- WS-C spike — kotlinx-serialization + 2 routes + Paparazzi smoke. Owner-visible go/no-go gate before S01b.
+- WS-D pre-Codex smoke gate + Codex review.
+
+**Test surface:**
+- `TierLadder` unit tests — every T0–T6 path + tie-break combinations.
+- `DeepLinkUri.build/parse` round-trip (incl. URL encoding edge cases).
+- Room schema migration test (empty → seeded → query → eviction).
+- DAO query correctness (priority ordering, expiry filter, tombstone purge at 30d).
+
+**Acceptance:**
+- `core-nav` module compiles, exports 12 contract types.
+- Both apps wire Room database via Hilt, DI graph compiles.
+- Spike: `BookingPriceApprovalRoute(bookingId="bk123")` round-trips through Compose Nav; Paparazzi golden recorded.
+- **Owner-signed go/no-go decision recorded** (or fallback ADR committed if no-go).
+
+**Out of scope:** NotificationRouter Android adapter (S01b-1), FCM service refactor (S01b-1), route migration (S01b-2).
+
+---
+
+### E11-S01b — pre-split into S01b-1 + S01b-2 (Codex verify pass)
+
+S01b is **pre-committed to a 2-story split**. Codex flagged the "split if over 1500 lines" deferral as the same rationalization as the original S01 deferral.
+
+---
+
+### E11-S01b-1 — Router + Ingestor + FCM + cold-start (Foundation, Opus plan)
+
+**Scope:**
+- Per-app `NotificationRouter` Android adapter (parses `RemoteMessage` → delegates to `core-nav` parser).
+- Per-app `PendingActionIngestor` orchestrator with full stale-event ruleset (§2.10): version compare + tombstone check + `confirmActive` belt-and-suspenders.
+- Customer-app: refactor existing `CustomerFirebaseMessagingService` to delegate to Ingestor.
+- Tech-app: refactor existing `HomeservicesFcmService` to delegate to Ingestor.
+- Cold-start integration in both `MainActivity`s (auth → reconcile → tier ladder → coordinator).
+- **Android 13+ `POST_NOTIFICATIONS` runtime permission flow** (Codex): request on first FCM-relevant screen view. Denied → degrade gracefully (in-app cards stay; no tray notifications). Permission state observable so Coordinator can adjust banner intensity.
+
+**Work streams:**
+- WS-A NotificationRouter adapter + Ingestor (after S01a, with go decision). Sonnet subagent per app.
+- WS-B FCM service refactor (parallel with WS-A).
+- WS-C Cold-start integration (`MainActivity` + `AppNavigation`); after WS-A.
+- WS-D POST_NOTIFICATIONS permission flow + degradation path.
+- WS-E pre-Codex smoke gate + Codex review.
+
+**Test surface:**
+- `Ingestor.ingest` full ruleset: RESOLVED tombstone drop, version stale drop, unknown-id `confirmActive` 404 drop, fresh upsert.
+- `Ingestor.reconcile` semantics: marks-missing-as-resolved, purges expired, purges 30-day tombstones.
+- Cold-start integration test (instrumentation): unauth → AuthRoute; tech KYC NOT_STARTED → KycRoute; tech with active job → ActiveJobRoute.
+- Foreground FCM banner-vs-silent-refresh decision (with dirty-state merger).
+- POST_NOTIFICATIONS denied → tray suppressed, in-app cards still render.
+- POST_NOTIFICATIONS granted → tray notifications work end-to-end.
+
+**Acceptance:**
+- Both apps cold-start through tier ladder.
+- FCM in foreground/background routes through Ingestor.
+- POST_NOTIFICATIONS request flow + denied-path degradation observable.
+
+**Out of scope:** route migration codemod (S01b-2), event-bus removal (S01b-2), logout cleanup wiring (S01b-2).
+
+---
+
+### E11-S01b-2 — Route migration + event-bus removal + logout cleanup (Foundation, Opus plan)
+
+**Scope:**
+- **Route migration codemod (Haiku-suitable):** convert all existing routes in customer-app + tech-app to typed `@Serializable` form (or sealed-class strings if S01a fallback ADR active). Listed targets in §9.
+- **Explicit removal of the 7 event-bus files (6 distinct types — `RatingPromptEventBus` exists in both apps):**
+  - `customer-app/.../data/booking/PriceApprovalEventBus.kt`
+  - `customer-app/.../data/rating/RatingPromptEventBus.kt`
+  - `customer-app/.../data/tracking/TrackingEventBus.kt`
+  - `technician-app/.../data/jobOffer/JobOfferEventBus.kt`
+  - `technician-app/.../data/earnings/EarningsUpdateEventBus.kt`
+  - `technician-app/.../data/rating/RatingPromptEventBus.kt`
+  - `technician-app/.../data/rating/RatingReceivedEventBus.kt`
+  - Replace each consumer with `PendingActionStore.observeActive` filtered by relevant type, plus `IngestEvent` flow collection where foreground reactivity is needed.
+- **Logout cleanup wiring** (§4.7): `PendingActionStore.clearAll()` + `FirebaseMessaging.deleteToken()` + topic unsubscribe in `LogoutUseCase`.
+
+**Work streams:**
+- WS-A Route migration codemod (Haiku subagent; mechanical sweep).
+- WS-B Event-bus removal (Haiku-then-Sonnet — codemod removes injection sites, Sonnet replaces consumers).
+- WS-C Logout cleanup integration.
+- WS-D pre-Codex smoke gate + Codex review.
+
+**Test surface:**
+- All routes round-trip through typed `@Serializable` form.
+- Every prior consumer of each event bus compiles + observes via Ingestor/Store.
+- Logout clears store + FCM token + topics; verified by integration test.
+
+**Acceptance:**
+- All 7 event-bus files deleted from the codebase.
+- Logout leaves no `pending_actions` rows + no FCM topic subscriptions + no FCM token.
+- Codex review passes; CI green.
+
+**Depends on:** S01b-1 (router/ingestor wiring must exist before consumers can migrate to it).
+
+---
+
+### E11-S02 — Backend pending-actions + observability (Foundation, Opus plan)
+
+**Scope — endpoints:**
+
+| Method | Path | Status | Notes |
+|---|---|---|---|
+| GET | `/v1/customers/me/pending-actions` | new | filter status=ACTIVE + expiresAt>now |
+| GET | `/v1/technicians/me/pending-actions` | new | same |
+| GET | `/v1/customers/me/bookings?status=...` | partial | confirm in `bookings.ts`; computed-on-read |
+| GET | `/v1/technicians/me/dashboard` | new aggregator | KYC + active-job + pending-offer + today's earnings + today's ratings |
+| GET | `/v1/technicians/active-job/{bookingId}` | exists | `active-job.ts:117` — no change |
+| PATCH | `/v1/technicians/me/availability` | **new — net-new endpoint** | replaces local-only toggle |
+
+**Cosmos:**
+- New collection `pending_actions`, partition key `/userId`.
+- Composite index `(userId, status, expiresAt)` for hot read.
+- Indexes on `priority`, `createdAt`, `type`.
+- Zod schema `api/src/schemas/pendingActions.ts`.
+- **`version` field is monotonic int.** Bumped on every mutation by projector via Cosmos optimistic concurrency:
+  ```
+  1. read row by id (returns _etag)
+  2. compute new state; new_version = existing.version + 1 (skip bump if mutation is semantic no-op)
+  3. replace with header IfMatch: <_etag>
+  4. on 412 Precondition Failed → re-read + retry (max 3 attempts, exponential backoff)
+  5. on 5xx → emit pending_action_upsert_failed log; do NOT call sendFcm; rely on next change-feed retry
+  ```
+- **No version inflation:** if a change-feed event would set the same logical state (e.g., booking transitioned through a state then back to same state), `upsertAction` returns the existing row unchanged.
+
+**Projector triggers (5 source adapters; one shared harness):**
+
+| Adapter | Source collection | `PendingActionType` emitted (must match enum in §3.1) |
+|---|---|---|
+| `bookings` | `bookings` (existing change feed) | `ADDON_APPROVAL_REQUESTED`, `RATING_PROMPT_CUSTOMER`, `COMPLAINT_UPDATE` |
+| `ratings` | `ratings` | `RATING_RECEIVED` |
+| `kyc` | `kyc_submissions` | `KYC_RESUME` |
+| `dispatch_attempts` | `dispatch_attempts` (NOT `job_offers`) | `JOB_OFFER` |
+| `complaints` | `complaints` (existing — `complaints-repository.ts`) | `COMPLAINT_UPDATE` |
+
+(Naming aligned with existing FCM wire types per §9.2 and §3.1 enum. **No invented type names.**)
+
+**Shared harness (single file `services/pending-action-projector.ts`):**
+- `upsertAction(action)` — version-bumping idempotent upsert via ETag/IfMatch (above).
+- `resolveAction(id)` — sets status=RESOLVED, bumps version (same ETag flow).
+- `expireAction(id)` — sets status=EXPIRED, bumps version.
+- **Strict ordering helper:** `await upsertAction(); await emitFcm()` — never reverse.
+
+**Semgrep rule:** in any file matching `trigger-projector-*.ts`, fail CI if `sendFcm()` is called before `upsertAction()` in the same function body.
+
+**Observability acceptance criteria (Codex flag):** structured logs at:
+- `pending_action_upsert` (id, version, action_type, projector_source)
+- `pending_action_stale_drop` (id, existing_version, incoming_version) — client-side
+- `fcm_send_attempt` (action_id, target_user_id)
+- `fcm_send_success` (action_id, ms_elapsed)
+- `fcm_send_failure` (action_id, error_code) — does not retry inline; relies on next reconcile()
+
+Logs shipped via existing OpenTelemetry pipeline (per `api/src/observability/`).
+
+**Work streams:**
+- WS-A Cosmos collection + Zod schema + indexes + RU budget probe.
+- WS-B Projector harness + 5 source adapters (parallel — fan out 5 Sonnet subagents after harness).
+- WS-C Read API + dashboard aggregator + availability PATCH.
+- WS-D Auth middleware audit (cross-user 403 tests on every endpoint).
+- WS-E Semgrep rule + observability logs.
+- WS-F pre-Codex smoke gate + Codex review.
+
+**Test surface:**
+- Duplicate change-feed events → idempotent upsert (no version inflation).
+- Stale-state cleanup (booking moves AWAITING_PRICE_APPROVAL → PAID → projector resolves `ADDON_APPROVAL_REQUESTED`).
+- Expiry (`dispatch_attempts` TTL passes → `JOB_OFFER` action expired by background timer).
+- Cross-user 403 (user B fetches user A's actions).
+- FCM-after-upsert ordering (Semgrep rule fires on inverted code).
+- `version` monotonicity under concurrent writes (412 retry path under simulated contention).
+- Semantic-no-op mutation does NOT bump version.
+- Read API filters resolved/expired correctly.
+
+**Acceptance:**
+- All 6 endpoints respond with correct shapes.
+- All 5 projectors observed during integration test (synthetic state transitions trigger correct upserts).
+- Semgrep rule ships and fires.
+- Structured logs visible in OTel.
+- ETag retry path verified under contention test.
+
+---
+
+### E11-S03 — Customer home durable hooks (Feature, Sonnet plan)
+
+**Scope:**
+- Replace `CatalogueHomeScreen` → `CustomerHomeScreen` with state-driven sections:
+  1. **Pending actions stack** (top 3 by priority) — observes `PendingActionStore.observeActive(role=customer)`.
+  2. **Active booking card(s)** — observes `BookingsRepository.observeActive()` via `GET /v1/customers/me/bookings?status=active`. Tap → `ServiceTrackingRoute` (or `BookingPriceApprovalRoute` if applicable).
+  3. **Recent bookings list** (last 5 completed) — entry to Rating, Complaint, Receipt.
+  4. **Catalogue sections** (existing) — below state-driven sections.
+- ViewModel implements `DirtyStateMerger` (returns `false` for `isDirty()` — home is read-only, always silent-merge OK).
+- Paparazzi goldens (CI Linux only) for: empty state, with-pending-actions, with-active-booking, with-recent-bookings, full state.
+
+**Test surface:**
+- ViewModel state composition (3 Flows merged correctly).
+- Pending action card tap → correct `routeFor(action)`.
+- Active booking card tap → tracking vs price-approval branching.
+
+**Out of scope:** SOS, trust dossier, confidence score (see S05b-1, S05b-2).
+
+---
+
+### E11-S04 — Technician dashboard durable hooks (Feature, Sonnet plan)
+
+**Pre-req hygiene (first task in plan):** Fix `ActiveJobResponse.id` mismatch — Android expects `id`, API returns `bookingId`. Either rename Android field or adjust API response. Owner pick at plan-write; default to API-side rename to `id` for consistency. Codex flagged this as an existing bug worth fixing before E11 builds on it.
+
+**Scope:**
+- Replace `HomeGraph` landing → `TechnicianDashboardScreen` with sections:
+  1. Availability toggle — round-trips `PATCH /v1/technicians/me/availability` (real, not local-only).
+  2. KYC status card (only shown if status ∈ {SUBMITTED, MANUAL_REVIEW, COMPLETE}; NOT_STARTED/INCOMPLETE blocks at T1).
+  3. Current assignment card — observes `DashboardRepository.observe()`. Tap → `ActiveJobRoute(bookingId)`.
+  4. Pending offer card — TTL countdown; observes `PendingActionStore` filtered by `JOB_OFFER`.
+  5. Pending rating prompt card — `RATING_PROMPT_TECHNICIAN`.
+  6. Earnings summary chip → tap to existing earnings screen.
+  7. Ratings summary chip → tap to existing my-ratings screen.
+  8. Support entry → complaints.
+- ViewModel implements `DirtyStateMerger` (always silent-merge OK).
+- Paparazzi goldens.
+
+**Test surface:** dashboard composition; availability PATCH integration; pending-action card filtering by type; KYC card visibility.
+
+---
+
+### E11-S05a — Tech job execution hooks (Feature, Sonnet plan)
+
+**Scope:**
+- IN_PROGRESS active-job screen gains "Request add-on" CTA. Endpoint exists (`POST /v1/bookings/{id}/request-addon` at `bookings.ts:109`).
+- After call succeeds, screen shows "Waiting for customer approval" pending banner. Source state remains `AWAITING_PRICE_APPROVAL`; the **pending-action TYPE** is `ADDON_APPROVAL_REQUESTED` (existing FCM wire type, projected into customer's pending actions by the bookings projector).
+- Complaint entry from active-job (in-progress + completed) and from rating-receive screen → existing `Complaint` route (already exists).
+
+**Test surface:** add-on request UX (CTA visibility on IN_PROGRESS only; "waiting" banner after submission); complaint entry navigation.
+
+**Note:** Codex correction — I was wrong to invent a new source state. Use existing `AWAITING_PRICE_APPROVAL` source state; the action TYPE is the discovery handle.
+
+---
+
+### E11-S05b-1 — Customer trust dossier + confidence (Feature, Sonnet plan)
+
+**Scope:**
+- `TrustDossierCard` accepts nullable `technicianId: String?`. If null, render `PlatformTrustCard` (service-level + platform-level trust badges; no fake tech avatar; no "unavailable technician" placeholder).
+- Confidence score conditional load — only fetch when `assignedTechnicianId` exists. Surfaces on assigned-booking + tracking only; NOT on generic catalogue browsing.
+
+**Test surface:** trust dossier null-vs-present rendering; confidence-score fetch conditional.
+
+---
+
+### E11-S05b-2 — Customer SOS audio truth-up (Feature, Sonnet plan, OWNER-BLOCKED)
+
+**Owner decision required at plan-write time:**
+
+- **Option A — wire upload:** SOS recording (`filesDir/sos/sos-<bookingId>.m4a`) uploads to Firebase Storage at `bookings/{bookingId}/sos/{technicianUid}/<timestamp>.m4a`. Storage rules amended (currently only allow photos at `bookings/{bookingId}/photos/...` per `firebase/storage.rules:18`). Encrypt-at-rest (existing default). 7-day TTL via Cloud Function or scheduled cleanup. ADR documents privacy + storage cost.
+- **Option B — copy fix:** change `SosConsentDialog` copy from "You can attach a short local audio recording to help owner support review the situation" (at `SosConsentDialog.kt:17`) to "Recording stays on this device for your reference. It will not be uploaded." Delete `MediaRecorder` upload-path code.
+
+**Scope (after owner picks):**
+- Implement chosen option.
+- Update existing `triggerSos` API consumer (`SosUseCase.kt`) to pass storage path if Option A.
+- Test surface depends on option.
+
+**Codex flag:** existing app records locally but never uploads. Current copy implies attachment. **This is a real bug** — must be resolved one way or another.
+
+---
+
+### E11-S05c — Onboarding placement (Feature, Sonnet plan)
+
+**Scope:**
+- T1 ladder update: `if (tech.firstRun && tech.kycStatus == NOT_STARTED) → OnboardingRoute → KycRoute`. Persist `onboardingShownAt` in DataStore (or post to `POST /v1/technicians/me/onboarding-completed` if owner wants server-side tracking; default local).
+- Ladder paths tested: fresh signup (Onboarding → KYC), returning incomplete-KYC (skip Onboarding → KYC), returning manual-review (dashboard with KYC card), returning complete (dashboard).
+
+---
+
+### E11-S06-warn — Static reachability gate (warn-only mode) (Foundation, Sonnet plan)
+
+**Scope:**
+- Gradle task `:reachabilityCheck` per app, runs on every PR.
+- Reflects on:
+  1. `AppRoute` sealed hierarchy (every leaf type).
+  2. `AndroidManifest.xml` deep-link `<intent-filter>` entries.
+  3. `PendingActionType` enum.
+  4. NavGraph composable bindings (extracted via KSP or AST scan of `AppNavigation.kt` + graph files).
+  5. Per-app `WorkflowEntries.kt` declaration (manual list of `RouteSpec → entry-from-screen` pairs).
+- For each `AppRoute` leaf, asserts ≥1 of: workflow entry, `PendingActionType → routeFor` mapping, deep-link filter, dashboard pending-action mapping.
+- **Warn-only mode:** logs missing reachability to CI output; does NOT fail build.
+
+**Suppression workflow (Codex):**
+- File path: `<app>/reachability-suppressions.txt` (committed; one per app).
+- Line format: `<RouteName> <expiry-date-iso> <author-handle> <reason>`
+- **Rules:**
+  - Only the project owner (`Alok Tiwari`) may add or extend a suppression. PR author cannot self-suppress.
+  - PR adding a suppression must include co-review by owner (squash-merge requires owner-approved review).
+  - **Default expiry: 14 days.** Maximum allowed: 30 days. Longer requires explicit owner-written ADR.
+  - Expired entries fail CI (warn mode) **loudly** — i.e., CI step exits 0 but with `##[error]` annotation visible in the PR check.
+  - Suppressions audited monthly (cron job opens issue listing all active suppressions and their expiries).
+
+**Acceptance:** runs on every PR; emits warnings; suppressions file in place with the workflow above; no build failures from missing reachability yet.
+
+**Out of scope:** runtime "fetches current backend state before sensitive action" — that's a per-story acceptance criterion + code-review checklist.
+
+---
+
+### E11-S06-fail — Static reachability gate (promote to fail mode) (Foundation, Sonnet plan)
+
+**Scope:**
+- Promote `:reachabilityCheck` from warn-only to fail mode.
+- Audit `app/reachability-suppressions.txt` — every entry must have explicit owner sign-off and a future expiry; expired entries cause CI fail.
+- Add `:reachabilityCheck` to `ship.yml` required checks.
+
+**Acceptance:** PR with unreachable route fails CI; PR with valid suppression passes; expired suppression fails CI.
+
+---
+
+## 6. Error/Edge Handling
+
+| Case | Handling |
+|---|---|
+| Duplicate FCM (same `messageId` or same deterministic action id) | Deterministic id + version check → idempotent (§2.10) |
+| Action expired between server-fetch and user-tap | Screen opens, fetches source, sees mismatch → renders "no longer needed" + auto-pop after 2s; local row resolved on next reconcile |
+| Source state moved on (booking auto-cancelled by no-show while approval pending) | Same as above — screen is the reconciliation point |
+| Offline cold start | Skip reconcile; local store drives `decideInitialRoute`; banner indicates stale; retry on connectivity restore |
+| Race: FCM "new" + reconcile fetching at same time | Both upsert with same id; **version check** ensures last-writer-with-higher-version wins |
+| Cross-user residue after logout | `clearAll()` on logout (§4.7); reconcile after re-login restores fresh |
+| Stale-event resurrection (FCM arrives after server resolved) | **§2.10 three-mechanism rule:** RESOLVED tombstone drop OR version stale drop OR `confirmActive` 404 drop |
+| FCM arrives 30+ days after row resolved + tombstone purged | `confirmActive` belt-and-suspenders — ingestor's `existing == null` branch hits API; 404 → drop |
+| Same logical state mutation re-fired by change feed | `upsertAction` semantic-no-op skip — no version inflation (§S02) |
+| ETag conflict on concurrent projector writes | Re-read + retry (max 3 attempts); on persistent failure → `pending_action_upsert_failed` log + skip FCM |
+| Dirty UI input + foreground SourceRefreshNeeded | `DirtyStateMerger.canSilentMerge` returns false → show "Refresh available" banner instead of silent reload (§2.11) |
+| Notification tap during low-interruptibility screen (mid-payment) | Coordinator defers navigation; shows banner instead (§4.5) |
+| User taps low-tier action while T0/T1 gate would apply (unauth, KYC-blocked) | Gate wins; tapped action stays in store; nudge user post-gate |
+| FCM token rotated mid-session | Server-side projector targets userId, not token; new token registered on next FCM init; no action lost |
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Unit (per story)
+
+- `core-nav` — `TierLadder.resolve` exhaustive (every T0–T6 path × tie-break dimensions); `DeepLinkUri` round-trip incl. URL encoding.
+- `Ingestor` — version-aware stale drop; reconcile eviction; markResolvedFromFcm idempotency.
+- DAO — query correctness (priority order, expiry filter).
+- Per-app ViewModels — state composition; DirtyStateMerger contract honored.
+
+### 7.2 Instrumentation (S01b)
+
+- Cold start → tier ladder → coordinator: unauth + KYC-blocked + active-job + active-booking + pending-action paths.
+- Foreground FCM → banner-vs-silent-refresh decision.
+- Hot deep-link tap → defer-vs-navigate decision.
+- Logout cleanup leaves no rows / no FCM token / no topic subscriptions.
+
+### 7.3 Backend (S02)
+
+- Idempotency: replay change-feed event 3× → 1 upsert, 1 FCM, version stable.
+- Stale-state cleanup: source transitions through projector emit/resolve sequence.
+- Expiry: `dispatch_attempts` TTL → `JOB_OFFER` action `EXPIRED`.
+- Cross-user 403: every endpoint.
+- Semgrep rule fires on inverted FCM-before-upsert code.
+- Version monotonicity under concurrent writes.
+
+### 7.4 Reachability gate (S06)
+
+- Warn mode: PR with unreachable route emits CI warning; passes build.
+- Fail mode: PR with unreachable route fails CI; valid suppression passes; expired suppression fails.
+
+### 7.5 Acceptance test (epic-level, post-S05c)
+
+- End-to-end: create booking → FCM ADDON_APPROVAL_REQUESTED while customer-app backgrounded → tray notification → tap → AuthGate → cold-start reconcile → tier ladder → PriceApprovalRoute → submit approval → projector resolves → reconcile next time evicts row.
+
+---
+
+## 8. Out of Scope (Deliberate Omissions)
+
+- HTTPS App Links / Digital Asset Links — deferred (no domain).
+- Computed-on-read pending actions for dashboard counters — stays computed; promotion only if RU budget forces.
+- Runtime "fetch backend state before sensitive action" assertion in S06 — per-story acceptance criterion + code-review checklist only.
+- Customer ServiceTracking as Tier 2 — deliberate UX asymmetry (see §2.6).
+- Migrating admin-web to typed routes — Next.js routing is separate concern; out of E11.
+- Push delivery telemetry beyond the 5 structured logs (§S02 observability) — FCM delivery is best-effort at ₹0.
+
+---
+
+## 9. Pre-Existing Work to Coordinate
+
+### 9.1 Event buses to remove in S01b-2 (7 files / 6 distinct types)
+
+`RatingPromptEventBus` exists in **both** apps — counts as 2 files (1 type).
+
+| # | File | Class |
+|---|---|---|
+| 1 | `customer-app/.../data/booking/PriceApprovalEventBus.kt` | `PriceApprovalEventBus` |
+| 2 | `customer-app/.../data/rating/RatingPromptEventBus.kt` | `RatingPromptEventBus` (customer) |
+| 3 | `customer-app/.../data/tracking/TrackingEventBus.kt` | `TrackingEventBus` |
+| 4 | `technician-app/.../data/jobOffer/JobOfferEventBus.kt` | `JobOfferEventBus` |
+| 5 | `technician-app/.../data/earnings/EarningsUpdateEventBus.kt` | `EarningsUpdateEventBus` |
+| 6 | `technician-app/.../data/rating/RatingPromptEventBus.kt` | `RatingPromptEventBus` (technician) |
+| 7 | `technician-app/.../data/rating/RatingReceivedEventBus.kt` | `RatingReceivedEventBus` |
+
+Consumers of each bus (`MainActivity.kt`, `AppNavigation.kt`, ViewModels) must be migrated to `PendingActionStore.observeActive` or `IngestEvent` flow.
+
+### 9.2 Existing FCM wire types to reuse (do NOT invent new ones in S01a `PendingActionType` enum)
+
+`ADDON_APPROVAL_REQUESTED`, `RATING_PROMPT_CUSTOMER`, `RATING_PROMPT_TECHNICIAN`, `RATING_RECEIVED`, `EARNINGS_UPDATE`, `JOB_OFFER`. Source: `api/src/services/fcm.service.ts`, `customer-app/.../firebase/CustomerFirebaseMessagingService.kt`, `technician-app/.../data/fcm/HomeservicesFcmService.kt`.
+
+### 9.3 Pre-existing bugs to fix as plan pre-reqs
+
+- **S04 pre-req:** `ActiveJobResponse.id` mismatch (Android `ActiveJobApiService.kt:26` expects `id`; API `active-job.ts:40` returns `bookingId`).
+- **S05b-2 pre-req (if Option A):** Storage rules at `firebase/storage.rules:18` only allow `bookings/{bookingId}/photos/...` — must add `bookings/{bookingId}/sos/...` rule.
+
+---
+
+## 10. Open Owner Decisions
+
+1. **S05b-2 SOS audio: Option A (wire upload + ADR + storage rules + TTL) vs Option B (copy fix + delete MediaRecorder code).** Blocks S05b-2 plan-write only; S05b-1 is unblocked.
+2. **S04 ActiveJob id-mismatch fix direction:** API rename `bookingId` → `id` (preferred for consistency) vs Android rename `id` → `bookingId` (less risk if API consumers depend on `bookingId`). Decide at S04 plan-write.
+3. **S05c onboarding completion tracking:** local DataStore only vs `POST /me/onboarding-completed` server-side. Default local; flip if owner needs analytics on it.
+
+---
+
+## 11. References
+
+- **Codex briefings (audit trail):** `docs/superpowers/specs/.codex-briefings/2026-05-01-e11-decomposition-review.md` (first pass) + `docs/superpowers/specs/.codex-briefings/2026-05-01-e11-final-verify.md` (verify pass)
+- **Sprint roadmap:** `docs/stories/README.md`
+- **Architecture:** `docs/architecture.md`
+- **PRD:** `docs/prd.md`
+- **Pattern library:**
+  - `docs/patterns/firebase-callbackflow-lifecycle.md` (relevant for FCM service refactor)
+  - `docs/patterns/hilt-module-android-test-scope.md` (cross-module DI for `core-nav`)
+  - `docs/patterns/paparazzi-cross-os-goldens.md` (S03/S04/S05* visual goldens)
+
+---
+
+## 12. Story Order & Cadence (post-Codex verify)
+
+**12 stories total** after Codex's S01b pre-split:
+
+```
+Wave 1 (parallel):  S01a, S02
+Wave 2:             S01b-1 (depends on S01a's go decision OR fallback ADR)
+Wave 3:             S01b-2 (depends on S01b-1)
+Wave 4 (parallel):  S03, S04, S05a, S05c, S06-warn (all depend on S01b-2 + S02 except S05c which only needs S01b-2)
+Wave 5 (parallel):  S05b-1 (depends on S03), S05b-2 (owner-blocked)
+Wave 6:             S06-fail (depends on S05c + S06-warn)
+```
+
+Each story enters its own brainstorm + plan + execute cycle per project CLAUDE.md per-story protocol. Foundation stories (**S01a, S01b-1, S01b-2, S02**) get fresh sessions for plan-writing per CLAUDE.md security/cross-cutting trigger.

--- a/plans/E11-S01a-1-core-nav-contracts.md
+++ b/plans/E11-S01a-1-core-nav-contracts.md
@@ -1,0 +1,1166 @@
+# E11-S01a-1 — `core-nav` Module + Contracts + TierLadder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land a new pure-Kotlin `core-nav` Gradle module (peer to `design-system`) holding shared route/pending-action contracts and the `TierLadder` pure-function logic for E11. After this plan ships, both Android apps can reference the contract types via `implementation(libs.homeservices.core.nav)` without taking on any Android dependency from core-nav itself.
+
+**Architecture:** `core-nav` is a third Gradle build consumed by both apps via `includeBuild("../core-nav")`. It is JVM-only — no Android, Room, Compose, or Hilt dependencies. It exports 14 contract types: `RouteSpec`, `PendingActionType`/`Status`/`Priority`, `PendingAction`, `NotificationIntent`, `DeepLinkUri`, `NotificationRouter`, `AuthState` (+ `Authenticated`), `ActiveJobSummary`, `BookingSummary`, `RouteContext`, `RouteResolver`, `TierLadder` (+ `Routes`). The `TierLadder.resolve` pure function implements the T0–T6 priority ladder from spec §2.6 and is fully covered by JVM unit tests.
+
+**Tech Stack:** Kotlin 2.0.21 (`-Xexplicit-api=strict`, `-Werror`), Gradle 8.6 wrapper (matched to apps), `kotlin-jvm` plugin, kotlinx-coroutines-core 1.8.1, JUnit 5 + MockK + AssertJ.
+
+**Prerequisite:** None — Wave 1 of E11 (parallel with E11-S02 on the API side).
+**Produces:** Compile-clean `core-nav/` module exporting 14 contract types; both apps wire it via composite build and continue to compile.
+**Out of scope:** Per-app Room layer (covered by E11-S01a-2), kotlinx-serialization spike (E11-S01a-3), `NotificationRouter` Android adapter / `PendingActionIngestor` / FCM service refactor (S01b-1), mass route migration / event-bus removal (S01b-2).
+
+---
+
+## Spec & invariants the plan must respect
+
+- Spec: `docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md` §3.1 + §5 "E11-S01a"
+- This plan is part 1 of a size-gate-driven 3-way split: `E11-S01a-1` (this), `E11-S01a-2` (per-app Room), `E11-S01a-3` (typed-routes spike).
+- `core-nav` is **pure Kotlin** — `kotlinx-coroutines-core` is permitted (it's pure JVM); `androidx`, `com.google.android`, `com.google.firebase`, `dagger` imports are NOT. Verified by a final grep in WS-D.
+- Reuse existing FCM wire types in `PendingActionType`: `ADDON_APPROVAL_REQUESTED`, `RATING_PROMPT_CUSTOMER`, `RATING_PROMPT_TECHNICIAN`, `RATING_RECEIVED`, `EARNINGS_UPDATE`, `JOB_OFFER`. New types added in E11: `KYC_RESUME`, `COMPLAINT_UPDATE`, `SUPPORT_FOLLOWUP`, `SAFETY_SOS_FOLLOWUP`. **Do not invent additional names** (spec §9.2).
+- libs.versions.toml drift invariant: first task is to copy `customer-app/gradle/libs.versions.toml` to `technician-app/gradle/libs.versions.toml` so the per-app catalogues stay in sync.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `core-nav/settings.gradle.kts` | Create | Standalone Gradle build root |
+| `core-nav/build.gradle.kts` | Create | `kotlin-jvm` pure Kotlin library |
+| `core-nav/gradle/libs.versions.toml` | Create | Local version catalogue |
+| `core-nav/gradle/wrapper/gradle-wrapper.{jar,properties}` + `gradlew{,.bat}` | Create | Wrapper (copied from customer-app) |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/RouteSpec.kt` | Create | `RouteSpec` interface |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/PendingActionType.kt` | Create | enum |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/PendingActionStatus.kt` | Create | `PendingActionStatus` + `PendingActionPriority` enums |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/PendingAction.kt` | Create | data class |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/NotificationIntent.kt` | Create | `NotificationIntent` data class + `DeepLinkUri` builder/parser |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/NotificationRouter.kt` | Create | parser interface |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/AuthState.kt` | Create | `AuthState` sealed + `ActiveJobSummary` + `BookingSummary` |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/RouteContext.kt` | Create | `RouteContext` data class + `RouteResolver` interface |
+| `core-nav/src/main/kotlin/com/homeservices/corenav/TierLadder.kt` | Create | `TierLadder.resolve` pure function |
+| `core-nav/src/test/kotlin/com/homeservices/corenav/PendingActionTest.kt` | Create | Equality + copy round-trip |
+| `core-nav/src/test/kotlin/com/homeservices/corenav/DeepLinkUriTest.kt` | Create | build/parse round-trip + URL encoding |
+| `core-nav/src/test/kotlin/com/homeservices/corenav/TierLadderTest.kt` | Create | T0–T6 paths + tie-break combinations |
+| `customer-app/settings.gradle.kts` | Modify | Add `includeBuild("../core-nav")` |
+| `technician-app/settings.gradle.kts` | Modify | Same |
+| `customer-app/gradle/libs.versions.toml` | Modify | Add `homeservices-core-nav` lib alias |
+| `technician-app/gradle/libs.versions.toml` | Modify | Same — sync from customer first, then layer the alias |
+| `customer-app/app/build.gradle.kts` | Modify | Add `implementation(libs.homeservices.core.nav)` |
+| `technician-app/app/build.gradle.kts` | Modify | Same |
+
+---
+
+## Work-stream graph
+
+This plan is one work stream (WS-A from spec §S01a) plus its WS-D close-out gate. Tasks A1–A9 must run in order (each builds on the previous file's symbols). A0 is the libs sync; A10 + WS-D are smoke + Codex.
+
+---
+
+## Task A0 — Sync technician-app `libs.versions.toml` from customer-app
+
+- [ ] **A0.1 — Copy and diff**
+
+  ```bash
+  cp customer-app/gradle/libs.versions.toml technician-app/gradle/libs.versions.toml
+  git diff technician-app/gradle/libs.versions.toml
+  ```
+
+  Expected: empty diff in normal operation. If there is drift, it must be reconciled before continuing.
+
+- [ ] **A0.2 — Commit if there was drift**
+
+  ```bash
+  git add technician-app/gradle/libs.versions.toml
+  git commit -m "chore(technician-app): sync libs.versions.toml from customer-app (E11-S01a-1 invariant)"
+  ```
+
+  Skip this step if the diff was empty.
+
+---
+
+## Task A1 — Scaffold `core-nav` Gradle build
+
+- [ ] **A1.1 — Create directory tree + copy wrapper**
+
+  ```bash
+  mkdir -p core-nav/gradle/wrapper
+  mkdir -p core-nav/src/main/kotlin/com/homeservices/corenav
+  mkdir -p core-nav/src/test/kotlin/com/homeservices/corenav
+  cp customer-app/gradlew core-nav/gradlew
+  cp customer-app/gradlew.bat core-nav/gradlew.bat
+  cp customer-app/gradle/wrapper/gradle-wrapper.jar core-nav/gradle/wrapper/gradle-wrapper.jar
+  cp customer-app/gradle/wrapper/gradle-wrapper.properties core-nav/gradle/wrapper/gradle-wrapper.properties
+  chmod +x core-nav/gradlew
+  ```
+
+- [ ] **A1.2 — Create `core-nav/settings.gradle.kts`**
+
+  ```kotlin
+  pluginManagement {
+      repositories {
+          gradlePluginPortal()
+          google()
+          mavenCentral()
+      }
+  }
+
+  dependencyResolutionManagement {
+      repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+      repositories {
+          google()
+          mavenCentral()
+      }
+  }
+
+  rootProject.name = "core-nav"
+  ```
+
+- [ ] **A1.3 — Create `core-nav/gradle/libs.versions.toml`**
+
+  ```toml
+  [versions]
+  kotlin = "2.0.21"
+  java = "21"
+  coroutines = "1.8.1"
+  ktlint = "12.1.1"
+  detekt = "1.23.7"
+  junit5 = "5.11.3"
+  mockk = "1.13.13"
+  assertj = "3.26.3"
+
+  [libraries]
+  kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+  junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit5" }
+  junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+  junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+  mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+  assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+  kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+  [plugins]
+  kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+  ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+  detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+  ```
+
+- [ ] **A1.4 — Create `core-nav/build.gradle.kts`**
+
+  ```kotlin
+  import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+  plugins {
+      alias(libs.plugins.kotlin.jvm)
+      alias(libs.plugins.ktlint)
+      alias(libs.plugins.detekt)
+  }
+
+  group = "com.homeservices"
+  version = "0.1.0"
+
+  kotlin {
+      jvmToolchain(libs.versions.java.get().toInt())
+      compilerOptions {
+          jvmTarget.set(JvmTarget.JVM_17)
+          allWarningsAsErrors.set(true)
+          freeCompilerArgs.addAll("-Xexplicit-api=strict", "-Xjsr305=strict")
+      }
+  }
+
+  dependencies {
+      implementation(libs.kotlinx.coroutines.core)
+      testImplementation(libs.junit.jupiter)
+      testImplementation(libs.junit.jupiter.api)
+      testRuntimeOnly(libs.junit.jupiter.engine)
+      testImplementation(libs.mockk)
+      testImplementation(libs.assertj.core)
+      testImplementation(libs.kotlinx.coroutines.test)
+  }
+
+  tasks.test { useJUnitPlatform() }
+
+  ktlint { version.set("1.3.1"); ignoreFailures.set(false) }
+
+  detekt {
+      toolVersion = libs.versions.detekt.get()
+      buildUponDefaultConfig = true
+      allRules = false
+      autoCorrect = false
+      ignoreFailures = false
+  }
+  ```
+
+- [ ] **A1.5 — Smoke build + commit**
+
+  ```bash
+  cd core-nav && ./gradlew assemble && cd ..
+  git add core-nav/
+  git commit -m "feat(core-nav): scaffold pure-Kotlin module for E11 shared contracts"
+  ```
+
+  Expected: `BUILD SUCCESSFUL`.
+
+---
+
+## Task A2 — Wire `core-nav` into both apps via composite build
+
+- [ ] **A2.1 — Add `includeBuild("../core-nav")` to both apps' `settings.gradle.kts`**
+
+  Append after the existing `includeBuild("../design-system")` line in both `customer-app/settings.gradle.kts` and `technician-app/settings.gradle.kts`:
+
+  ```kotlin
+  includeBuild("../core-nav")
+  ```
+
+- [ ] **A2.2 — Add `core-nav` lib alias to both apps' `gradle/libs.versions.toml`**
+
+  In each, insert next to `homeservices-design-system`:
+
+  ```toml
+  homeservices-core-nav = { module = "com.homeservices:core-nav", version = "0.1.0" }
+  ```
+
+- [ ] **A2.3 — Add `implementation(libs.homeservices.core.nav)` to both apps' `app/build.gradle.kts`**
+
+  In each `dependencies { ... }` block, immediately after the existing `implementation(libs.homeservices.design.system)`:
+
+  ```kotlin
+  implementation(libs.homeservices.core.nav)
+  ```
+
+- [ ] **A2.4 — Verify both apps still configure**
+
+  ```bash
+  cd customer-app && ./gradlew :app:help -q && cd ..
+  cd technician-app && ./gradlew :app:help -q && cd ..
+  ```
+
+  Expected: both runs exit 0. Composite-build substitution maps `com.homeservices:core-nav:0.1.0` to the local module.
+
+- [ ] **A2.5 — Commit**
+
+  ```bash
+  git add customer-app/settings.gradle.kts customer-app/gradle/libs.versions.toml customer-app/app/build.gradle.kts \
+          technician-app/settings.gradle.kts technician-app/gradle/libs.versions.toml technician-app/app/build.gradle.kts
+  git commit -m "feat(apps): wire core-nav module via composite build"
+  ```
+
+---
+
+## Task A3 — `RouteSpec` interface
+
+- [ ] **A3.1 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/RouteSpec.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Cross-app route identifier. Per-app `RouteSpec` enums implement this; consumers
+   * (`TierLadder`, `RouteResolver`) reason about routes by name without knowing
+   * which app owns them.
+   */
+  public interface RouteSpec {
+      public val name: String
+  }
+  ```
+
+- [ ] **A3.2 — Compile + commit**
+
+  ```bash
+  cd core-nav && ./gradlew compileKotlin && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/RouteSpec.kt
+  git commit -m "feat(core-nav): RouteSpec interface"
+  ```
+
+---
+
+## Task A4 — Pending-action enums + `PendingAction` data class (TDD)
+
+- [ ] **A4.1 — Create the enum files**
+
+  `core-nav/src/main/kotlin/com/homeservices/corenav/PendingActionType.kt`:
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Wire-compatible with the existing FCM `data["type"]` strings. Names match
+   * `api/src/services/fcm.service.ts` and the existing per-app FCM services.
+   * Do not rename or invent variants without amending the API + both FCM services.
+   */
+  public enum class PendingActionType {
+      // Existing FCM wire types (spec §9.2):
+      ADDON_APPROVAL_REQUESTED,
+      RATING_PROMPT_CUSTOMER,
+      RATING_PROMPT_TECHNICIAN,
+      RATING_RECEIVED,
+      EARNINGS_UPDATE,
+      JOB_OFFER,
+      // New types in E11:
+      KYC_RESUME,
+      COMPLAINT_UPDATE,
+      SUPPORT_FOLLOWUP,
+      SAFETY_SOS_FOLLOWUP,
+  }
+  ```
+
+  `core-nav/src/main/kotlin/com/homeservices/corenav/PendingActionStatus.kt`:
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  public enum class PendingActionStatus { ACTIVE, RESOLVED, EXPIRED }
+
+  public enum class PendingActionPriority { HIGH, NORMAL, LOW }
+  ```
+
+- [ ] **A4.2 — Failing test `core-nav/src/test/kotlin/com/homeservices/corenav/PendingActionTest.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  import org.assertj.core.api.Assertions.assertThat
+  import org.junit.jupiter.api.Test
+
+  class PendingActionTest {
+      private fun fixture(version: Long = 1L): PendingAction = PendingAction(
+          id = "JOB_OFFER:technician:user-1:dispatch_attempt:da-9",
+          userId = "user-1",
+          role = "technician",
+          type = PendingActionType.JOB_OFFER,
+          entityType = "dispatch_attempt",
+          entityId = "da-9",
+          routeUri = "homeservices://action/JOB_OFFER?bookingId=bk-7",
+          priority = PendingActionPriority.HIGH,
+          status = PendingActionStatus.ACTIVE,
+          sourceStatus = null,
+          version = version,
+          createdAt = 1_700_000_000_000L,
+          updatedAt = 1_700_000_000_000L,
+          expiresAt = 1_700_000_060_000L,
+          resolvedAt = null,
+      )
+
+      @Test
+      fun `equality is by content`() {
+          assertThat(fixture()).isEqualTo(fixture())
+      }
+
+      @Test
+      fun `copy with bumped version preserves id and shows different equality`() {
+          val original = fixture(version = 1L)
+          val bumped = original.copy(version = 2L)
+          assertThat(bumped.id).isEqualTo(original.id)
+          assertThat(bumped.version).isEqualTo(2L)
+          assertThat(bumped).isNotEqualTo(original)
+      }
+  }
+  ```
+
+- [ ] **A4.3 — Run test — fails (`PendingAction` does not exist)**
+
+  ```bash
+  cd core-nav && ./gradlew test
+  ```
+
+- [ ] **A4.4 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/PendingAction.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Durable action-index row. Source entity is always re-fetched on screen entry —
+   * this row is a discovery handle, not the truth about the booking/job/rating.
+   *
+   * `version` is monotonically bumped server-side via Cosmos optimistic concurrency
+   * (`_etag` IfMatch). The ingestor (S01b-1) drops payloads with
+   * `incoming.version <= existing.version`.
+   */
+  public data class PendingAction(
+      val id: String,
+      val userId: String,
+      val role: String,
+      val type: PendingActionType,
+      val entityType: String,
+      val entityId: String,
+      val routeUri: String,
+      val priority: PendingActionPriority,
+      val status: PendingActionStatus,
+      val sourceStatus: String?,
+      val version: Long,
+      val createdAt: Long,
+      val updatedAt: Long,
+      val expiresAt: Long?,
+      val resolvedAt: Long?,
+  )
+  ```
+
+- [ ] **A4.5 — Run test — must pass; commit**
+
+  ```bash
+  cd core-nav && ./gradlew test && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/PendingActionType.kt \
+          core-nav/src/main/kotlin/com/homeservices/corenav/PendingActionStatus.kt \
+          core-nav/src/main/kotlin/com/homeservices/corenav/PendingAction.kt \
+          core-nav/src/test/kotlin/com/homeservices/corenav/PendingActionTest.kt
+  git commit -m "feat(core-nav): PendingAction + Type/Status/Priority enums"
+  ```
+
+  Expected: 2 tests pass.
+
+---
+
+## Task A5 — `NotificationIntent` + `DeepLinkUri` (TDD)
+
+- [ ] **A5.1 — Failing test `core-nav/src/test/kotlin/com/homeservices/corenav/DeepLinkUriTest.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  import org.assertj.core.api.Assertions.assertThat
+  import org.junit.jupiter.api.Test
+
+  class DeepLinkUriTest {
+      @Test
+      fun `build then parse round-trips a simple intent`() {
+          val intent = NotificationIntent(
+              type = PendingActionType.ADDON_APPROVAL_REQUESTED,
+              entityId = "bk-7",
+              rawArgs = mapOf("bookingId" to "bk-7"),
+          )
+          assertThat(DeepLinkUri.parse(DeepLinkUri.build(intent))).isEqualTo(intent)
+      }
+
+      @Test
+      fun `parse returns null on a non-homeservices scheme`() {
+          assertThat(DeepLinkUri.parse("https://example.com/booking?id=1")).isNull()
+      }
+
+      @Test
+      fun `parse returns null on an unknown action type`() {
+          assertThat(DeepLinkUri.parse("homeservices://action/NONSENSE_TYPE?bookingId=bk-1")).isNull()
+      }
+
+      @Test
+      fun `build URL-encodes argument values containing spaces and ampersands`() {
+          val intent = NotificationIntent(
+              type = PendingActionType.SUPPORT_FOLLOWUP,
+              entityId = "ticket-1",
+              rawArgs = mapOf(
+                  "ticketId" to "ticket-1",
+                  "subject" to "Re: refund & credit",
+              ),
+          )
+          val uri = DeepLinkUri.build(intent)
+          assertThat(uri).contains("subject=Re%3A+refund+%26+credit")
+          assertThat(DeepLinkUri.parse(uri)?.rawArgs?.get("subject"))
+              .isEqualTo("Re: refund & credit")
+      }
+
+      @Test
+      fun `parse tolerates argument-less URIs`() {
+          val parsed = DeepLinkUri.parse("homeservices://action/EARNINGS_UPDATE")
+          assertThat(parsed).isNotNull
+          assertThat(parsed?.type).isEqualTo(PendingActionType.EARNINGS_UPDATE)
+          assertThat(parsed?.rawArgs).isEmpty()
+      }
+
+      @Test
+      fun `parse extracts entityId from a conventional bookingId arg`() {
+          val parsed = DeepLinkUri.parse("homeservices://action/ADDON_APPROVAL_REQUESTED?bookingId=bk-7")
+          assertThat(parsed?.entityId).isEqualTo("bk-7")
+      }
+  }
+  ```
+
+- [ ] **A5.2 — Run test — fails**
+
+  ```bash
+  cd core-nav && ./gradlew test --tests "com.homeservices.corenav.DeepLinkUriTest"
+  ```
+
+- [ ] **A5.3 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/NotificationIntent.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  import java.net.URLDecoder
+  import java.net.URLEncoder
+  import java.nio.charset.StandardCharsets
+
+  /**
+   * Parsed FCM-data or deep-link payload. `rawArgs` keeps every key/value passed
+   * through the URI; `entityId` is extracted to a typed slot for ergonomic ingestor use.
+   */
+  public data class NotificationIntent(
+      val type: PendingActionType,
+      val entityId: String,
+      val rawArgs: Map<String, String>,
+  )
+
+  /**
+   * Pure builder/parser for `homeservices://action/<TYPE>?<args>`.
+   *
+   * `entityId` resolution rule: prefer `entityId`, then `bookingId`, then `jobOfferId`,
+   * then `dispatchAttemptId`, then `id`, else empty string.
+   */
+  public object DeepLinkUri {
+      private const val SCHEME = "homeservices"
+      private const val HOST = "action"
+      private val ENTITY_ID_KEYS: List<String> =
+          listOf("entityId", "bookingId", "jobOfferId", "dispatchAttemptId", "id")
+
+      public fun build(intent: NotificationIntent): String {
+          val query = intent.rawArgs.entries
+              .joinToString("&") { (k, v) -> "${encode(k)}=${encode(v)}" }
+          val tail = if (query.isEmpty()) "" else "?$query"
+          return "$SCHEME://$HOST/${intent.type.name}$tail"
+      }
+
+      public fun parse(uri: String): NotificationIntent? {
+          if (!uri.startsWith("$SCHEME://$HOST/")) return null
+          val afterPrefix = uri.removePrefix("$SCHEME://$HOST/")
+          val parts = afterPrefix.split('?', limit = 2)
+          val typeStr = parts[0]
+          val queryStr = if (parts.size == 2) parts[1] else ""
+          val type = runCatching { PendingActionType.valueOf(typeStr) }.getOrNull() ?: return null
+          val rawArgs: Map<String, String> = if (queryStr.isEmpty()) {
+              emptyMap()
+          } else {
+              queryStr.split('&').associate { kv ->
+                  val pair = kv.split('=', limit = 2)
+                  decode(pair[0]) to decode(if (pair.size == 2) pair[1] else "")
+              }
+          }
+          val entityId = ENTITY_ID_KEYS.firstNotNullOfOrNull { rawArgs[it] } ?: ""
+          return NotificationIntent(type = type, entityId = entityId, rawArgs = rawArgs)
+      }
+
+      private fun encode(s: String): String = URLEncoder.encode(s, StandardCharsets.UTF_8.name())
+      private fun decode(s: String): String = URLDecoder.decode(s, StandardCharsets.UTF_8.name())
+  }
+  ```
+
+- [ ] **A5.4 — Run test — pass; commit**
+
+  ```bash
+  cd core-nav && ./gradlew test --tests "com.homeservices.corenav.DeepLinkUriTest" && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/NotificationIntent.kt \
+          core-nav/src/test/kotlin/com/homeservices/corenav/DeepLinkUriTest.kt
+  git commit -m "feat(core-nav): NotificationIntent + DeepLinkUri builder/parser"
+  ```
+
+  Expected: 6 tests pass.
+
+---
+
+## Task A6 — `NotificationRouter` interface
+
+- [ ] **A6.1 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/NotificationRouter.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Pure parser interface. The Android adapter (S01b-1) supplies the FCM
+   * `RemoteMessage.data` map; this interface accepts a plain `Map<String, String>`
+   * so it stays JVM-only.
+   */
+  public interface NotificationRouter {
+      public fun parseFcmData(data: Map<String, String>): NotificationIntent?
+
+      public fun parseDeepLink(uri: String): NotificationIntent?
+  }
+  ```
+
+- [ ] **A6.2 — Compile + commit**
+
+  ```bash
+  cd core-nav && ./gradlew compileKotlin && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/NotificationRouter.kt
+  git commit -m "feat(core-nav): NotificationRouter parser interface"
+  ```
+
+---
+
+## Task A7 — `AuthState` + `ActiveJobSummary` + `BookingSummary`
+
+- [ ] **A7.1 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/AuthState.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Auth result snapshot used by `RouteContext`. Per-app `SessionManager` collapses
+   * its richer auth state into one of these two shapes before invoking the resolver.
+   */
+  public sealed interface AuthState {
+      public object Unauthenticated : AuthState
+
+      public data class Authenticated(val userId: String, val role: String) : AuthState
+  }
+
+  /** Minimal active-job projection consumed by Tier 2 (technician-only). */
+  public data class ActiveJobSummary(
+      val bookingId: String,
+      val status: String,
+  )
+
+  /** Minimal active-booking projection consumed by Tier 2 (customer-only). */
+  public data class BookingSummary(
+      val bookingId: String,
+      val status: String,
+  )
+  ```
+
+- [ ] **A7.2 — Compile + commit**
+
+  ```bash
+  cd core-nav && ./gradlew compileKotlin && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/AuthState.kt
+  git commit -m "feat(core-nav): AuthState + ActiveJobSummary + BookingSummary"
+  ```
+
+---
+
+## Task A8 — `RouteContext` + `RouteResolver` interface
+
+- [ ] **A8.1 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/RouteContext.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Snapshot used to evaluate the initial-route ladder. Composed once per cold start
+   * (after auth + reconcile + parallel source-state probes) and passed to
+   * [TierLadder.resolve].
+   */
+  public data class RouteContext(
+      val authState: AuthState,
+      val role: String,
+      val activeActions: List<PendingAction>,
+      val techKycStatus: String?,
+      val techActiveJob: ActiveJobSummary?,
+      val customerActiveBookings: List<BookingSummary>,
+  )
+
+  /**
+   * Decides initial and per-event routes. Per-app implementation supplies the
+   * `RouteSpec` enum it owns; the interface stays cross-app.
+   */
+  public interface RouteResolver {
+      public suspend fun decideInitialRoute(ctx: RouteContext): RouteSpec
+
+      public fun routeFor(action: PendingAction): RouteSpec
+
+      public fun routeFor(intent: NotificationIntent): RouteSpec
+  }
+  ```
+
+- [ ] **A8.2 — Compile + commit**
+
+  ```bash
+  cd core-nav && ./gradlew compileKotlin && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/RouteContext.kt
+  git commit -m "feat(core-nav): RouteContext + RouteResolver interface"
+  ```
+
+---
+
+## Task A9 — `TierLadder.resolve` pure function (TDD)
+
+This is the heart of the contracts module. Tests must cover every T0–T6 path plus the documented tie-break dimensions.
+
+- [ ] **A9.1 — Failing test `core-nav/src/test/kotlin/com/homeservices/corenav/TierLadderTest.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  import org.assertj.core.api.Assertions.assertThat
+  import org.junit.jupiter.api.Nested
+  import org.junit.jupiter.api.Test
+
+  /** Test-only RouteSpec impls — keeps the ladder logic tested without per-app deps. */
+  private enum class Spec : RouteSpec {
+      Auth, Kyc, ActiveJob, PriceApproval, JobOffer, Complaint, Rating, Home, Dashboard
+  }
+
+  private val routes: TierLadder.Routes = TierLadder.Routes(
+      auth = Spec.Auth,
+      kyc = Spec.Kyc,
+      activeJob = Spec.ActiveJob,
+      priceApproval = Spec.PriceApproval,
+      jobOffer = Spec.JobOffer,
+      complaint = Spec.Complaint,
+      rating = Spec.Rating,
+      customerHome = Spec.Home,
+      technicianDashboard = Spec.Dashboard,
+  )
+
+  private fun action(
+      type: PendingActionType,
+      priority: PendingActionPriority = PendingActionPriority.NORMAL,
+      id: String = "${type.name}:user:1:entity:1",
+      expiresAt: Long? = null,
+      createdAt: Long = 0L,
+  ): PendingAction = PendingAction(
+      id = id, userId = "user-1", role = "customer",
+      type = type, entityType = "x", entityId = "1",
+      routeUri = "", priority = priority, status = PendingActionStatus.ACTIVE,
+      sourceStatus = null, version = 1L,
+      createdAt = createdAt, updatedAt = createdAt,
+      expiresAt = expiresAt, resolvedAt = null,
+  )
+
+  private fun ctx(
+      auth: AuthState = AuthState.Authenticated("u-1", "customer"),
+      role: String = "customer",
+      actions: List<PendingAction> = emptyList(),
+      techKyc: String? = null,
+      techJob: ActiveJobSummary? = null,
+      customerBookings: List<BookingSummary> = emptyList(),
+  ): RouteContext = RouteContext(auth, role, actions, techKyc, techJob, customerBookings)
+
+  class TierLadderTest {
+      @Nested
+      inner class Tier0Gate {
+          @Test fun `unauthenticated routes to auth`() {
+              assertThat(TierLadder.resolve(ctx(auth = AuthState.Unauthenticated), routes))
+                  .isEqualTo(Spec.Auth)
+          }
+      }
+
+      @Nested
+      inner class Tier1Blocking {
+          @Test fun `tech with NOT_STARTED or INCOMPLETE KYC is blocked`() {
+              listOf("NOT_STARTED", "INCOMPLETE").forEach { kyc ->
+                  assertThat(TierLadder.resolve(ctx(role = "technician", techKyc = kyc), routes))
+                      .withFailMessage("kyc=$kyc").isEqualTo(Spec.Kyc)
+              }
+          }
+          @Test fun `tech with SUBMITTED MANUAL_REVIEW or COMPLETE KYC is NOT blocked`() {
+              listOf("SUBMITTED", "MANUAL_REVIEW", "COMPLETE").forEach { kyc ->
+                  assertThat(TierLadder.resolve(ctx(role = "technician", techKyc = kyc), routes))
+                      .withFailMessage("kyc=$kyc").isEqualTo(Spec.Dashboard)
+              }
+          }
+      }
+
+      @Nested
+      inner class Tier2LiveOps {
+          @Test fun `tech ASSIGNED EN_ROUTE REACHED IN_PROGRESS routes to ActiveJob`() {
+              listOf("ASSIGNED", "EN_ROUTE", "REACHED", "IN_PROGRESS").forEach { status ->
+                  assertThat(
+                      TierLadder.resolve(
+                          ctx(role = "technician", techKyc = "COMPLETE",
+                              techJob = ActiveJobSummary("bk-1", status)),
+                          routes,
+                      ),
+                  ).withFailMessage("status=$status").isEqualTo(Spec.ActiveJob)
+              }
+          }
+          @Test fun `customer AWAITING_PRICE_APPROVAL routes to PriceApproval`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "customer",
+                          customerBookings = listOf(BookingSummary("bk-2", "AWAITING_PRICE_APPROVAL"))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.PriceApproval)
+          }
+          @Test fun `customer ServiceTracking is NOT Tier 2 — asymmetry`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "customer",
+                          customerBookings = listOf(BookingSummary("bk-3", "ASSIGNED"))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.Home)
+          }
+      }
+
+      @Nested
+      inner class Tier3HighAction {
+          @Test fun `unexpired JOB_OFFER routes to JobOffer`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "technician", techKyc = "COMPLETE",
+                          actions = listOf(action(PendingActionType.JOB_OFFER, PendingActionPriority.HIGH,
+                              expiresAt = Long.MAX_VALUE))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.JobOffer)
+          }
+          @Test fun `expired JOB_OFFER does NOT take Tier 3`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "technician", techKyc = "COMPLETE",
+                          actions = listOf(action(PendingActionType.JOB_OFFER, PendingActionPriority.HIGH,
+                              expiresAt = 1L))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.Dashboard)
+          }
+      }
+
+      @Nested
+      inner class Tier4NormalAction {
+          @Test fun `KYC_RESUME routes to Kyc`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "technician", techKyc = "MANUAL_REVIEW",
+                          actions = listOf(action(PendingActionType.KYC_RESUME))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.Kyc)
+          }
+          @Test fun `COMPLAINT_UPDATE routes to Complaint`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "customer",
+                          actions = listOf(action(PendingActionType.COMPLAINT_UPDATE))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.Complaint)
+          }
+      }
+
+      @Nested
+      inner class Tier5LowAction {
+          @Test fun `RATING_PROMPT_CUSTOMER routes to Rating`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "customer",
+                          actions = listOf(action(PendingActionType.RATING_PROMPT_CUSTOMER, PendingActionPriority.LOW))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.Rating)
+          }
+      }
+
+      @Nested
+      inner class Tier6Default {
+          @Test fun `customer with no actions lands on Home`() {
+              assertThat(TierLadder.resolve(ctx(role = "customer"), routes)).isEqualTo(Spec.Home)
+          }
+          @Test fun `tech with no actions and complete KYC lands on Dashboard`() {
+              assertThat(TierLadder.resolve(ctx(role = "technician", techKyc = "COMPLETE"), routes))
+                  .isEqualTo(Spec.Dashboard)
+          }
+      }
+
+      @Nested
+      inner class TieBreaks {
+          @Test fun `T1 KYC blocking beats T3 JOB_OFFER`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "technician", techKyc = "NOT_STARTED",
+                          actions = listOf(action(PendingActionType.JOB_OFFER, PendingActionPriority.HIGH,
+                              expiresAt = Long.MAX_VALUE))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.Kyc)
+          }
+          @Test fun `T2 active job beats T3 offer`() {
+              assertThat(
+                  TierLadder.resolve(
+                      ctx(role = "technician", techKyc = "COMPLETE",
+                          techJob = ActiveJobSummary("bk-1", "IN_PROGRESS"),
+                          actions = listOf(action(PendingActionType.JOB_OFFER, PendingActionPriority.HIGH,
+                              expiresAt = Long.MAX_VALUE))),
+                      routes,
+                  ),
+              ).isEqualTo(Spec.ActiveJob)
+          }
+          @Test fun `pickWithinTier — earliest non-null expiresAt wins`() {
+              val a = action(PendingActionType.COMPLAINT_UPDATE, id = "a", expiresAt = 200L, createdAt = 1L)
+              val b = action(PendingActionType.COMPLAINT_UPDATE, id = "b", expiresAt = 100L, createdAt = 2L)
+              assertThat(TierLadder.pickWithinTier(listOf(a, b))).isEqualTo(b)
+          }
+          @Test fun `pickWithinTier — null expiresAt loses to non-null`() {
+              val a = action(PendingActionType.COMPLAINT_UPDATE, id = "a", expiresAt = null, createdAt = 1L)
+              val b = action(PendingActionType.COMPLAINT_UPDATE, id = "b", expiresAt = 100L, createdAt = 2L)
+              assertThat(TierLadder.pickWithinTier(listOf(a, b))).isEqualTo(b)
+          }
+          @Test fun `pickWithinTier — tied expiresAt falls back to oldest createdAt`() {
+              val a = action(PendingActionType.COMPLAINT_UPDATE, id = "a", expiresAt = 100L, createdAt = 5L)
+              val b = action(PendingActionType.COMPLAINT_UPDATE, id = "b", expiresAt = 100L, createdAt = 1L)
+              assertThat(TierLadder.pickWithinTier(listOf(a, b))).isEqualTo(b)
+          }
+          @Test fun `pickWithinTier — tied createdAt falls back to lexicographic id`() {
+              val a = action(PendingActionType.COMPLAINT_UPDATE, id = "z", expiresAt = 100L, createdAt = 1L)
+              val b = action(PendingActionType.COMPLAINT_UPDATE, id = "a", expiresAt = 100L, createdAt = 1L)
+              assertThat(TierLadder.pickWithinTier(listOf(a, b))).isEqualTo(b)
+          }
+      }
+  }
+  ```
+
+- [ ] **A9.2 — Run test — fails (TierLadder doesn't exist)**
+
+  ```bash
+  cd core-nav && ./gradlew test --tests "com.homeservices.corenav.TierLadderTest"
+  ```
+
+- [ ] **A9.3 — Create `core-nav/src/main/kotlin/com/homeservices/corenav/TierLadder.kt`**
+
+  ```kotlin
+  package com.homeservices.corenav
+
+  /**
+   * Pure tier-ladder resolver. T0–T6 priority order matches spec §2.6:
+   *
+   *   T0 GATE          unauthenticated → auth
+   *   T1 BLOCKING      tech KYC ∈ {NOT_STARTED, INCOMPLETE} → kyc
+   *   T2 LIVE_OPS      tech active job ∈ {ASSIGNED, EN_ROUTE, REACHED, IN_PROGRESS} → activeJob
+   *                    customer booking AWAITING_PRICE_APPROVAL → priceApproval
+   *   T3 HIGH_ACTION   JOB_OFFER (unexpired), SAFETY_SOS_FOLLOWUP
+   *   T4 NORMAL_ACTION KYC_RESUME, COMPLAINT_UPDATE, SUPPORT_FOLLOWUP
+   *   T5 LOW_ACTION    RATING_PROMPT_*, RATING_RECEIVED, EARNINGS_UPDATE, ADDON_APPROVAL_REQUESTED
+   *   T6 DEFAULT       role-specific home/dashboard
+   *
+   * Within-tier tie-break: earliest non-null expiresAt → oldest createdAt → lexicographic id.
+   * Customer ServiceTracking is deliberately NOT in T2 — see spec §2.6 asymmetry note.
+   */
+  public object TierLadder {
+      public data class Routes(
+          val auth: RouteSpec,
+          val kyc: RouteSpec,
+          val activeJob: RouteSpec,
+          val priceApproval: RouteSpec,
+          val jobOffer: RouteSpec,
+          val complaint: RouteSpec,
+          val rating: RouteSpec,
+          val customerHome: RouteSpec,
+          val technicianDashboard: RouteSpec,
+      )
+
+      private val LIVE_OPS_TECH_STATUSES: Set<String> =
+          setOf("ASSIGNED", "EN_ROUTE", "REACHED", "IN_PROGRESS")
+      private val BLOCKING_KYC_STATUSES: Set<String> = setOf("NOT_STARTED", "INCOMPLETE")
+
+      public fun resolve(
+          ctx: RouteContext,
+          routes: Routes,
+          now: Long = System.currentTimeMillis(),
+      ): RouteSpec {
+          if (ctx.authState is AuthState.Unauthenticated) return routes.auth
+
+          if (ctx.role == "technician" && ctx.techKycStatus in BLOCKING_KYC_STATUSES) {
+              return routes.kyc
+          }
+
+          if (ctx.role == "technician" && ctx.techActiveJob?.status in LIVE_OPS_TECH_STATUSES) {
+              return routes.activeJob
+          }
+          if (ctx.role == "customer" &&
+              ctx.customerActiveBookings.any { it.status == "AWAITING_PRICE_APPROVAL" }) {
+              return routes.priceApproval
+          }
+
+          val activeUnexpired: List<PendingAction> = ctx.activeActions
+              .filter { it.status == PendingActionStatus.ACTIVE }
+              .filter { (it.expiresAt ?: Long.MAX_VALUE) > now }
+
+          val t3Types = setOf(PendingActionType.JOB_OFFER, PendingActionType.SAFETY_SOS_FOLLOWUP)
+          if (activeUnexpired.any { it.type in t3Types }) return routes.jobOffer
+
+          val t4Types = setOf(
+              PendingActionType.KYC_RESUME,
+              PendingActionType.COMPLAINT_UPDATE,
+              PendingActionType.SUPPORT_FOLLOWUP,
+          )
+          val t4 = activeUnexpired.filter { it.type in t4Types }
+          if (t4.isNotEmpty()) {
+              return when (pickWithinTier(t4).type) {
+                  PendingActionType.KYC_RESUME -> routes.kyc
+                  PendingActionType.COMPLAINT_UPDATE, PendingActionType.SUPPORT_FOLLOWUP -> routes.complaint
+                  else -> routes.complaint
+              }
+          }
+
+          val t5Types = setOf(
+              PendingActionType.RATING_PROMPT_CUSTOMER,
+              PendingActionType.RATING_PROMPT_TECHNICIAN,
+              PendingActionType.RATING_RECEIVED,
+              PendingActionType.EARNINGS_UPDATE,
+              PendingActionType.ADDON_APPROVAL_REQUESTED,
+          )
+          if (activeUnexpired.any { it.type in t5Types }) return routes.rating
+
+          return if (ctx.role == "technician") routes.technicianDashboard else routes.customerHome
+      }
+
+      /**
+       * Within-tier tie-break: earliest non-null expiresAt → oldest createdAt → lexicographic id.
+       * Null `expiresAt` is treated as `Long.MAX_VALUE` (never expires) so it loses to any non-null.
+       */
+      public fun pickWithinTier(actions: List<PendingAction>): PendingAction {
+          require(actions.isNotEmpty()) { "pickWithinTier requires at least one action" }
+          return actions.sortedWith(
+              compareBy<PendingAction> { it.expiresAt ?: Long.MAX_VALUE }
+                  .thenBy { it.createdAt }
+                  .thenBy { it.id },
+          ).first()
+      }
+  }
+  ```
+
+- [ ] **A9.4 — Run all core-nav tests — must pass; commit**
+
+  ```bash
+  cd core-nav && ./gradlew test && cd ..
+  git add core-nav/src/main/kotlin/com/homeservices/corenav/TierLadder.kt \
+          core-nav/src/test/kotlin/com/homeservices/corenav/TierLadderTest.kt
+  git commit -m "feat(core-nav): TierLadder pure resolver with full T0-T6 coverage"
+  ```
+
+  Expected: ~22 tests across PendingActionTest + DeepLinkUriTest + TierLadderTest, all passing.
+
+---
+
+## Task A10 — Verify both apps still compile against `core-nav`
+
+- [ ] **A10.1 — Compile check**
+
+  ```bash
+  cd customer-app && ./gradlew :app:compileDebugKotlin && cd ..
+  cd technician-app && ./gradlew :app:compileDebugKotlin && cd ..
+  ```
+
+  Expected: both `BUILD SUCCESSFUL`. core-nav additions are non-breaking.
+
+---
+
+## WS-D — pre-Codex smoke + Codex review + close-out
+
+### Task D1 — Pre-Codex smoke for both apps + core-nav
+
+- [ ] **D1.1 — Customer app smoke**
+
+  ```bash
+  bash tools/pre-codex-smoke.sh customer-app
+  ```
+
+  Expected: exit 0 (ktlint, detekt, lint, unit tests, assembleDebug all green).
+
+- [ ] **D1.2 — Technician app smoke**
+
+  ```bash
+  bash tools/pre-codex-smoke.sh technician-app
+  ```
+
+  Expected: exit 0.
+
+- [ ] **D1.3 — core-nav clean build + tests + lint**
+
+  The smoke harness only knows about the two app subprojects. core-nav has its own gradle wrapper.
+
+  ```bash
+  cd core-nav && ./gradlew clean build test ktlintCheck detekt
+  ```
+
+  Expected: `BUILD SUCCESSFUL`. ~22 unit tests pass.
+
+---
+
+### Task D2 — No-Android-leakage check on `core-nav`
+
+- [ ] **D2.1 — Grep for forbidden imports in core-nav main sources**
+
+  ```bash
+  grep -rE "androidx|com.google.android|com.google.firebase|dagger" core-nav/src/main/kotlin/ || echo "clean"
+  ```
+
+  Expected output: literal string `clean`. Any matches must be removed before Codex review — core-nav's pure-JVM invariant is non-negotiable.
+
+---
+
+### Task D3 — Codex review
+
+- [ ] **D3.1 — Run Codex against main**
+
+  ```bash
+  codex review --base main
+  ```
+
+  Expected: review passes; `.codex-review-passed` updated. Any P1 finding → STOP and fix in a new commit before pushing. No `--no-verify`. No `CLAUDE_OVERRIDE_REASON` unless the owner explicitly authorizes.
+
+  This story has no auth/payment/PII surface — `/security-review` is **not** required.
+
+---
+
+### Task D4 — Push + PR
+
+- [ ] **D4.1 — Push + open PR**
+
+  ```bash
+  git push -u origin <branch>
+  gh pr create --title "feat(android): E11-S01a-1 core-nav module + contracts + TierLadder" --body "$(cat <<'EOF'
+  ## Summary
+  - New `core-nav` Gradle module (pure Kotlin) wired into both apps via composite build.
+  - Exports 14 contract types: RouteSpec, PendingAction*, NotificationIntent, DeepLinkUri, NotificationRouter, RouteContext/RouteResolver, AuthState, ActiveJobSummary, BookingSummary, TierLadder.
+  - TierLadder pure-function resolver with full T0-T6 + tie-break test coverage.
+  - No Android dependencies in core-nav (verified by grep).
+
+  ## Out of scope
+  - Per-app Room layer → E11-S01a-2.
+  - kotlinx-serialization typed-route spike → E11-S01a-3.
+
+  ## Test plan
+  - [x] core-nav clean build green; ~22 unit tests pass
+  - [x] Both apps still compile against core-nav via composite build
+  - [x] pre-codex-smoke.sh green for both apps
+  - [x] Codex review green
+  EOF
+  )"
+  ```
+
+  PR auto-merges on CI green per project flow.
+
+---
+
+## Acceptance Criteria
+
+This plan completes when ALL of the following hold:
+
+1. **`core-nav` ships:** `core-nav/` compiles, ~22 unit tests pass, and both apps compile against it via composite-build substitution.
+2. **14 contract types exported:** `RouteSpec`, `PendingActionType`, `PendingActionStatus`, `PendingActionPriority`, `PendingAction`, `NotificationIntent`, `DeepLinkUri`, `NotificationRouter`, `AuthState`, `ActiveJobSummary`, `BookingSummary`, `RouteContext`, `RouteResolver`, `TierLadder`. `AuthState.Authenticated` and `TierLadder.Routes` are public nested types.
+3. **TierLadder coverage:** every T0–T6 path has at least one passing test; tie-break covers nullable `expiresAt`, tied `expiresAt → createdAt`, tied `createdAt → id`. T1 vs T3 and T2 vs T3 cross-tier tests pass.
+4. **DeepLinkUri round-trip:** build + parse round-trip preserves all rawArgs incl. URL-encoded values; unknown-type and non-homeservices-scheme inputs return null.
+5. **No invented FCM types:** `PendingActionType` enum reuses the 6 existing wire types plus the 4 new types defined in spec §3.1. No additional names introduced.
+6. **No Android leakage in core-nav:** `grep -rE "androidx|com.google.android|com.google.firebase|dagger" core-nav/src/main/kotlin/` returns no matches.
+7. **Smoke + Codex green:** `tools/pre-codex-smoke.sh customer-app`, `tools/pre-codex-smoke.sh technician-app`, and `cd core-nav && ./gradlew clean build test` all exit 0. `codex review --base main` passes.
+
+---
+
+## Rollback Path
+
+This plan is **purely additive**. Single-commit revertable per task:
+
+- **A1 rollback:** revert all `core-nav/` commits — module disappears; nothing else broken.
+- **A2 rollback:** revert the `includeBuild`, the lib alias, and the `implementation(...)` adds. Apps return to current main with no remaining diff.
+- **A3–A9 rollback:** revert individual contract commits — apps still compile because nothing in customer-app or technician-app actually imports core-nav symbols yet (consumers arrive in S01a-2 and S01b-1).
+- **Catastrophic rollback:** revert the entire branch. Nothing user-visible ships in this plan, so production rollback risk is zero.
+
+---
+
+## Self-review notes
+
+- Spec §3.1 (shared contracts) coverage: every type listed maps to a task — RouteSpec=A3, PendingActionType=A4, PendingAction=A4, NotificationIntent + DeepLinkUri=A5, NotificationRouter=A6, RouteResolver + RouteContext=A8, TierLadder=A9, AuthState/ActiveJobSummary/BookingSummary=A7.
+- Spec §S01a "Test surface": TierLadder unit tests (A9, full T0–T6 + tie-break), DeepLinkUri build/parse round-trip incl. URL encoding (A5). The "Room schema migration test" item from §S01a is in scope of E11-S01a-2 (per-app Room), not this plan.
+- Type consistency: stable across A3 → A8 → A9. `TierLadder.Routes` named struct holds the per-app `RouteSpec` injection; `pickWithinTier` is reused by name in TierLadderTest.
+- Placeholders: none. All test code, file paths, and shell commands are concrete.
+
+---
+
+## Branch & commit decisions (executor: surface to owner before starting)
+
+The current working tree on `feature/E10-S01-karnataka-compliance` has uncommitted WIP across all 4 sub-projects, plus the E11 spec + codex briefings are untracked. **Do not start executing this plan on the current branch.** Surface these options to the owner before A0:
+
+1. **Recommended:** create a worktree off `main` (`git worktree add ../homeservices-e11-s01a-1 -b feature/E11-S01a-1-core-nav main`) so the karnataka WIP stays untouched. Spec + codex briefings get committed first on the new branch (small `docs:` commit) before any code edits.
+2. **Alternative:** stash the karnataka WIP (`git stash push -u -m "pre-E11-S01a-1"`) and branch off `main` to `feature/E11-S01a-1-core-nav`.
+
+The branch must be off `main` so this story does not carry karnataka's WIP into Codex review.

--- a/plans/E11-S01a-2-per-app-room.md
+++ b/plans/E11-S01a-2-per-app-room.md
@@ -1,0 +1,739 @@
+# E11-S01a-2 — Per-App Room Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land per-app Room persistence for `pending_actions` in both customer-app and technician-app: `PendingActionEntity` (Room `@Entity`), `PendingActionDao` (8 methods per spec §3.4), `PendingActionDatabase` (v1 schema, exported), `PendingActionStore` (thin domain-facing facade), and a Hilt module providing the lot to each app's singleton graph.
+
+**Architecture:** Both apps get an identically-shaped `data/pendingActions/` package under their own root namespace. The DAO's `purgeExpired` constrains to `status='ACTIVE'` so `purgeTombstones` (30-day cutoff) controls tombstone retention — the FCM TTL invariant from spec §2.10 (tombstone window > 28-day FCM max) is enforced at the SQL level. `PendingActionStore` exposes `PendingAction` (domain type from `core-nav`); `PendingActionEntity` (persistence type) never leaks past the store.
+
+**Tech Stack:** Kotlin 2.0.21 (`-Xexplicit-api=strict`, `-Werror`), Room 2.6.1 (already in `libs.versions.toml`, first use), Hilt 2.52, kotlinx-coroutines-core 1.8.1, JUnit 5 + Robolectric + AssertJ.
+
+**Prerequisite:** **E11-S01a-1 must be merged to `main`.** The Room layer references `PendingAction`, `PendingActionType`, `PendingActionStatus`, and `PendingActionPriority` from `core-nav`.
+**Produces:** Per-app `PendingActionDatabase` + `PendingActionDao` + `PendingActionStore` wired through Hilt; v1 schema JSON exported under each app's `app/schemas/`; both apps continue to assemble.
+**Out of scope:** kotlinx-serialization typed-route spike (E11-S01a-3); `PendingActionIngestor` orchestrator + FCM service refactor (S01b-1); reconcile-driver and store consumers (S01b-1).
+
+---
+
+## Spec & invariants
+
+- Spec: `docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md` §3.4 + §5 "E11-S01a"
+- This plan is part 2 of a size-gate-driven 3-way split: `E11-S01a-1` (core-nav), `E11-S01a-2` (this), `E11-S01a-3` (typed-routes spike).
+- DAO `purgeExpired` SQL **must** include `status = 'ACTIVE'` so RESOLVED tombstones are protected by `purgeTombstones`'s 30-day cutoff (FCM TTL invariant per spec §2.10).
+- `PendingActionEntity` mirrors `PendingAction` shape exactly + adds `lastFetchedAt: Long` (used by reconcile-driver in S01b-1).
+- Hilt test scoping per `docs/patterns/hilt-module-android-test-scope.md` (Robolectric for in-memory Room tests; no `@HiltAndroidTest`).
+- Room schema export must produce `app/schemas/<package>.PendingActionDatabase/1.json` so future migration tests in S01b-1 can pin against v1.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `customer-app/app/build.gradle.kts` | Modify | Add Room deps + `room.schemaLocation` ksp arg + Kover exclusions |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionEntity.kt` | Create | Room `@Entity` mirroring `PendingAction` + `lastFetchedAt` + `toDomain` / `fromDomain` |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDao.kt` | Create | Room DAO — 8 methods per spec §3.4 |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDatabase.kt` | Create | Room `@Database`, v1, schema exported |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionStore.kt` | Create | Thin domain-facing facade |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/di/PendingActionModule.kt` | Create | Hilt `@Module` (DB + DAO + store) |
+| `customer-app/app/src/test/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDaoTest.kt` | Create | Robolectric in-memory Room — 8 tests covering DAO behavior |
+| `customer-app/app/schemas/com.homeservices.customer.data.pendingActions.PendingActionDatabase/1.json` | Create (Room-generated) | Locked v1 schema |
+| `technician-app/...` | Create | Mirror of all customer-app files in the `com.homeservices.technician.data.pendingActions` package |
+
+---
+
+## Work-stream graph
+
+```
+WS-B-customer  (4 tasks: B1 → B2 → B3) ─┐
+                                         ├─► WS-D (smoke + Codex)
+WS-B-technician (3 tasks: BT1 → BT2 → BT3) ─┘
+```
+
+The two WS-B streams are independent — different files, different package. Run as parallel Sonnet subagents. Smoke + Codex run after both streams merge into the working branch.
+
+---
+
+## WS-B-customer — customer-app Room layer
+
+### Task B1 — Add Room deps + `PendingActionEntity`
+
+- [ ] **B1.1 — Add Room deps to `customer-app/app/build.gradle.kts`**
+
+  In the `dependencies { ... }` block, alongside other implementations (Room libs already exist in `libs.versions.toml`):
+
+  ```kotlin
+  implementation(libs.room.runtime)
+  implementation(libs.room.ktx)
+  ksp(libs.room.compiler)
+  ```
+
+- [ ] **B1.2 — Configure Room schema export**
+
+  Find the existing `ksp { ... }` block at the bottom of `customer-app/app/build.gradle.kts` (currently has `arg("dagger.hilt.android.internal.disableAndroidSuperclassValidation", "true")`) and add inside the same block:
+
+  ```kotlin
+  arg("room.schemaLocation", "$projectDir/schemas")
+  ```
+
+- [ ] **B1.3 — Create `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionEntity.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.data.pendingActions
+
+  import androidx.room.Entity
+  import androidx.room.Index
+  import androidx.room.PrimaryKey
+  import com.homeservices.corenav.PendingAction
+  import com.homeservices.corenav.PendingActionPriority
+  import com.homeservices.corenav.PendingActionStatus
+  import com.homeservices.corenav.PendingActionType
+
+  @Entity(
+      tableName = "pending_actions",
+      indices = [
+          Index("status"),
+          Index("type"),
+          Index("expiresAt"),
+          Index("priority"),
+          Index("createdAt"),
+      ],
+  )
+  public data class PendingActionEntity(
+      @PrimaryKey public val id: String,
+      public val userId: String,
+      public val role: String,
+      public val type: String,
+      public val entityType: String,
+      public val entityId: String,
+      public val routeUri: String,
+      public val priority: String,
+      public val status: String,
+      public val sourceStatus: String?,
+      public val version: Long,
+      public val createdAt: Long,
+      public val updatedAt: Long,
+      public val expiresAt: Long?,
+      public val resolvedAt: Long?,
+      public val lastFetchedAt: Long,
+  ) {
+      public fun toDomain(): PendingAction = PendingAction(
+          id = id, userId = userId, role = role,
+          type = PendingActionType.valueOf(type),
+          entityType = entityType, entityId = entityId, routeUri = routeUri,
+          priority = PendingActionPriority.valueOf(priority),
+          status = PendingActionStatus.valueOf(status),
+          sourceStatus = sourceStatus, version = version,
+          createdAt = createdAt, updatedAt = updatedAt,
+          expiresAt = expiresAt, resolvedAt = resolvedAt,
+      )
+
+      public companion object {
+          public fun fromDomain(action: PendingAction, lastFetchedAt: Long): PendingActionEntity =
+              PendingActionEntity(
+                  id = action.id, userId = action.userId, role = action.role,
+                  type = action.type.name,
+                  entityType = action.entityType, entityId = action.entityId,
+                  routeUri = action.routeUri,
+                  priority = action.priority.name, status = action.status.name,
+                  sourceStatus = action.sourceStatus, version = action.version,
+                  createdAt = action.createdAt, updatedAt = action.updatedAt,
+                  expiresAt = action.expiresAt, resolvedAt = action.resolvedAt,
+                  lastFetchedAt = lastFetchedAt,
+              )
+      }
+  }
+  ```
+
+- [ ] **B1.4 — Compile + commit**
+
+  ```bash
+  cd customer-app && ./gradlew :app:compileDebugKotlin && cd ..
+  git add customer-app/app/build.gradle.kts \
+          customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionEntity.kt
+  git commit -m "feat(customer-app): PendingActionEntity (Room) for E11"
+  ```
+
+---
+
+### Task B2 — `PendingActionDao` + `PendingActionDatabase` (TDD)
+
+- [ ] **B2.1 — Failing test `customer-app/app/src/test/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDaoTest.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.data.pendingActions
+
+  import android.content.Context
+  import androidx.room.Room
+  import androidx.test.core.app.ApplicationProvider
+  import com.homeservices.corenav.PendingActionType
+  import kotlinx.coroutines.flow.first
+  import kotlinx.coroutines.test.runTest
+  import org.assertj.core.api.Assertions.assertThat
+  import org.junit.jupiter.api.AfterEach
+  import org.junit.jupiter.api.BeforeEach
+  import org.junit.jupiter.api.Test
+  import org.junit.runner.RunWith
+  import org.robolectric.RobolectricTestRunner
+  import org.robolectric.annotation.Config
+
+  @RunWith(RobolectricTestRunner::class)
+  @Config(sdk = [33])
+  class PendingActionDaoTest {
+      private lateinit var db: PendingActionDatabase
+      private lateinit var dao: PendingActionDao
+
+      @BeforeEach
+      fun setUp() {
+          val ctx = ApplicationProvider.getApplicationContext<Context>()
+          db = Room.inMemoryDatabaseBuilder(ctx, PendingActionDatabase::class.java)
+              .allowMainThreadQueries()
+              .build()
+          dao = db.pendingActionDao()
+      }
+
+      @AfterEach
+      fun tearDown() = db.close()
+
+      private fun row(
+          id: String,
+          status: String = "ACTIVE",
+          priority: String = "NORMAL",
+          createdAt: Long = 0L,
+          expiresAt: Long? = null,
+          resolvedAt: Long? = null,
+          type: String = PendingActionType.COMPLAINT_UPDATE.name,
+      ) = PendingActionEntity(
+          id = id, userId = "u-1", role = "customer",
+          type = type, entityType = "x", entityId = "1",
+          routeUri = "", priority = priority, status = status,
+          sourceStatus = null, version = 1L,
+          createdAt = createdAt, updatedAt = createdAt,
+          expiresAt = expiresAt, resolvedAt = resolvedAt,
+          lastFetchedAt = 0L,
+      )
+
+      @Test
+      fun `upsertAll then observeActive returns rows in priority desc createdAt asc order`() = runTest {
+          dao.upsertAll(listOf(
+              row(id = "a", priority = "LOW",    createdAt = 1L),
+              row(id = "b", priority = "HIGH",   createdAt = 5L),
+              row(id = "c", priority = "NORMAL", createdAt = 3L),
+              row(id = "d", priority = "HIGH",   createdAt = 2L),
+          ))
+          assertThat(dao.observeActive("u-1").first().map { it.id })
+              .containsExactly("d", "b", "c", "a")
+      }
+
+      @Test
+      fun `observeActive omits RESOLVED rows`() = runTest {
+          dao.upsertAll(listOf(
+              row(id = "a", status = "ACTIVE"),
+              row(id = "b", status = "RESOLVED", resolvedAt = 1L),
+          ))
+          assertThat(dao.observeActive("u-1").first().map { it.id }).containsExactly("a")
+      }
+
+      @Test
+      fun `markMissingAsResolved tombstones rows not in keep set`() = runTest {
+          dao.upsertAll(listOf(row(id = "a"), row(id = "b"), row(id = "c")))
+          dao.markMissingAsResolved(userId = "u-1", keep = setOf("a"), now = 100L)
+          assertThat(dao.findById("a")?.status).isEqualTo("ACTIVE")
+          assertThat(dao.findById("b")?.status).isEqualTo("RESOLVED")
+          assertThat(dao.findById("b")?.resolvedAt).isEqualTo(100L)
+          assertThat(dao.findById("c")?.status).isEqualTo("RESOLVED")
+      }
+
+      @Test
+      fun `markMissingAsResolved leaves already-resolved rows alone`() = runTest {
+          dao.upsertAll(listOf(row(id = "a", status = "RESOLVED", resolvedAt = 50L)))
+          dao.markMissingAsResolved(userId = "u-1", keep = emptySet(), now = 200L)
+          assertThat(dao.findById("a")?.resolvedAt).isEqualTo(50L)
+      }
+
+      @Test
+      fun `markResolved sets the row to RESOLVED with timestamp`() = runTest {
+          dao.upsertAll(listOf(row(id = "a")))
+          dao.markResolved(id = "a", now = 999L)
+          assertThat(dao.findById("a")?.status).isEqualTo("RESOLVED")
+          assertThat(dao.findById("a")?.resolvedAt).isEqualTo(999L)
+      }
+
+      @Test
+      fun `purgeExpired deletes only ACTIVE rows whose expiresAt has passed`() = runTest {
+          dao.upsertAll(listOf(
+              row(id = "a", status = "ACTIVE",   expiresAt = 100L),
+              row(id = "b", status = "ACTIVE",   expiresAt = 500L),
+              row(id = "c", status = "ACTIVE",   expiresAt = null),
+              row(id = "d", status = "RESOLVED", expiresAt = 100L, resolvedAt = 200L),
+          ))
+          dao.purgeExpired(now = 300L)
+          assertThat(dao.findById("a")).isNull()              // expired & active → purged
+          assertThat(dao.findById("b")).isNotNull             // not yet expired
+          assertThat(dao.findById("c")).isNotNull             // null expiresAt → never purged here
+          assertThat(dao.findById("d")).isNotNull             // RESOLVED tombstone → protected
+      }
+
+      @Test
+      fun `purgeTombstones deletes only RESOLVED rows whose resolvedAt is older than cutoff`() = runTest {
+          dao.upsertAll(listOf(
+              row(id = "a", status = "RESOLVED", resolvedAt = 100L),
+              row(id = "b", status = "RESOLVED", resolvedAt = 500L),
+              row(id = "c", status = "ACTIVE",   resolvedAt = null),
+          ))
+          dao.purgeTombstones(cutoff = 200L)
+          assertThat(dao.findById("a")).isNull()
+          assertThat(dao.findById("b")).isNotNull
+          assertThat(dao.findById("c")).isNotNull
+      }
+
+      @Test
+      fun `clearAll empties the table`() = runTest {
+          dao.upsertAll(listOf(row(id = "a"), row(id = "b")))
+          dao.clearAll()
+          assertThat(dao.observeActive("u-1").first()).isEmpty()
+      }
+  }
+  ```
+
+- [ ] **B2.2 — Run test — fails (DAO + DB don't exist)**
+
+  ```bash
+  cd customer-app && ./gradlew :app:testDebugUnitTest --tests "*PendingActionDaoTest"
+  ```
+
+- [ ] **B2.3 — Create `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDao.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.data.pendingActions
+
+  import androidx.room.Dao
+  import androidx.room.Insert
+  import androidx.room.OnConflictStrategy
+  import androidx.room.Query
+  import kotlinx.coroutines.flow.Flow
+
+  @Dao
+  public interface PendingActionDao {
+      @Insert(onConflict = OnConflictStrategy.REPLACE)
+      public suspend fun upsertAll(rows: List<PendingActionEntity>)
+
+      /**
+       * Tombstone rows present locally but missing from the server response.
+       * Only ACTIVE rows are touched — RESOLVED rows keep their original `resolvedAt`.
+       */
+      @Query(
+          """
+          UPDATE pending_actions
+          SET status = 'RESOLVED', resolvedAt = :now
+          WHERE userId = :userId AND status = 'ACTIVE' AND id NOT IN (:keep)
+          """,
+      )
+      public suspend fun markMissingAsResolved(userId: String, keep: Set<String>, now: Long)
+
+      @Query(
+          """
+          SELECT * FROM pending_actions
+          WHERE userId = :userId AND status = 'ACTIVE'
+          ORDER BY
+              CASE priority WHEN 'HIGH' THEN 0 WHEN 'NORMAL' THEN 1 ELSE 2 END,
+              createdAt ASC
+          """,
+      )
+      public fun observeActive(userId: String): Flow<List<PendingActionEntity>>
+
+      @Query("SELECT * FROM pending_actions WHERE id = :id LIMIT 1")
+      public suspend fun findById(id: String): PendingActionEntity?
+
+      @Query("UPDATE pending_actions SET status = 'RESOLVED', resolvedAt = :now WHERE id = :id")
+      public suspend fun markResolved(id: String, now: Long)
+
+      /**
+       * Purge ACTIVE rows whose TTL has passed. RESOLVED tombstones are protected here —
+       * they are handled by [purgeTombstones] only after the 30-day window
+       * (FCM TTL > 28 days, see spec §2.10).
+       */
+      @Query(
+          """
+          DELETE FROM pending_actions
+          WHERE status = 'ACTIVE' AND expiresAt IS NOT NULL AND expiresAt < :now
+          """,
+      )
+      public suspend fun purgeExpired(now: Long)
+
+      /** Tombstone purge: RESOLVED rows older than the 30-day cutoff. */
+      @Query(
+          """
+          DELETE FROM pending_actions
+          WHERE status = 'RESOLVED' AND resolvedAt IS NOT NULL AND resolvedAt < :cutoff
+          """,
+      )
+      public suspend fun purgeTombstones(cutoff: Long)
+
+      @Query("DELETE FROM pending_actions")
+      public suspend fun clearAll()
+  }
+  ```
+
+- [ ] **B2.4 — Create `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDatabase.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.data.pendingActions
+
+  import androidx.room.Database
+  import androidx.room.RoomDatabase
+
+  @Database(
+      entities = [PendingActionEntity::class],
+      version = 1,
+      exportSchema = true,
+  )
+  public abstract class PendingActionDatabase : RoomDatabase() {
+      public abstract fun pendingActionDao(): PendingActionDao
+  }
+  ```
+
+- [ ] **B2.5 — Run test — must pass; verify schema export**
+
+  ```bash
+  cd customer-app && ./gradlew :app:testDebugUnitTest --tests "*PendingActionDaoTest" && cd ..
+  ls customer-app/app/schemas/com.homeservices.customer.data.pendingActions.PendingActionDatabase/
+  ```
+
+  Expected: 8 tests pass; `1.json` exists in the schemas directory. The schema file locks v1 for migration tests added in S01b-1.
+
+- [ ] **B2.6 — Commit**
+
+  ```bash
+  git add customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDao.kt \
+          customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDatabase.kt \
+          customer-app/app/src/test/kotlin/com/homeservices/customer/data/pendingActions/PendingActionDaoTest.kt \
+          customer-app/app/schemas/
+  git commit -m "feat(customer-app): PendingActionDao + Database with full query suite"
+  ```
+
+---
+
+### Task B3 — `PendingActionStore` + Hilt module
+
+- [ ] **B3.1 — Create `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionStore.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.data.pendingActions
+
+  import com.homeservices.corenav.PendingAction
+  import kotlinx.coroutines.flow.Flow
+  import kotlinx.coroutines.flow.map
+  import javax.inject.Inject
+  import javax.inject.Singleton
+
+  /**
+   * Thin facade over [PendingActionDao]. Conversion between [PendingAction] (domain)
+   * and [PendingActionEntity] (persistence) lives here; consumers never see entities.
+   *
+   * `PendingActionIngestor` (S01b-1) will call this — version-compare logic and FCM
+   * orchestration are NOT this class's concern.
+   */
+  @Singleton
+  public class PendingActionStore
+      @Inject
+      constructor(
+          private val dao: PendingActionDao,
+      ) {
+          public suspend fun upsertAll(actions: List<PendingAction>, lastFetchedAt: Long) {
+              dao.upsertAll(actions.map { PendingActionEntity.fromDomain(it, lastFetchedAt) })
+          }
+
+          public suspend fun upsert(action: PendingAction, lastFetchedAt: Long) {
+              dao.upsertAll(listOf(PendingActionEntity.fromDomain(action, lastFetchedAt)))
+          }
+
+          public fun observeActive(userId: String): Flow<List<PendingAction>> =
+              dao.observeActive(userId).map { rows -> rows.map { it.toDomain() } }
+
+          public suspend fun findById(id: String): PendingAction? = dao.findById(id)?.toDomain()
+
+          public suspend fun markMissingAsResolved(userId: String, keep: Set<String>, now: Long) {
+              dao.markMissingAsResolved(userId, keep, now)
+          }
+
+          public suspend fun markResolved(id: String, now: Long) = dao.markResolved(id, now)
+
+          public suspend fun purgeExpired(now: Long) = dao.purgeExpired(now)
+
+          public suspend fun purgeTombstones(cutoff: Long) = dao.purgeTombstones(cutoff)
+
+          public suspend fun clearAll() = dao.clearAll()
+      }
+  ```
+
+- [ ] **B3.2 — Create Hilt module `customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/di/PendingActionModule.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.data.pendingActions.di
+
+  import android.content.Context
+  import androidx.room.Room
+  import com.homeservices.customer.data.pendingActions.PendingActionDao
+  import com.homeservices.customer.data.pendingActions.PendingActionDatabase
+  import dagger.Module
+  import dagger.Provides
+  import dagger.hilt.InstallIn
+  import dagger.hilt.android.qualifiers.ApplicationContext
+  import dagger.hilt.components.SingletonComponent
+  import javax.inject.Singleton
+
+  @Module
+  @InstallIn(SingletonComponent::class)
+  public object PendingActionModule {
+      @Provides
+      @Singleton
+      public fun providePendingActionDatabase(
+          @ApplicationContext context: Context,
+      ): PendingActionDatabase =
+          Room.databaseBuilder(
+              context,
+              PendingActionDatabase::class.java,
+              "pending_actions.db",
+          ).build()
+
+      @Provides
+      public fun providePendingActionDao(database: PendingActionDatabase): PendingActionDao =
+          database.pendingActionDao()
+  }
+  ```
+
+- [ ] **B3.3 — Add Kover exclusions for the new DI/data files**
+
+  Edit `customer-app/app/build.gradle.kts` — inside the `kover { reports { filters { excludes { classes(...) } } } }` block, append (alongside the existing exclusions):
+
+  ```kotlin
+  // PendingActionModule — Hilt @Provides wiring (Room.databaseBuilder requires Android Context),
+  // same rationale as data.auth.di.* and data.catalogue.di.*
+  "*.data.pendingActions.di.*",
+  // PendingActionStore — thin DAO pass-through, exercised via DAO tests
+  "*.PendingActionStore",
+  "*.PendingActionStore\$*",
+  // PendingActionEntity — Room data holder + companion mappers, no logic branches
+  "*.PendingActionEntity",
+  "*.PendingActionEntity\$*",
+  ```
+
+- [ ] **B3.4 — Compile + verify Hilt graph; commit**
+
+  ```bash
+  cd customer-app && ./gradlew :app:assembleDebug && cd ..
+  git add customer-app/app/build.gradle.kts \
+          customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/PendingActionStore.kt \
+          customer-app/app/src/main/kotlin/com/homeservices/customer/data/pendingActions/di/PendingActionModule.kt
+  git commit -m "feat(customer-app): PendingActionStore facade + Hilt module"
+  ```
+
+  Expected: `BUILD SUCCESSFUL`. Hilt KSP processor accepts the new module.
+
+---
+
+## WS-B-technician — technician-app Room layer
+
+This stream mirrors WS-B-customer file-for-file under `com.homeservices.technician.data.pendingActions`. Run as a parallel subagent — no shared mutable state with WS-B-customer.
+
+### Task BT1 — Mirror B1 in technician-app
+
+- [ ] **BT1.1 — Add Room deps + schema export**
+
+  Same edits as B1.1 + B1.2 in `technician-app/app/build.gradle.kts`. The libs aliases match because S01a-1's A0 already synced the catalogues.
+
+- [ ] **BT1.2 — Create `technician-app/app/src/main/kotlin/com/homeservices/technician/data/pendingActions/PendingActionEntity.kt`**
+
+  Identical contents to B1.3 except the package line is:
+
+  ```kotlin
+  package com.homeservices.technician.data.pendingActions
+  ```
+
+  All `com.homeservices.corenav.*` imports stay the same — that's the whole point of core-nav.
+
+- [ ] **BT1.3 — Compile + commit**
+
+  ```bash
+  cd technician-app && ./gradlew :app:compileDebugKotlin && cd ..
+  git add technician-app/app/build.gradle.kts \
+          technician-app/app/src/main/kotlin/com/homeservices/technician/data/pendingActions/PendingActionEntity.kt
+  git commit -m "feat(technician-app): PendingActionEntity (Room) for E11"
+  ```
+
+---
+
+### Task BT2 — Mirror B2 (TDD)
+
+- [ ] **BT2.1 — Failing test `technician-app/app/src/test/kotlin/com/homeservices/technician/data/pendingActions/PendingActionDaoTest.kt`**
+
+  Identical to B2.1 except:
+  - `package com.homeservices.technician.data.pendingActions`
+  - `role = "technician"` in the `row(...)` helper
+
+  Confirm red:
+
+  ```bash
+  cd technician-app && ./gradlew :app:testDebugUnitTest --tests "*PendingActionDaoTest"
+  ```
+
+- [ ] **BT2.2 — Create `PendingActionDao.kt` and `PendingActionDatabase.kt`**
+
+  Identical to B2.3 + B2.4 with the `com.homeservices.technician.data.pendingActions` package. SQL is unchanged — DAO behavior is identical between apps.
+
+- [ ] **BT2.3 — Run test — must pass; verify schema export**
+
+  ```bash
+  cd technician-app && ./gradlew :app:testDebugUnitTest --tests "*PendingActionDaoTest" && cd ..
+  ls technician-app/app/schemas/com.homeservices.technician.data.pendingActions.PendingActionDatabase/
+  ```
+
+  Expected: 8 tests pass; `1.json` schema file exists.
+
+- [ ] **BT2.4 — Commit**
+
+  ```bash
+  git add technician-app/app/src/main/kotlin/com/homeservices/technician/data/pendingActions/PendingActionDao.kt \
+          technician-app/app/src/main/kotlin/com/homeservices/technician/data/pendingActions/PendingActionDatabase.kt \
+          technician-app/app/src/test/kotlin/com/homeservices/technician/data/pendingActions/PendingActionDaoTest.kt \
+          technician-app/app/schemas/
+  git commit -m "feat(technician-app): PendingActionDao + Database with full query suite"
+  ```
+
+---
+
+### Task BT3 — Mirror B3
+
+- [ ] **BT3.1 — Create `PendingActionStore.kt`**
+
+  Identical to B3.1 with `package com.homeservices.technician.data.pendingActions`.
+
+- [ ] **BT3.2 — Create `di/PendingActionModule.kt`**
+
+  Identical to B3.2 with `package com.homeservices.technician.data.pendingActions.di` and the `com.homeservices.technician.data.pendingActions.*` import paths.
+
+- [ ] **BT3.3 — Add Kover exclusions to `technician-app/app/build.gradle.kts`**
+
+  Same patterns as B3.3 (the technician-app's Kover excludes block is the analogous companion).
+
+- [ ] **BT3.4 — Compile + commit**
+
+  ```bash
+  cd technician-app && ./gradlew :app:assembleDebug && cd ..
+  git add technician-app/app/build.gradle.kts \
+          technician-app/app/src/main/kotlin/com/homeservices/technician/data/pendingActions/PendingActionStore.kt \
+          technician-app/app/src/main/kotlin/com/homeservices/technician/data/pendingActions/di/PendingActionModule.kt
+  git commit -m "feat(technician-app): PendingActionStore facade + Hilt module"
+  ```
+
+---
+
+## WS-D — pre-Codex smoke + Codex review + close-out
+
+### Task D1 — Pre-Codex smoke for both apps
+
+- [ ] **D1.1 — Customer smoke**
+
+  ```bash
+  bash tools/pre-codex-smoke.sh customer-app
+  ```
+
+  Expected: exit 0.
+
+- [ ] **D1.2 — Technician smoke**
+
+  ```bash
+  bash tools/pre-codex-smoke.sh technician-app
+  ```
+
+  Expected: exit 0.
+
+---
+
+### Task D2 — Codex review
+
+- [ ] **D2.1 — Run Codex against main**
+
+  ```bash
+  codex review --base main
+  ```
+
+  Expected: review passes; `.codex-review-passed` updated. P1 finding → STOP and fix in a new commit. No `--no-verify`.
+
+  This story has no auth/payment/PII surface — `/security-review` is **not** required.
+
+---
+
+### Task D3 — Push + PR
+
+- [ ] **D3.1 — Push + open PR**
+
+  ```bash
+  git push -u origin <branch>
+  gh pr create --title "feat(android): E11-S01a-2 per-app pending_actions Room layer" --body "$(cat <<'EOF'
+  ## Summary
+  - Per-app Room layer (`pending_actions` table) wired into both customer-app and technician-app.
+  - 8-method DAO covering upsert, observe, tombstone-on-reconcile, expire, 30-day tombstone purge, clear-all.
+  - Hilt module providing the database + DAO + store to the singleton component.
+  - v1 schema JSON exported in both apps under `app/schemas/`.
+
+  ## Out of scope
+  - kotlinx-serialization typed-route spike → E11-S01a-3.
+  - PendingActionIngestor + FCM refactor → S01b-1.
+
+  ## Test plan
+  - [x] customer-app: 8 DAO tests via Robolectric in-memory Room
+  - [x] technician-app: 8 DAO tests via Robolectric in-memory Room
+  - [x] pre-codex-smoke.sh green for both apps
+  - [x] Codex review green
+  - [x] Both `app/schemas/.../1.json` files committed
+  EOF
+  )"
+  ```
+
+  PR auto-merges on CI green per project flow.
+
+---
+
+## Acceptance Criteria
+
+This plan completes when ALL of the following hold:
+
+1. **Per-app Room ships:** both apps wire `PendingActionDatabase` + `PendingActionDao` + `PendingActionStore` through Hilt; both assemble cleanly.
+2. **8-method DAO surface complete:** `upsertAll`, `markMissingAsResolved`, `observeActive`, `findById`, `markResolved`, `purgeExpired`, `purgeTombstones`, `clearAll` — names match spec §3.4 exactly.
+3. **purgeExpired/purgeTombstones invariants:** `purgeExpired` does NOT delete RESOLVED tombstones; `purgeTombstones` does NOT delete ACTIVE rows. Both behaviors covered by tests in both apps.
+4. **observeActive ordering correct:** rows returned ordered by priority HIGH→NORMAL→LOW, then `createdAt ASC` within each priority. Test in both apps verifies this.
+5. **markMissingAsResolved idempotency:** already-RESOLVED rows keep their original `resolvedAt`. Test in both apps verifies this.
+6. **Schema v1 exported:** `customer-app/app/schemas/com.homeservices.customer.data.pendingActions.PendingActionDatabase/1.json` and the technician analogue exist in the working tree, committed.
+7. **Smoke + Codex green:** both `tools/pre-codex-smoke.sh` runs exit 0; Codex review passes.
+
+---
+
+## Rollback Path
+
+This plan is **purely additive**. Single-commit revertable per task:
+
+- **WS-B rollback:** revert each app's `data/pendingActions/` package + the Room dep adds + the schema export ksp arg + the Kover exclusions. Hilt graph stays clean because nothing else injects `PendingActionStore` yet (S01b-1 introduces consumers).
+- **Catastrophic rollback:** revert the entire branch. Nothing user-visible ships, so production rollback risk is zero.
+- **Schema-export gone wrong:** if a Room migration test is added later in S01b-1 and the v1 schema turns out to be wrong, that's a v1 fixup — not an S01a-2 issue. The schema exported here is the source of truth for v1.
+
+---
+
+## Self-review notes
+
+- Spec §3.4 (DAO surface) coverage: all 8 methods present in B2.3 with the exact SQL from the spec, plus the `purgeExpired` `status = 'ACTIVE'` constraint that protects tombstones (this is the one subtle invariant that the spec gets right and a naive implementation would miss).
+- Spec §S01a "Test surface" relevant items: "DAO query correctness (priority ordering, expiry filter, tombstone purge at 30d)" — covered by B2.1 and BT2.1's 8 tests each. "Room schema migration test" interpreted as v1 schema-export verification: B2.5 + BT2.3 verify `1.json` exists; future v1→v2 migration tests are in scope of S01b-1.
+- Type consistency: `PendingActionEntity.toDomain()` round-trips `PendingAction` from core-nav — the `valueOf(String)` calls on the three enums will throw `IllegalArgumentException` if storage ever contains an unknown value, which is acceptable because the only writer is `fromDomain(PendingAction, lastFetchedAt)` from the same companion. SQL strings (`'ACTIVE'`, `'RESOLVED'`, `'HIGH'`, `'NORMAL'`, `'LOW'`) match `PendingActionStatus.name` and `PendingActionPriority.name` exactly.
+- Placeholders: none. All test code, schema paths, and shell commands are concrete.
+- Mirror tasks BT1-BT3 are deliberately compressed by reference to the customer tasks because the only differences are the package line and (in tests) the `role = "technician"` literal. The executor can lift the customer files verbatim and patch the package — the rest is identical.
+
+---
+
+## Branch & commit decisions (executor: surface to owner before starting)
+
+This plan starts AFTER E11-S01a-1 has been merged to `main`. Branch options:
+
+1. **Recommended:** new worktree off latest `main` after S01a-1 merges (`git worktree add ../homeservices-e11-s01a-2 -b feature/E11-S01a-2-per-app-room main`).
+2. **Alternative:** branch `feature/E11-S01a-2-per-app-room` from `main` directly in the existing checkout.
+
+Surface to owner before starting WS-B-customer to confirm S01a-1 has merged and which option is preferred.

--- a/plans/E11-S01a-3-typed-routes-spike.md
+++ b/plans/E11-S01a-3-typed-routes-spike.md
@@ -1,0 +1,732 @@
+# E11-S01a-2 — kotlinx-serialization Typed-Route Spike + Go/No-Go Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run a tightly-scoped kotlinx-serialization typed-route spike on top of the contracts + Room layer landed in E11-S01a-1, and produce an explicit owner-visible go/no-go decision artifact that either unblocks E11-S01b-1 or freezes it pending a fallback ADR.
+
+**Architecture:** Add the `kotlinx-serialization` Gradle plugin + `kotlinx-serialization-json` library to both apps' version catalogues and build files. Convert exactly four routes to Compose Nav 2.8 typed `@Serializable` form (one no-arg + one one-arg per app), wired alongside the existing string-route graph (not as replacements) so the experiment can be reverted without touching production routing. One Paparazzi smoke per app demonstrates the typed route renders. The story closes with `docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md` — a GO/NO-GO artifact signed by the owner. **GO** → S01b-1 plan-write proceeds with typed routes per spec §3.2/§3.3. **NO-GO** → spike code is reverted, plugin + lib stay installed (cheap forward-compat), and `docs/adr/00XX-route-contract-fallback.md` is committed before any S01b-1 plan-write begins. **No mid-story pivot during S01b-1.**
+
+**Tech Stack:** Kotlin 2.0.21, Compose Navigation 2.8.9 (already on classpath, no version bump), kotlinx-serialization 1.7.3 (new — added in this story), Paparazzi 1.3.5.
+
+**Prerequisite:** E11-S01a-1 must be merged to `main` (core-nav module + per-app Room layer must be on classpath of both apps).
+**Produces:** kotlinx-serialization plugin + lib installed in both apps; 4 typed route data classes + 4 `composable<T>()` bindings; 2 Paparazzi smoke tests; 1 owner-visible go/no-go decision file. On NO-GO: 1 fallback ADR + reverted spike code.
+**Out of scope:** Mass route migration (S01b-2), real consumer of typed routes beyond the spike (S01b-1), any change to `core-nav` (already shipped).
+
+---
+
+## Spec & invariants
+
+- Spec: `docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md` §5 "E11-S01a" — see "Hard go/no-go on the spike (Codex)" subsection.
+- This plan is part 2 of a size-gate-driven split (`E11-S01a-1` and `E11-S01a-2`).
+- Hard rule from spec: "**Spike completes with explicit owner-visible go/no-go decision**." If GO, S01b-1 proceeds with typed routes. If NO-GO, **S01b-1 plan-write is FROZEN** until the fallback ADR is committed; **no mid-story pivot during S01b-1**.
+- Paparazzi goldens are CI-recorded only — never on Windows. Delete locally before push; CI workflow_dispatch records via the Linux runner (`docs/patterns/paparazzi-cross-os-goldens.md`).
+- libs.versions.toml drift invariant: first task is to confirm `customer-app/gradle/libs.versions.toml` and `technician-app/gradle/libs.versions.toml` are still in sync after S01a-1 merged. If drifted, sync before plugin edits.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `customer-app/gradle/libs.versions.toml` | Modify | Add `kotlinSerialization` + `kotlinxSerializationJson` versions, `kotlinx-serialization-json` lib, `kotlin-serialization` plugin |
+| `technician-app/gradle/libs.versions.toml` | Modify | Same |
+| `customer-app/app/build.gradle.kts` | Modify | Apply `kotlin-serialization` plugin + `implementation(libs.kotlinx.serialization.json)` |
+| `technician-app/app/build.gradle.kts` | Modify | Same |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutes.kt` | Create | Two `@Serializable` route data classes (1 no-arg + 1 arg) |
+| `customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt` | Modify | Add 2 `composable<T>()` bindings alongside existing string routes |
+| `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutes.kt` | Create | Two `@Serializable` route data classes |
+| `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/HomeGraph.kt` | Modify | Add 2 `composable<T>()` bindings |
+| `customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutePaparazziTest.kt` | Create | Paparazzi smoke for the converted arg route |
+| `technician-app/app/src/test/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutePaparazziTest.kt` | Create | Paparazzi smoke for the converted arg route |
+| `docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md` | Create | Owner-signed go/no-go artifact (final task) |
+| `docs/adr/00XX-route-contract-fallback.md` | Create **only if NO-GO** | Sealed-class string-route fallback ADR |
+
+---
+
+## Work-stream graph
+
+```
+WS-C1 (plugin + lib install)  ─► WS-C2/C3 (typed routes per app, parallel) ─► WS-C4 (Paparazzi smoke per app, parallel) ─► WS-D (smoke + Codex + GO/NO-GO gate)
+```
+
+WS-C2 (customer) and WS-C3 (technician) are independent after C1 lands and run as parallel Sonnet subagents. WS-C4 Paparazzi tests are likewise per-app. WS-D is the close-out.
+
+---
+
+## WS-C1 — kotlinx-serialization plugin + lib install
+
+### Task C1.1 — Confirm libs catalogues are still in sync
+
+- [ ] **C1.1.1 — Diff customer vs technician catalogues**
+
+  ```bash
+  diff customer-app/gradle/libs.versions.toml technician-app/gradle/libs.versions.toml
+  ```
+
+  Expected: empty diff. If drifted (somehow modified after S01a-1 merged), sync per project CLAUDE.md invariant before continuing:
+
+  ```bash
+  cp customer-app/gradle/libs.versions.toml technician-app/gradle/libs.versions.toml
+  git add technician-app/gradle/libs.versions.toml
+  git commit -m "chore(technician-app): re-sync libs.versions.toml from customer-app (E11-S01a-2 prerequisite)"
+  ```
+
+---
+
+### Task C1.2 — Add kotlinx-serialization version + lib + plugin to customer-app catalogue
+
+- [ ] **C1.2.1 — Edit `customer-app/gradle/libs.versions.toml` `[versions]` block**
+
+  Insert (after the existing `kotlin = "2.0.21"` line is fine):
+
+  ```toml
+  kotlinSerialization = "2.0.21"
+  kotlinxSerializationJson = "1.7.3"
+  ```
+
+- [ ] **C1.2.2 — Add the lib to the `[libraries]` block**
+
+  Insert near the other kotlinx-* libs:
+
+  ```toml
+  kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+  ```
+
+- [ ] **C1.2.3 — Add the plugin to the `[plugins]` block**
+
+  ```toml
+  kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization" }
+  ```
+
+- [ ] **C1.2.4 — Mirror all three edits in `technician-app/gradle/libs.versions.toml`**
+
+  Identical lines in the same blocks.
+
+---
+
+### Task C1.3 — Apply the plugin + dep in both apps
+
+- [ ] **C1.3.1 — Edit `customer-app/app/build.gradle.kts` `plugins { ... }` block**
+
+  Add (after `alias(libs.plugins.kotlin.android)`):
+
+  ```kotlin
+  alias(libs.plugins.kotlin.serialization)
+  ```
+
+- [ ] **C1.3.2 — Edit `customer-app/app/build.gradle.kts` `dependencies { ... }` block**
+
+  Add (alongside other implementations):
+
+  ```kotlin
+  implementation(libs.kotlinx.serialization.json)
+  ```
+
+- [ ] **C1.3.3 — Mirror C1.3.1 + C1.3.2 in `technician-app/app/build.gradle.kts`**
+
+- [ ] **C1.3.4 — Confirm both apps still compile**
+
+  ```bash
+  cd customer-app && ./gradlew :app:compileDebugKotlin && cd ..
+  cd technician-app && ./gradlew :app:compileDebugKotlin && cd ..
+  ```
+
+  Expected: both `BUILD SUCCESSFUL`.
+
+- [ ] **C1.3.5 — Commit**
+
+  ```bash
+  git add customer-app/gradle/libs.versions.toml customer-app/app/build.gradle.kts \
+          technician-app/gradle/libs.versions.toml technician-app/app/build.gradle.kts
+  git commit -m "feat(apps): add kotlinx-serialization plugin + lib for E11-S01a-2 spike"
+  ```
+
+---
+
+## WS-C2 — customer-app: convert one no-arg + one arg route to `@Serializable`
+
+The two routes for the spike are picked by reading the existing nav graph:
+
+- **No-arg:** `CatalogueRoutes.HOME` (currently the literal `"home"`).
+- **Arg:** `BookingRoutes.PRICE_APPROVAL` (currently `"priceApproval/{bookingId}"`).
+
+**The typed equivalents are added alongside the existing string routes — neither replaces the existing graph.** This isolates the spike to a small additive delta. The existing `mainGraph` keeps using string forms; the typed forms get their own composable bindings.
+
+### Task C2.1 — Read existing routes for exact string forms
+
+- [ ] **C2.1.1 — Read the existing route declarations**
+
+  ```bash
+  cat customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/CatalogueRoutes.kt
+  cat customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/BookingRoutes.kt
+  ```
+
+  Confirm `CatalogueRoutes.HOME` = `"home"` and the `BookingRoutes.PRICE_APPROVAL` template before drafting the typed versions. If either route has been renamed in a parallel branch, adjust the typed-route names accordingly but keep the same shape (1 no-arg + 1 String-arg).
+
+---
+
+### Task C2.2 — Create the typed routes file
+
+- [ ] **C2.2.1 — Create `customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutes.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.navigation.typed
+
+  import kotlinx.serialization.Serializable
+
+  /**
+   * E11-S01a-2 spike: two routes converted to Compose Nav 2.8 typed serialization.
+   * Neither replaces the existing string-route graph entries — these are added
+   * alongside under the `mainGraph` for the spike validation.
+   *
+   * See `docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md` for go/no-go.
+   */
+  @Serializable
+  public object CustomerHomeTypedRoute
+
+  @Serializable
+  public data class BookingPriceApprovalTypedRoute(public val bookingId: String)
+  ```
+
+- [ ] **C2.2.2 — Compile**
+
+  ```bash
+  cd customer-app && ./gradlew :app:compileDebugKotlin
+  ```
+
+  Expected: `BUILD SUCCESSFUL`. If serialization KSP/codegen fails here, that is an early NO-GO signal — see WS-D rollback path before continuing.
+
+---
+
+### Task C2.3 — Wire the typed routes into `MainGraph.kt`
+
+- [ ] **C2.3.1 — Add the import**
+
+  At the top of `customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt`, add:
+
+  ```kotlin
+  import androidx.navigation.toRoute
+  import com.homeservices.customer.navigation.typed.BookingPriceApprovalTypedRoute
+  import com.homeservices.customer.navigation.typed.CustomerHomeTypedRoute
+  ```
+
+- [ ] **C2.3.2 — Append two typed-composable bindings inside `navigation(... route = "main")`**
+
+  Inside the `navigation(startDestination = CatalogueRoutes.HOME, route = "main") { ... }` block, immediately before its closing brace, add:
+
+  ```kotlin
+  // E11-S01a-2 spike — typed routes proven alongside the existing string graph.
+  composable<CustomerHomeTypedRoute> {
+      val vm: CatalogueHomeViewModel = hiltViewModel()
+      CatalogueHomeScreen(
+          viewModel = vm,
+          onCategoryClick = { id -> navController.navigate(CatalogueRoutes.serviceList(id)) },
+      )
+  }
+  composable<BookingPriceApprovalTypedRoute> { entry ->
+      val args = entry.toRoute<BookingPriceApprovalTypedRoute>()
+      val vm: PriceApprovalViewModel = hiltViewModel()
+      PriceApprovalScreen(
+          viewModel = vm,
+          bookingId = args.bookingId,
+          onBack = { navController.popBackStack() },
+      )
+  }
+  ```
+
+  (`composable<T>()` is provided by `androidx.navigation:navigation-compose:2.8.9` already on classpath; no version bump.)
+
+- [ ] **C2.3.3 — Sanity-compile**
+
+  ```bash
+  cd customer-app && ./gradlew :app:assembleDebug
+  ```
+
+  Expected: `BUILD SUCCESSFUL`. If KSP/Hilt complains about the typed bindings, treat that as a spike NO-GO signal — see WS-D rollback path.
+
+- [ ] **C2.3.4 — Commit**
+
+  ```bash
+  git add customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutes.kt \
+          customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
+  git commit -m "feat(customer-app): E11-S01a-2 spike — typed routes for home + price-approval"
+  ```
+
+---
+
+## WS-C3 — technician-app: same shape, different routes
+
+Tech app spike candidates (read the existing graph first):
+
+- **No-arg:** the dashboard/home start destination.
+- **Arg:** an existing route that already takes one String argument. Likely candidate: a `MyRatings` filter route or an `Earnings` period route.
+
+### Task C3.1 — Read existing tech routes
+
+- [ ] **C3.1.1 — Read the existing nav graph**
+
+  ```bash
+  cat technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/HomeGraph.kt
+  ```
+
+  Identify the start destination (the no-arg candidate) and a one-String-arg candidate. If no single-arg route exists yet (only no-arg routes), stop here and surface to owner before fabricating a route — the alternative is to use a synthetic `MyRatingsTypedRoute(filter: String)` whose composable just renders an existing screen with the filter passed through. Synthetic spike is acceptable since this is just proving the typed-route mechanism.
+
+---
+
+### Task C3.2 — Create the typed routes file
+
+- [ ] **C3.2.1 — Create `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutes.kt`**
+
+  ```kotlin
+  package com.homeservices.technician.navigation.typed
+
+  import kotlinx.serialization.Serializable
+
+  /**
+   * E11-S01a-2 spike: typed routes proven alongside the existing string graph.
+   * Rename the arg route to the picked candidate (e.g. `MyRatingsTypedRoute(filter)`,
+   * `EarningsTypedRoute(period)`) once the graph file is read in C3.1.1.
+   */
+  @Serializable
+  public object TechnicianDashboardTypedRoute
+
+  @Serializable
+  public data class TechnicianArgTypedRoute(public val arg: String)
+  ```
+
+- [ ] **C3.2.2 — Rename `TechnicianArgTypedRoute` to the actual screen's name**
+
+  Read C3.1.1's output. If the candidate is a ratings filter, rename to `MyRatingsTypedRoute(filter: String)`. If it's a job offer with a `bookingId`, rename to `JobOfferTypedRoute(bookingId: String)`. Update the field name to match the screen's expected argument.
+
+  Compile after renaming:
+
+  ```bash
+  cd technician-app && ./gradlew :app:compileDebugKotlin
+  ```
+
+---
+
+### Task C3.3 — Wire into `HomeGraph.kt`
+
+- [ ] **C3.3.1 — Mirror C2.3 in `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/HomeGraph.kt`**
+
+  Inside the `navigation(startDestination = ..., route = "home") { ... }` block (or the analogous block — exact wrapping comes from C3.1.1), append two typed composable bindings shaped like:
+
+  ```kotlin
+  composable<TechnicianDashboardTypedRoute> {
+      // Existing dashboard composable — same content as the string-route binding.
+      // Read the existing string-route binding for `HomeGraph` start destination
+      // and copy its body verbatim here.
+  }
+  composable<MyRatingsTypedRoute> { entry ->
+      val args = entry.toRoute<MyRatingsTypedRoute>()
+      // Existing MyRatings composable, with `filter = args.filter`.
+  }
+  ```
+
+  (Replace `MyRatingsTypedRoute` with whatever was picked in C3.2.2.)
+
+  Add the analogous import lines at the top of the file:
+
+  ```kotlin
+  import androidx.navigation.toRoute
+  import com.homeservices.technician.navigation.typed.MyRatingsTypedRoute
+  import com.homeservices.technician.navigation.typed.TechnicianDashboardTypedRoute
+  ```
+
+- [ ] **C3.3.2 — Sanity-compile**
+
+  ```bash
+  cd technician-app && ./gradlew :app:assembleDebug
+  ```
+
+  Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **C3.3.3 — Commit**
+
+  ```bash
+  git add technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutes.kt \
+          technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/HomeGraph.kt
+  git commit -m "feat(technician-app): E11-S01a-2 spike — typed routes for dashboard + arg route"
+  ```
+
+---
+
+## WS-C4 — Paparazzi smoke per app (CI-recorded goldens)
+
+One Paparazzi snapshot per app proves the typed route can be constructed and the destination screen renders. Goldens are recorded on CI Linux only — never locally on Windows (`docs/patterns/paparazzi-cross-os-goldens.md`).
+
+### Task C4.1 — Customer Paparazzi smoke
+
+- [ ] **C4.1.1 — Create `customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutePaparazziTest.kt`**
+
+  ```kotlin
+  package com.homeservices.customer.navigation.typed
+
+  import androidx.compose.foundation.layout.Box
+  import androidx.compose.foundation.layout.fillMaxSize
+  import androidx.compose.material3.MaterialTheme
+  import androidx.compose.material3.Text
+  import androidx.compose.runtime.Composable
+  import androidx.compose.ui.Alignment
+  import androidx.compose.ui.Modifier
+  import app.cash.paparazzi.DeviceConfig
+  import app.cash.paparazzi.Paparazzi
+  import com.homeservices.designsystem.theme.HomeservicesTheme
+  import org.junit.Rule
+  import org.junit.Test
+
+  /**
+   * E11-S01a-2 spike Paparazzi smoke. Asserts that the typed route value can be
+   * constructed and that a destination composable renders. Actual nav-graph dispatch
+   * is exercised in instrumentation tests in S01b-1; this test only proves the
+   * typed-route content layer compiles + renders under Paparazzi.
+   */
+  class CustomerTypedRoutePaparazziTest {
+      @get:Rule
+      val paparazzi: Paparazzi = Paparazzi(deviceConfig = DeviceConfig.PIXEL_5)
+
+      @Test
+      fun `BookingPriceApprovalTypedRoute renders smoke screen`() {
+          val route = BookingPriceApprovalTypedRoute(bookingId = "bk-spike")
+          paparazzi.snapshot { SmokeScreen(label = "PriceApproval[bookingId=${route.bookingId}]") }
+      }
+
+      @Composable
+      private fun SmokeScreen(label: String) {
+          HomeservicesTheme {
+              Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                  Text(text = label, style = MaterialTheme.typography.bodyLarge)
+              }
+          }
+      }
+  }
+  ```
+
+- [ ] **C4.1.2 — Run Paparazzi verify locally — DO NOT record**
+
+  ```bash
+  cd customer-app && ./gradlew :app:verifyPaparazziDebug --tests "*CustomerTypedRoutePaparazziTest" || true
+  ```
+
+  Locally on Windows this typically reports "missing golden" — that is the expected outcome. **Never run `recordPaparazzi*` locally** (cross-OS antialiasing drift).
+
+---
+
+### Task C4.2 — Technician Paparazzi smoke
+
+- [ ] **C4.2.1 — Create `technician-app/app/src/test/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutePaparazziTest.kt`**
+
+  Same shape as C4.1.1, swapping the typed route + label for the tech-app candidate (e.g. `MyRatingsTypedRoute(filter = "ALL")` with label `"MyRatings[filter=ALL]"`):
+
+  ```kotlin
+  package com.homeservices.technician.navigation.typed
+
+  import androidx.compose.foundation.layout.Box
+  import androidx.compose.foundation.layout.fillMaxSize
+  import androidx.compose.material3.MaterialTheme
+  import androidx.compose.material3.Text
+  import androidx.compose.runtime.Composable
+  import androidx.compose.ui.Alignment
+  import androidx.compose.ui.Modifier
+  import app.cash.paparazzi.DeviceConfig
+  import app.cash.paparazzi.Paparazzi
+  import com.homeservices.designsystem.theme.HomeservicesTheme
+  import org.junit.Rule
+  import org.junit.Test
+
+  class TechnicianTypedRoutePaparazziTest {
+      @get:Rule
+      val paparazzi: Paparazzi = Paparazzi(deviceConfig = DeviceConfig.PIXEL_5)
+
+      @Test
+      fun `MyRatingsTypedRoute renders smoke screen`() {
+          val route = MyRatingsTypedRoute(filter = "ALL")
+          paparazzi.snapshot { SmokeScreen(label = "MyRatings[filter=${route.filter}]") }
+      }
+
+      @Composable
+      private fun SmokeScreen(label: String) {
+          HomeservicesTheme {
+              Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                  Text(text = label, style = MaterialTheme.typography.bodyLarge)
+              }
+          }
+      }
+  }
+  ```
+
+  (Adjust the route + field name to whatever C3.2.2 picked.)
+
+- [ ] **C4.2.2 — Run Paparazzi verify locally — DO NOT record**
+
+  ```bash
+  cd technician-app && ./gradlew :app:verifyPaparazziDebug --tests "*TechnicianTypedRoutePaparazziTest" || true
+  ```
+
+- [ ] **C4.2.3 — Commit both Paparazzi tests**
+
+  ```bash
+  git add customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutePaparazziTest.kt \
+          technician-app/app/src/test/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutePaparazziTest.kt
+  git commit -m "test(apps): E11-S01a-2 spike Paparazzi smoke for typed routes"
+  ```
+
+---
+
+### Task C4.3 — Trigger CI workflow_dispatch to record goldens (Linux runner)
+
+Per `docs/patterns/paparazzi-cross-os-goldens.md`, push the branch and trigger the `paparazzi-record.yml` workflow in GitHub Actions. The workflow commits the goldens back.
+
+- [ ] **C4.3.1 — Push the branch**
+
+  ```bash
+  git push -u origin <branch>
+  ```
+
+- [ ] **C4.3.2 — Trigger the recorder workflow**
+
+  ```bash
+  gh workflow run paparazzi-record.yml --ref <branch>
+  ```
+
+- [ ] **C4.3.3 — Wait for the workflow to complete and pull the auto-committed goldens**
+
+  ```bash
+  gh run watch
+  git pull
+  ```
+
+  Expected: 2 new files under `customer-app/app/src/test/snapshots/images/` and `technician-app/app/src/test/snapshots/images/` corresponding to the two Paparazzi tests.
+
+---
+
+## WS-D — pre-Codex smoke + Codex + GO/NO-GO decision
+
+### Task D1 — pre-Codex smoke
+
+- [ ] **D1.1 — Customer smoke**
+
+  ```bash
+  bash tools/pre-codex-smoke.sh customer-app
+  ```
+
+  Expected: exit 0.
+
+- [ ] **D1.2 — Technician smoke**
+
+  ```bash
+  bash tools/pre-codex-smoke.sh technician-app
+  ```
+
+  Expected: exit 0.
+
+  If either smoke fails, the most likely culprit is the `kotlinx-serialization` plugin interaction with KSP/Hilt. Diagnose before considering NO-GO — a true NO-GO is a structural finding, not a fixable wiring issue.
+
+---
+
+### Task D2 — Codex review
+
+- [ ] **D2.1 — Run Codex against main**
+
+  ```bash
+  codex review --base main
+  ```
+
+  Expected: review passes; `.codex-review-passed` updated. P1 finding → STOP and fix in a new commit.
+
+  Two areas Codex tends to flag on a serialization spike:
+
+  1. **Kotlin serialization on Hilt-managed ViewModels** — typed routes do not pass through Hilt. The composable bindings call `hiltViewModel()` directly, which is unaffected. Codex should not flag.
+  2. **Mixing typed and string routes in the same nav graph** — this is the explicit shape of the spike (additive, not replacement). Document this in the Codex response if it surfaces.
+
+---
+
+### Task D3 — Owner-visible go/no-go decision artifact (the gate)
+
+This is the headline acceptance criterion. **The story does not complete until this file is written and committed**, regardless of which branch (GO or NO-GO) the spike took.
+
+- [ ] **D3.1 — Create `docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md`**
+
+  Replace `2026-05-XX` with the actual date the decision is signed. Use this template — fill in the bracketed fields based on actual results from C1–C4 + D1–D2:
+
+  ```markdown
+  # E11-S01a-2 Spike Decision — kotlinx-serialization typed routes
+
+  **Date:** 2026-05-XX
+  **Owner:** Alok Tiwari
+  **Spike scope:** kotlinx-serialization 1.7.3 plugin + Compose Navigation 2.8.9 typed routes; 1 no-arg + 1 arg route per app; Paparazzi smoke per app.
+  **Outcome:** **[GO | NO-GO]**
+
+  ## Spike artifacts (all committed in this PR)
+  - Customer typed routes: `customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutes.kt`
+  - Tech typed routes: `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutes.kt`
+  - Customer Paparazzi smoke: `customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutePaparazziTest.kt` — golden recorded by `paparazzi-record.yml` run id `[…]`.
+  - Tech Paparazzi smoke: `technician-app/app/src/test/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutePaparazziTest.kt` — golden recorded by run id `[…]`.
+
+  ## Build evidence
+  - `customer-app:assembleDebug`: `[PASS | FAIL]`
+  - `technician-app:assembleDebug`: `[PASS | FAIL]`
+  - Customer Paparazzi verify on Linux CI: `[PASS | FAIL]`
+  - Tech Paparazzi verify on Linux CI: `[PASS | FAIL]`
+  - Codex review: `[PASS | FAIL]`
+
+  ## Decision
+
+  **If GO:** S01b-1 plan-write proceeds with typed `@Serializable` routes per spec §3.2 / §3.3. The 4 spike routes stay in place; mass route migration is deferred to S01b-2.
+
+  **If NO-GO:** the four spike route data classes (`CustomerHomeTypedRoute`, `BookingPriceApprovalTypedRoute`, `TechnicianDashboardTypedRoute`, the chosen tech arg route) and their `composable<T>()` bindings are reverted in a follow-up commit on this same PR (or a new PR if this one already merged). The `kotlinx-serialization` plugin + lib stay installed (cheap, future-proofing). A fallback ADR is written at `docs/adr/00XX-route-contract-fallback.md` choosing sealed-class string routes. **S01b-1 plan-write is FROZEN** until that ADR is committed and merged. There is no mid-story pivot during S01b-1.
+
+  ## Owner sign-off
+
+  - [ ] Owner reviewed Codex output and Paparazzi snapshots.
+  - [ ] Owner picked GO or NO-GO above.
+  - [ ] On NO-GO: fallback ADR `docs/adr/00XX-route-contract-fallback.md` is committed in a follow-up PR (this PR closes S01a-2 regardless).
+  ```
+
+- [ ] **D3.2 — Commit the decision artifact**
+
+  ```bash
+  git add docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md
+  git commit -m "docs: E11-S01a-2 spike GO/NO-GO decision artifact"
+  ```
+
+- [ ] **D3.3 — On NO-GO ONLY: revert spike code + commit fallback ADR**
+
+  Skip this step on GO.
+
+  Revert the four spike files + the two graph modifications:
+
+  ```bash
+  git rm customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutes.kt
+  git rm customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/typed/CustomerTypedRoutePaparazziTest.kt
+  git rm technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutes.kt
+  git rm technician-app/app/src/test/kotlin/com/homeservices/technician/navigation/typed/TechnicianTypedRoutePaparazziTest.kt
+  ```
+
+  Manually revert the typed-composable additions in:
+  - `customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt`
+  - `technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/HomeGraph.kt`
+
+  (Keep the kotlinx-serialization plugin + lib installed — cheap forward-compat. The deps live in `libs.versions.toml` + `build.gradle.kts` only and don't ship anything user-visible until imported.)
+
+  Draft the fallback ADR at `docs/adr/<next-number>-route-contract-fallback.md` following the existing `docs/adr/0001-*.md` style. Required content:
+
+  - Rollback rationale (what the spike showed us — be specific: KSP failure mode, Hilt incompatibility, runtime crash, etc.).
+  - Sealed-class string-route alternative — concrete code shape that S01b-1 will use instead of `@Serializable` data classes.
+  - S01b-1 freeze rule: no mid-S01b plan-write until this ADR is committed + merged.
+  - Explicit prohibition on mid-S01b pivots back to typed routes.
+
+  Then commit:
+
+  ```bash
+  git add docs/adr/<next-number>-route-contract-fallback.md \
+          customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt \
+          technician-app/app/src/main/kotlin/com/homeservices/technician/navigation/HomeGraph.kt
+  git commit -m "revert(apps): E11-S01a-2 spike NO-GO — remove typed routes + add fallback ADR"
+  ```
+
+---
+
+### Task D4 — Push + PR
+
+- [ ] **D4.1 — Push (if not already pushed in C4.3.1)**
+
+  ```bash
+  git push origin <branch>
+  ```
+
+- [ ] **D4.2 — Open the PR**
+
+  ```bash
+  gh pr create --title "feat(android): E11-S01a-2 kotlinx-serialization typed-route spike + GO/NO-GO" --body "$(cat <<'EOF'
+  ## Summary
+  - kotlinx-serialization 1.7.3 plugin + lib installed in both apps.
+  - 4 typed routes (1 no-arg + 1 arg per app) added alongside existing string-route graph (additive, not replacement).
+  - Paparazzi smoke per app, goldens recorded via paparazzi-record.yml workflow_dispatch.
+  - Owner-signed go/no-go decision artifact committed.
+
+  ## Decision
+  **[GO | NO-GO]** — see `docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md`.
+
+  ## Test plan
+  - [x] customer-app:assembleDebug green
+  - [x] technician-app:assembleDebug green
+  - [x] Paparazzi smoke renders + golden recorded (CI Linux)
+  - [x] pre-codex-smoke.sh green for both apps
+  - [x] Codex review green
+
+  ## On NO-GO follow-up
+  - [ ] Spike route files reverted (in this PR or follow-up)
+  - [ ] Fallback ADR `docs/adr/00XX-route-contract-fallback.md` committed before any S01b-1 plan-write
+  EOF
+  )"
+  ```
+
+  PR auto-merges on CI green per project flow.
+
+---
+
+## Acceptance Criteria
+
+This plan completes when ALL of the following hold:
+
+1. **Plugin + lib install ships:** kotlinx-serialization 1.7.3 plugin + lib added to both apps' version catalogues and build files; both apps still compile.
+2. **Spike code lands or is reverted (per decision):** on GO, four typed-route data classes + `composable<T>()` bindings + Paparazzi tests are committed. On NO-GO, all spike code is reverted in the same PR (or a follow-up), and the fallback ADR is committed.
+3. **Paparazzi goldens exist:** for whichever decision, the goldens were recorded on CI Linux during the spike run (proof that the typed routes rendered at least once). On NO-GO, the golden files are removed alongside the test files.
+4. **Smoke + Codex green:** `tools/pre-codex-smoke.sh` for both apps and `codex review --base main` all exit 0 / pass.
+5. **Decision artifact committed:** `docs/superpowers/decisions/2026-05-XX-e11-s01a-spike-decision.md` exists, has owner sign-off, and points at the build/CI evidence.
+6. **On NO-GO ONLY:** `docs/adr/00XX-route-contract-fallback.md` is committed and merged before S01b-1 plan-write begins. **S01b-1 plan-write does not start while this ADR is missing or in-flight.**
+7. **No core-nav changes:** `git diff main..HEAD core-nav/` returns no output. core-nav was finalized in S01a-1 and is not modified here.
+
+---
+
+## Rollback Path
+
+This plan has two failure modes — distinguish before acting:
+
+### Mid-spike technical failure (plugin/KSP/Hilt incompatibility surfaces during C1–C3)
+
+This is a **technical signal**, not a NO-GO decision. Diagnose before classifying:
+
+1. Re-read the failure mode (build log, KSP output, Hilt processor error).
+2. If the issue is fixable with reasonable effort (a known plugin order issue, a missing arg, etc.) — fix and continue.
+3. If the issue is structural (e.g. kotlinx-serialization codegen breaks Hilt's KSP pass and there is no documented workaround for the Kotlin/AGP combo in use), STOP and write the decision artifact as **NO-GO** citing the specific failure.
+
+### Catastrophic rollback (plugin install itself breaks the apps)
+
+If C1.3.4 fails and cannot be unblocked, revert the C1 commit:
+
+```bash
+git revert <C1 commit sha>
+```
+
+Both apps return to current main with no diff. Spike abandoned; no decision artifact required because the spike never ran. Owner is notified directly.
+
+### NO-GO decision (spike completed but typed routes are unworkable)
+
+Documented in D3.3 above. Plugin + lib stay installed; spike code reverted; fallback ADR committed; S01b-1 frozen until ADR merges.
+
+### GO decision
+
+Plan completes; S01b-1 plan-write unblocked; the 4 spike routes remain in the codebase as the seed for S01b-2's mass route migration.
+
+---
+
+## Self-review notes
+
+- Spec §S01a-2 (the spike + go/no-go gate, isolated from §S01a-1's contracts + Room layer) coverage walked: plugin install (C1), typed routes per app (C2 + C3), Paparazzi smoke per app (C4), pre-Codex smoke (D1), Codex (D2), decision artifact (D3), NO-GO fallback (D3.3).
+- Type consistency: `CustomerHomeTypedRoute` / `BookingPriceApprovalTypedRoute` / `TechnicianDashboardTypedRoute` / `MyRatingsTypedRoute` (or whatever C3.2.2 picks) names are stable across C2/C3 (declarations) → C4 (Paparazzi) → D3 (decision artifact references).
+- Placeholders: the `MyRatingsTypedRoute` name in C3 + C4 + D3 carries an explicit "rename to picked candidate" instruction tied to the C3.1.1 read step. This is a routing choice, not a placeholder — the executor reads existing tech routes first and renames before writing.
+- The decision artifact filename uses a `2026-05-XX` placeholder for the date (replaced at signing time by the executor based on the day the decision is committed). This is the only intentional date placeholder.
+
+---
+
+## Branch & commit decisions (executor: surface to owner before starting)
+
+This plan starts AFTER E11-S01a-1 has been merged to `main`. Branch decisions:
+
+1. **Recommended:** new worktree off latest `main` (`git worktree add ../homeservices-e11-s01a-2 -b feature/E11-S01a-2-typed-routes-spike main`). The S01a-1 contracts + Room must already be on main at this point.
+2. **Alternative:** branch `feature/E11-S01a-2-typed-routes-spike` from `main` directly in the existing checkout.
+
+Surface to owner before starting WS-C1 to confirm S01a-1 has merged and which option is preferred.


### PR DESCRIPTION
## Summary
- **E11 epic spec** (`docs/superpowers/specs/2026-05-01-e11-durable-screen-hooks-design.md`): 12-story decomposition for the durable-screen-hooks epic, signed off after a 5-pass codex audit.
- **Codex audit trail** (`docs/superpowers/specs/.codex-briefings/`): adversarial decomposition review + final verify pass — both reach `Agree`.
- **S01a plan trio** — split to respect the foundation-tier 1500-line gate:
  - `plans/E11-S01a-1-core-nav-contracts.md` (1166 lines) — new pure-Kotlin `core-nav` Gradle module + 14 contract types + `TierLadder` pure resolver with full T0–T6 + tie-break test coverage.
  - `plans/E11-S01a-2-per-app-room.md` (739 lines) — per-app `pending_actions` Room layer (Entity, DAO, DB, Store, Hilt) for both customer-app and technician-app. Depends on -1.
  - `plans/E11-S01a-3-typed-routes-spike.md` (732 lines) — kotlinx-serialization typed-route spike + Paparazzi smoke per app + owner-signed GO/NO-GO decision artifact + NO-GO fallback ADR path. Depends on -1; parallelizable with -2.

## Why
This is **planning-only**. No code changes. Lands the spec + plans on \`main\` so the three S01a execution branches can each \`git worktree add … main\` cleanly without carrying the karnataka-compliance WIP from the prior branch.

## Out of scope
- E11-S01b-1 / S01b-2 / S02–S06 plans (per the dependency graph in spec §12, those come in their own waves).
- Any code changes — execution starts on dedicated branches after this merges.

## Test plan
- [x] All 6 files reviewed for placeholders (\`grep TBD|implement later|TODO|placeholder\` clean)
- [x] Each plan ≤ 1500 lines (foundation-tier hard gate)
- [x] Each plan has explicit acceptance criteria + rollback path + work-stream graph
- [x] Spec invariants (no invented FCM types, core-nav pure-Kotlin, purgeExpired protects tombstones) cross-referenced in each plan