### PR TITLE
fix(admin-web): e2e theme toggle test drives data-theme, not .dark class

### DIFF
--- a/admin-web/tests/e2e/landing.spec.ts
+++ b/admin-web/tests/e2e/landing.spec.ts
@@ -28,19 +28,27 @@ test('footer shows real commit sha and semver from /v1/health', async ({ page })
   await expect(footer).toContainText(/\d+\.\d+\.\d+/);
 });
 
-test('dark mode toggle changes computed background color', async ({ page }) => {
+test('theme toggle changes computed background color', async ({ page }) => {
   await page.goto('/');
-  // Read resolved backgroundColor on <html> — globals.css declares `html { background: var(--color-surface) }`.
-  // Reading custom properties via getPropertyValue can return empty for layer-scoped declarations in
-  // Chromium (Tailwind v4 wraps :root tokens in @layer theme); the resolved color is the reliable signal.
-  const initialBg = await page.evaluate(
+  // ThemeProvider toggles theme by mutating `documentElement.dataset.theme`.
+  // globals.css makes :root tokens dark by default and overrides them under
+  // `html[data-theme="light"]`; `.dark` is a no-op (line ~171). Force both
+  // states explicitly so the assertion is independent of cookie/system-pref
+  // defaults. Read resolved backgroundColor (not the var) — getPropertyValue
+  // can return empty for layer-scoped declarations in Tailwind v4's @theme.
+  await page.evaluate(() => {
+    document.documentElement.dataset['theme'] = 'light';
+  });
+  const lightBg = await page.evaluate(
     () => getComputedStyle(document.documentElement).backgroundColor,
   );
-  await page.evaluate(() => document.documentElement.classList.add('dark'));
+  await page.evaluate(() => {
+    document.documentElement.dataset['theme'] = 'dark';
+  });
   const darkBg = await page.evaluate(
     () => getComputedStyle(document.documentElement).backgroundColor,
   );
-  expect(darkBg).not.toBe(initialBg);
+  expect(lightBg).not.toBe(darkBg);
+  expect(lightBg).not.toBe('');
   expect(darkBg).not.toBe('');
-  expect(initialBg).not.toBe('');
 });


### PR DESCRIPTION
## Summary
- `tests/e2e/landing.spec.ts:31` was added against a "light is default" assumption that E10-S99 inverted. Both before/after backgrounds resolved to the same `rgb(14, 11, 8)` (= `#0E0B08`, the dark `--color-surface`), because `.dark` is documented as a no-op in `globals.css:171`.
- Fix drives the real production mechanism: `documentElement.dataset.theme` toggle between `light` and `dark`, exercising `html[data-theme="light"]` override at `globals.css:138`.
- Forces both states explicitly so the assertion is independent of cookie/system-pref defaults.
- Unblocks `admin-ship.yml` deploy job — currently skipped because `e2e-and-a11y` was failing on this single test.

## Test plan
- [ ] CI `quality-gate` passes
- [ ] After merge: `e2e-and-a11y` passes (the dark-mode test was the only failure on run 25241116142)
- [ ] Deploy job runs to completion → SWA URL `https://black-river-0af326a00.7.azurestaticapps.net` returns the actual app (not the placeholder page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)