### PR TITLE
feat(admin-web): wire Azure Static Web Apps deploy on main push

### DIFF
--- a/.github/workflows/admin-ship.yml
+++ b/.github/workflows/admin-ship.yml
@@ -1,6 +1,7 @@
 name: admin-ship
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
@@ -131,3 +132,36 @@ jobs:
         run: pnpm test:a11y
       - name: lighthouse CI budgets
         run: pnpm exec lhci autorun --config=lighthouserc.cjs
+
+  deploy:
+    name: Deploy to Azure Static Web Apps
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [quality-gate, e2e-and-a11y]
+    # Production deploy on main push or manual dispatch only.
+    # PR previews are intentionally NOT auto-deployed — keeps Free-tier env
+    # surface small and avoids leaking pre-merge UI to the public SWA URL.
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Deploy via Azure Static Web Apps action (Oryx builds Next.js)
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: admin-web
+          api_location: ''
+          output_location: ''
+        env:
+          # NEXT_PUBLIC_* are baked at build time by Oryx inside the SWA action
+          # container. Server-only secrets (JWT_SECRET, etc.) live in SWA app
+          # settings — set via `az staticwebapp appsettings set` (see runbook §5.1).
+          NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_APP_URL: ${{ vars.ADMIN_WEB_PUBLIC_URL }}
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}

--- a/admin-web/staticwebapp.config.json
+++ b/admin-web/staticwebapp.config.json
@@ -1,15 +1,2 @@
-{
-  "routes": [
-    {
-      "route": "/api/*",
-      "allowedRoles": ["anonymous"]
-    }
-  ],
-  "navigationFallback": {
-    "rewrite": "/index.html",
-    "exclude": ["/api/*", "/_next/*", "/static/*"]
-  },
-  "platform": {
-    "apiRuntime": "node:20"
-  }
-}
+{}
+

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -278,6 +278,96 @@ Safety events are always treated as real until confirmed otherwise.
 3. Mobile apps: Play Store release builds via GitHub Actions → internal testing track → (after manual sanity test) promote to production.
 4. Database migrations: Cosmos is schema-flexible; additive changes (new fields) need no migration. Breaking changes require a story + coordinated deploy.
 
