### PR TITLE
feat(home-heroo): recover dashboard + catalogue-visual components, wire as technician home

### DIFF
--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/CatalogueVisualImage.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/CatalogueVisualImage.kt
@@ -1,0 +1,244 @@
+package com.homeservices.customer.ui.catalogue
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+
+internal enum class CatalogueVisualSize {
+    Category,
+    ServiceCard,
+    Hero,
+}
+
+@Composable
+internal fun CatalogueVisualImage(
+    title: String,
+    imageUrl: String,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+    visualSize: CatalogueVisualSize = CatalogueVisualSize.Category,
+) {
+    var imageFailed by remember(imageUrl) { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        CatalogueImagePlaceholder(
+            title = title,
+            supportingText = supportingText,
+            visualSize = visualSize,
+            modifier = Modifier.fillMaxSize(),
+        )
+        if (imageUrl.isNotBlank() && !imageFailed) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = contentDescription,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                onError = { imageFailed = true },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CatalogueImagePlaceholder(
+    title: String,
+    supportingText: String?,
+    visualSize: CatalogueVisualSize,
+    modifier: Modifier = Modifier,
+) {
+    val palette = paletteFor(title)
+    val contentPadding =
+        when (visualSize) {
+            CatalogueVisualSize.ServiceCard -> 10.dp
+            CatalogueVisualSize.Category -> 14.dp
+            CatalogueVisualSize.Hero -> 24.dp
+        }
+
+    Surface(
+        modifier = modifier,
+        color = palette.start,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Brush.linearGradient(listOf(palette.start, palette.end)))
+                    .padding(contentPadding),
+        ) {
+            VisualBars(
+                color = palette.accent,
+                modifier = Modifier.align(Alignment.TopEnd),
+                compact = visualSize == CatalogueVisualSize.ServiceCard,
+            )
+            InitialsTile(
+                title = title,
+                color = palette.accent,
+                size =
+                    when (visualSize) {
+                        CatalogueVisualSize.ServiceCard -> 44.dp
+                        CatalogueVisualSize.Category -> 52.dp
+                        CatalogueVisualSize.Hero -> 68.dp
+                    },
+                modifier =
+                    when (visualSize) {
+                        CatalogueVisualSize.ServiceCard -> Modifier.align(Alignment.Center)
+                        else -> Modifier.align(Alignment.TopStart)
+                    },
+            )
+            if (visualSize == CatalogueVisualSize.Category) {
+                Column(
+                    modifier = Modifier.align(Alignment.BottomStart).fillMaxWidth(0.86f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Text(
+                        text = title,
+                        style =
+                            if (visualSize == CatalogueVisualSize.Hero) {
+                                MaterialTheme.typography.titleLarge
+                            } else {
+                                MaterialTheme.typography.titleSmall
+                            },
+                        fontWeight = FontWeight.SemiBold,
+                        color = palette.text,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    supportingText?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = palette.text.copy(alpha = 0.72f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InitialsTile(
+    title: String,
+    color: Color,
+    size: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.size(size),
+        shape = MaterialTheme.shapes.medium,
+        color = Color.White.copy(alpha = 0.58f),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = initialsFor(title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = color,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VisualBars(
+    color: Color,
+    compact: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val barWidth = if (compact) 8.dp else 12.dp
+    val baseHeight = if (compact) 22.dp else 34.dp
+    val heightStep = if (compact) 7.dp else 10.dp
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(if (compact) 3.dp else 5.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        repeat(3) { index ->
+            Surface(
+                modifier =
+                    Modifier
+                        .width(barWidth)
+                        .height(baseHeight + heightStep * index.toFloat()),
+                shape = MaterialTheme.shapes.extraSmall,
+                color = color.copy(alpha = 0.16f + index * 0.05f),
+            ) {}
+        }
+    }
+}
+
+private data class CataloguePalette(
+    val start: Color,
+    val end: Color,
+    val accent: Color,
+    val text: Color = Color(0xFF18202A),
+)
+
+private fun paletteFor(title: String): CataloguePalette {
+    val key = title.lowercase()
+    return when {
+        key.contains("clean") ->
+            CataloguePalette(Color(0xFFE7F4F1), Color(0xFFD3ECE7), Color(0xFF00796B))
+        key.contains("repair") || key.contains("electric") || key.contains("plumb") ->
+            CataloguePalette(Color(0xFFE8F0FB), Color(0xFFD7E5F7), Color(0xFF2E5EAA))
+        key.contains("beauty") || key.contains("salon") || key.contains("spa") ->
+            CataloguePalette(Color(0xFFF7E8EE), Color(0xFFF0D8E2), Color(0xFF9C3B63))
+        key.contains("appliance") || key.contains("ac") || key.contains("fridge") ->
+            CataloguePalette(Color(0xFFFFF3DF), Color(0xFFF8E4BC), Color(0xFF9A6500))
+        key.contains("paint") || key.contains("carpenter") ->
+            CataloguePalette(Color(0xFFEDECF6), Color(0xFFDDD9EF), Color(0xFF5A4E9A))
+        else -> fallbackPalettes[stableIndex(title, fallbackPalettes.size)]
+    }
+}
+
+private val fallbackPalettes =
+    listOf(
+        CataloguePalette(Color(0xFFE9F2EE), Color(0xFFD9E9E2), Color(0xFF276749)),
+        CataloguePalette(Color(0xFFF2ECE3), Color(0xFFE7DCCB), Color(0xFF7A5A2A)),
+        CataloguePalette(Color(0xFFE9EEF5), Color(0xFFD8E1EC), Color(0xFF415A77)),
+        CataloguePalette(Color(0xFFF4E9E3), Color(0xFFEAD8CD), Color(0xFF8A4F35)),
+        CataloguePalette(Color(0xFFEAF1F2), Color(0xFFD8E5E8), Color(0xFF2F6470)),
+    )
+
+private fun stableIndex(
+    value: String,
+    size: Int,
+): Int = value.fold(0) { acc, char -> acc + char.code }.let { kotlin.math.abs(it) % size }
+
+private fun initialsFor(title: String): String {
+    val initials =
+        title
+            .split(" ", "-", "&", "/")
+            .filter { it.isNotBlank() }
+            .take(2)
+            .joinToString("") { it.first().uppercaseChar().toString() }
+    return initials.ifBlank { "HS" }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/dashboard/TechnicianDashboardScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/dashboard/TechnicianDashboardScreen.kt
@@ -1,0 +1,295 @@
+package com.homeservices.technician.ui.dashboard
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.homeservices.designsystem.components.HsSectionCard
+import com.homeservices.designsystem.components.HsTrustBadge
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun TechnicianDashboardScreen(
+    onOpenEarnings: () -> Unit,
+    onOpenRatings: () -> Unit,
+    onOpenKyc: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = { TopAppBar(title = { Text("Technician home") }) },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            item { DashboardHeader() }
+            item { AvailabilityCard() }
+            item { TodaySnapshot() }
+            item {
+                WorkflowCard(
+                    onOpenEarnings = onOpenEarnings,
+                    onOpenRatings = onOpenRatings,
+                    onOpenKyc = onOpenKyc,
+                )
+            }
+            item { ActiveAssignmentCard() }
+            item { JobOffersCard() }
+            item { SupportCard() }
+        }
+    }
+}
+
+@Composable
+private fun DashboardHeader() {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        HsTrustBadge(text = "Live workspace")
+        Text(
+            text = "Technician operations",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = "Track availability, jobs, payouts, ratings, and support from one place.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun AvailabilityCard() {
+    var available by remember { mutableStateOf(true) }
+    HsSectionCard {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    text = if (available) "Available for jobs" else "Paused",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = "Live requests appear as timed offers when dispatch assigns one.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = available, onCheckedChange = { available = it })
+        }
+    }
+}
+
+@Composable
+private fun TodaySnapshot() {
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth()) {
+        MetricTile(
+            label = "Today",
+            value = "Rs 0",
+            supportingText = "Earnings",
+            modifier = Modifier.weight(1f),
+        )
+        MetricTile(
+            label = "Queue",
+            value = "0",
+            supportingText = "Active jobs",
+            modifier = Modifier.weight(1f),
+        )
+        MetricTile(
+            label = "Rating",
+            value = "New",
+            supportingText = "No reviews",
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun MetricTile(
+    label: String,
+    value: String,
+    supportingText: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = supportingText,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WorkflowCard(
+    onOpenEarnings: () -> Unit,
+    onOpenRatings: () -> Unit,
+    onOpenKyc: () -> Unit,
+) {
+    HsSectionCard(title = "Core workflow") {
+        DashboardNavRow(
+            title = "Earnings",
+            body = "Payout totals and 7-day activity",
+            status = "Open",
+            onClick = onOpenEarnings,
+        )
+        HorizontalDivider()
+        DashboardNavRow(
+            title = "Ratings",
+            body = "Customer feedback and score breakdown",
+            status = "Open",
+            onClick = onOpenRatings,
+        )
+        HorizontalDivider()
+        DashboardNavRow(
+            title = "KYC and documents",
+            body = "Identity and PAN verification flow",
+            status = "Review",
+            onClick = onOpenKyc,
+        )
+    }
+}
+
+@Composable
+private fun DashboardNavRow(
+    title: String,
+    body: String,
+    status: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Text(
+            text = status,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun ActiveAssignmentCard() {
+    HsSectionCard(title = "Current assignment") {
+        StatusPill(text = "No active job")
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = "Accepted bookings open the live tracker with address, stage updates, navigation, and completion photos.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun JobOffersCard() {
+    HsSectionCard(title = "Job offers") {
+        StatusPill(text = "Standby")
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = "New requests are shown as a full-screen offer with earnings, distance, slot, accept, and decline actions.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SupportCard() {
+    HsSectionCard(title = "Support and complaints") {
+        StatusPill(text = "No open issues")
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = "Issue reporting is available from job rating and completion flows when a booking needs support review.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun StatusPill(text: String) {
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Recovers two orphan UI components from the dropped `wip/home-heroo-refinements-2026-05-01` branch (commit `a70dd0d`, still in reflog) and **fixes the broken technician landing experience**.

## Why
Currently on main, the technician-app's `home_dashboard` route renders `EarningsScreen` directly. Two consequences:
1. Technicians land on an earnings page that requires backend auth — if not yet authed, shows "Could not load earnings" error
2. There's no proper "home" surface — no overview of availability, today's status, workflow links, active assignments, etc.

The dropped wip branch had `TechnicianDashboardScreen.kt` (~250 LOC) that was the intended proper home dashboard but never made it to main due to branch scope-contamination during the Ayodhya/Hindi pivot. This PR recovers it.

## Changes
- `customer-app/.../ui/catalogue/CatalogueVisualImage.kt` (NEW, 244 LOC) — Hero-style category card image. Currently uncalled; wiring is a follow-up.
- `technician-app/.../ui/dashboard/TechnicianDashboardScreen.kt` (NEW, ~250 LOC) — Proper home dashboard
- `technician-app/.../navigation/HomeGraph.kt` (MODIFIED) — `home_dashboard` now renders `TechnicianDashboardScreen`; new `earnings` sub-route renders `EarningsScreen` (navigated from WorkflowCard).

## Test plan
- [x] Both apps `compileDebugKotlin` green (verified locally)
- [x] technician-app `assembleDebug` green
- [x] Installed on Moto G Power 5G (2024) — landing screen now is the dashboard, earnings is reached via the WorkflowCard
- [x] CI: customer-ship + technician-ship + docs-ship quality-gates

## Known follow-ups
- `onOpenKyc` callback is currently a no-op (KYC lives in `OnboardingGraph` — cross-graph wiring needs separate design)
- `CatalogueVisualImage.kt` is recovered but not yet integrated into catalogue UI

## Recovery provenance
- Source: `git show a70dd0d:<path>` (reflog still has the SHA — recoverable for ~30 days from 2026-05-01)
- Original branch: `wip/home-heroo-refinements-2026-05-01` (dropped 2026-05-02 during pre-pivot cleanup; documented in `docs/archive/2026-05-02-pre-pivot-archives.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)