### PR TITLE
fix(admin-web): override FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 at SWA deploy step

### DIFF
--- a/.github/workflows/admin-ship.yml
+++ b/.github/workflows/admin-ship.yml
@@ -157,6 +157,12 @@ jobs:
           api_location: ''
           output_location: ''
         env:
+          # SWA action's container only supports Node 18/20/22; the workflow-scope
+          # FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 from line ~34 leaks into the action
+          # and breaks the deploy with "Node version 24.13.0 is not supported".
+          # Override here to keep Oryx + the action on supported runtimes.
+          # Oryx itself respects admin-web/.nvmrc (pinned to 22).
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: ''
           # NEXT_PUBLIC_* are baked at build time by Oryx inside the SWA action
           # container. Server-only secrets (JWT_SECRET, etc.) live in SWA app
           # settings — set via `az staticwebapp appsettings set` (see runbook §5.1).


### PR DESCRIPTION
## Summary
Last admin-ship run reached Oryx successfully (build completed in 63s, all routes compiled, manifest written) but the SWA deploy step then failed:

\`\`\`
Node version 24.13.0 is not supported.
Please use one of the following versions 18, 20, 22.
\`\`\`

Workflow-scope \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'\` (line ~34 of admin-ship.yml) is passed into the SWA action's docker container as an env var. The container's internal scripts honor it and try to use Node 24, which is past the 18/20/22 ceiling supported by Azure SWA's runtime.

Override the env at the deploy step to keep the action on supported Node. \`admin-web/.nvmrc\` is already pinned to \`22\` so Oryx itself was fine — this only fixes the post-build deploy step.

Token-side issue (initial \`deployment_token provided was invalid\`) was resolved separately by \`az staticwebapp secrets reset-api-key\` at 02:50 UTC.

## Test plan
- [ ] CI \`quality-gate\` passes
- [ ] After merge: \`e2e-and-a11y\` + \`Deploy to Azure Static Web Apps\` both succeed
- [ ] \`https://black-river-0af326a00.7.azurestaticapps.net\` returns the real app (not the SWA placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)