+### 5.1 Admin Web — One-time Azure Static Web Apps setup
+
+The `admin-ship.yml` workflow's `deploy` job pushes to an Azure Static Web App (Free SKU, ₹0/mo, 100 GB bandwidth). The resource and its secrets must be provisioned **once** before the first deploy.
+
+**Fast path (recommended):** export your Firebase web-app config to a local JSON file and run:
+
+```bash
+bash tools/bootstrap-admin-web-deploy.sh path/to/firebase-web-config.json
+```
+
+The script is idempotent — it creates the SWA resource if missing, fetches the deployment token, sets all 4 GitHub secrets + the `ADMIN_WEB_PUBLIC_URL` variable, and provisions `JWT_SECRET` on SWA app settings (preserved across re-runs unless `ROTATE_JWT=true`). Prereqs: `az login`, `gh auth login`, `jq`, `openssl`.
+
+The Firebase config JSON has the shape `{ "apiKey": "...", "authDomain": "...", "projectId": "..." }` — pull it from Firebase Console → Project settings → Your apps → Web → Config.
+
+**Manual path (if you'd rather drive it by hand):**
+
+**Step 1 — Create the Static Web App resource:**
+
+```bash
+az staticwebapp create \
+  --name swa-homeservices-admin-prod \
+  --resource-group rg-homeservices-prod \
+  --location eastasia \
+  --sku Free
+```
+
+(Same RG as the API Function App. **`centralindia` is NOT available** for `Microsoft.Web/staticSites` — SWA Free is restricted to `westus2 / centralus / eastus2 / westeurope / eastasia`. `eastasia` is closest to Bengaluru at ~140 ms RTT.)
+
+**Step 2 — Get the deployment token + public hostname:**
+
+```bash
+# Deployment token → goes into GH secret AZURE_STATIC_WEB_APPS_API_TOKEN
+az staticwebapp secrets list \
+  --name swa-homeservices-admin-prod \
+  --resource-group rg-homeservices-prod \
+  --query "properties.apiKey" -o tsv
+
+# Public hostname → goes into GH variable ADMIN_WEB_PUBLIC_URL
+az staticwebapp show \
+  --name swa-homeservices-admin-prod \
+  --resource-group rg-homeservices-prod \
+  --query "defaultHostname" -o tsv
+# Output looks like: swa-homeservices-admin-prod.<random>.5.azurestaticapps.net
+```
+
+**Step 3 — Configure GitHub repo secrets + variables:**
+
+`Settings → Secrets and variables → Actions`:
+
+| Type | Name | Value |
+|---|---|---|
+| Secret | `AZURE_STATIC_WEB_APPS_API_TOKEN` | from Step 2 |
+| Secret | `NEXT_PUBLIC_FIREBASE_API_KEY` | Firebase Console → Project settings → Web app config |
+| Secret | `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | same |
+| Secret | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | same |
+| Variable | `ADMIN_WEB_PUBLIC_URL` | `https://<defaultHostname from Step 2>` |
+
+**Step 4 — Set server-side runtime env vars via SWA app settings:**
+
+`NEXT_PUBLIC_*` are baked at build time (Step 3 above). Server-only secrets must be set on the SWA resource itself:
+
+```bash
+az staticwebapp appsettings set \
+  --name swa-homeservices-admin-prod \
+  --setting-names \
+    JWT_SECRET="$(openssl rand -hex 32)"
+```
+
+`JWT_SECRET` is consumed by `admin-web/middleware.ts` to verify the `hs_access` access-token cookie on `/dashboard/*`.
+
+**Step 5 — First deploy:**
+
+Push to `main` (or run `gh workflow run admin-ship.yml`). The `deploy` job will:
+1. Wait for `quality-gate` and `e2e-and-a11y` to pass.
+2. Invoke `Azure/static-web-apps-deploy@v1`, which runs Oryx inside the action's container — Oryx auto-detects Next.js 15, runs `pnpm install` + `pnpm build`, deploys SSR runtime + static assets.
+3. App goes live at the URL from Step 2 within ~2-3 min.
+
+**Step 6 — Verify:**
+
+```bash
+curl -I "$(az staticwebapp show --name swa-homeservices-admin-prod --resource-group rg-homeservices-prod --query 'defaultHostname' -o tsv | sed 's|^|https://|')"
+# Expect 200/302 (302 = middleware redirecting unauthenticated user to /login)
+```
+
+**Caveats:**
+- Azure SWA's hybrid Next.js support is in **preview** — middleware works but adds ~200-400 ms cold-start latency on first request after idle. Acceptable for an internal admin dashboard.
+- ISR (`revalidate`) is **not** supported — use SSR or static.
+- `next/image` Loader is restricted — defaults to unoptimized. Acceptable for admin.
+- If SWA hybrid Next.js limitations bite later, fallback is Azure App Service B1 (~₹1k/mo) or Container Apps (free 180k vCPU-sec/mo) — both need an ADR amendment to ADR-0007.
+
 **Rollback:**
 - Admin / API: revert commit + push to `main` → auto-rolls forward. Static Web Apps retains previous deployment slots.
 - Mobile: Play Store Staged Rollouts + Halt-Rollout feature. Previous APK users unaffected; new users get old version until hotfix ships.

--- a/tools/bootstrap-admin-web-deploy.sh
+++ b/tools/bootstrap-admin-web-deploy.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Bootstrap Azure Static Web Apps deployment for admin-web (idempotent).
+#
+# What it does:
+#   1. Creates the Static Web App resource if it doesn't exist (Free SKU).
+#   2. Pulls the deployment token + default hostname.
+#   3. Sets the required GitHub Actions secrets + variable on this repo.
+#   4. Generates a JWT_SECRET and pushes it to SWA app settings — only if
+#      one isn't already set (never rotates an existing secret silently).
+#
+# Prerequisites:
+#   - Azure CLI logged in (az login) with the right subscription set.
+#   - GitHub CLI logged in (gh auth login) with admin on this repo.
+#   - Firebase web-app config exported to a local JSON file with shape:
+#       {
+#         "apiKey":      "AIza...",
+#         "authDomain":  "homeservices.firebaseapp.com",
+#         "projectId":   "homeservices"
+#       }
+#     Get this from Firebase Console → Project settings → Your apps → Web → Config.
+#
+# Usage:
+#   bash tools/bootstrap-admin-web-deploy.sh <firebase-web-config.json>
+#
+# Re-runs are safe: existing resources/settings are reused; existing
+# JWT_SECRET is preserved (rotate manually with `--rotate-jwt` if needed).
+
+set -euo pipefail
+
+FIREBASE_CONFIG_PATH="${1:-}"
+ROTATE_JWT="${ROTATE_JWT:-false}"
+
+if [[ -z "$FIREBASE_CONFIG_PATH" ]]; then
+  echo "Usage: $0 <firebase-web-config.json>" >&2
+  echo "Set ROTATE_JWT=true to force-rotate the SWA JWT_SECRET." >&2
+  exit 2
+fi
+if [[ ! -f "$FIREBASE_CONFIG_PATH" ]]; then
+  echo "Firebase config file not found: $FIREBASE_CONFIG_PATH" >&2
+  exit 2
+fi
+
+# --- config ---
+RG="rg-homeservices-prod"
+SWA_NAME="swa-homeservices-admin-prod"
+# SWA Free is restricted to: westus2, centralus, eastus2, westeurope, eastasia.
+# centralindia is NOT available for Microsoft.Web/staticSites. eastasia (Hong Kong)
+# is the closest option to Bengaluru — ~140 ms RTT vs ~250 ms from westeurope.
+SWA_LOCATION="${SWA_LOCATION:-eastasia}"
+
+# --- preflight ---
+command -v az >/dev/null || { echo "az CLI not found" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq not found" >&2; exit 1; }
+
+az account show >/dev/null 2>&1 || { echo "az not logged in — run 'az login'" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "gh not logged in — run 'gh auth login'" >&2; exit 1; }
+
+FB_API_KEY="$(jq -er '.apiKey' "$FIREBASE_CONFIG_PATH")"
+FB_AUTH_DOMAIN="$(jq -er '.authDomain' "$FIREBASE_CONFIG_PATH")"
+FB_PROJECT_ID="$(jq -er '.projectId' "$FIREBASE_CONFIG_PATH")"
+
+echo "==> Subscription: $(az account show --query 'name' -o tsv)"
+echo "==> GH repo:      $(gh repo view --json nameWithOwner -q .nameWithOwner)"
+echo
+
+# --- 1. resource group (create if missing) ---
+if az group show --name "$RG" >/dev/null 2>&1; then
+  echo "[1/5] Resource group '$RG' already exists — reusing."
+else
+  echo "[1/5] Creating resource group '$RG' in $SWA_LOCATION..."
+  az group create --name "$RG" --location "$SWA_LOCATION" --output none
+fi
+
+# --- 2. SWA resource (create if missing) ---
+if az staticwebapp show --name "$SWA_NAME" --resource-group "$RG" >/dev/null 2>&1; then
+  echo "[2/5] SWA '$SWA_NAME' already exists — reusing."
+else
+  echo "[2/5] Creating SWA '$SWA_NAME' in $RG ($SWA_LOCATION, Free SKU)..."
+  az staticwebapp create \
+    --name "$SWA_NAME" \
+    --resource-group "$RG" \
+    --location "$SWA_LOCATION" \
+    --sku Free \
+    --output none
+fi
+
+# --- 3. fetch token + hostname ---
+echo "[3/5] Fetching deployment token + default hostname..."
+SWA_TOKEN="$(az staticwebapp secrets list --name "$SWA_NAME" --resource-group "$RG" --query 'properties.apiKey' -o tsv)"
+SWA_HOSTNAME="$(az staticwebapp show --name "$SWA_NAME" --resource-group "$RG" --query 'defaultHostname' -o tsv)"
+SWA_URL="https://${SWA_HOSTNAME}"
+
+# --- 4. GH secrets + variable ---
+echo "[4/5] Setting GitHub repo secrets + variable..."
+printf '%s' "$SWA_TOKEN"        | gh secret set AZURE_STATIC_WEB_APPS_API_TOKEN --body -
+printf '%s' "$FB_API_KEY"       | gh secret set NEXT_PUBLIC_FIREBASE_API_KEY     --body -
+printf '%s' "$FB_AUTH_DOMAIN"   | gh secret set NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN --body -
+printf '%s' "$FB_PROJECT_ID"    | gh secret set NEXT_PUBLIC_FIREBASE_PROJECT_ID  --body -
+gh variable set ADMIN_WEB_PUBLIC_URL --body "$SWA_URL"
+
+# --- 5. SWA app settings (server-side runtime) ---
+echo "[5/5] Configuring SWA app settings (JWT_SECRET)..."
+EXISTING_JWT="$(az staticwebapp appsettings list \
+  --name "$SWA_NAME" --resource-group "$RG" \
+  --query "properties.JWT_SECRET" -o tsv 2>/dev/null || echo "")"
+
+if [[ -n "$EXISTING_JWT" && "$ROTATE_JWT" != "true" ]]; then
+  echo "      JWT_SECRET already set — preserving (set ROTATE_JWT=true to rotate)."
+else
+  if [[ -n "$EXISTING_JWT" ]]; then
+    echo "      ROTATE_JWT=true — overwriting existing JWT_SECRET."
+  fi
+  NEW_JWT="$(openssl rand -hex 32)"
+  az staticwebapp appsettings set \
+    --name "$SWA_NAME" --resource-group "$RG" \
+    --setting-names "JWT_SECRET=$NEW_JWT" \
+    --output none
+  echo "      JWT_SECRET written to SWA app settings."
+fi
+
+echo
+echo "==> Done."
+echo "    SWA URL:  $SWA_URL"
+echo "    Trigger first deploy: gh workflow run admin-ship.yml"


### PR DESCRIPTION
## Summary
- Adds the missing `deploy` job to `admin-ship.yml` so admin-web actually ships on push to `main`.
- SWA resource (`swa-homeservices-admin-prod`, eastasia, Free SKU) and GH secrets/variables already provisioned out-of-band — see runbook §5.1.
- `staticwebapp.config.json` stripped to `{}` (prior static-export rewrite was silently ignored by SWA hybrid mode).
- New `tools/bootstrap-admin-web-deploy.sh` makes the one-time setup idempotent for future environments.

Live URL after merge: https://black-river-0af326a00.7.azurestaticapps.net

## Test plan
- [ ] PR CI: `quality-gate` passes (typecheck, unit tests, build, semgrep, generated-client drift check)
- [ ] After merge: `quality-gate` + `e2e-and-a11y` + `deploy` all green on the merge-to-main run
- [ ] `curl -I https://black-river-0af326a00.7.azurestaticapps.net` returns 302 (middleware redirect to /login) within ~3 min of deploy completion
- [ ] Hitting `/dashboard` while unauthenticated redirects to `/login` (middleware JWT gate works in the SWA runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)