### PR TITLE
fix(customer): show bookings and correct tracking status

### DIFF
--- a/api/src/cosmos/booking-repository.ts
+++ b/api/src/cosmos/booking-repository.ts
@@ -96,6 +96,20 @@ export const bookingRepo = {
     return resources;
   },
 
+  async getByCustomerId(customerId: string): Promise<BookingDoc[]> {
+    const { resources } = await getBookingsContainer()
+      .items.query<BookingDoc>({
+        query: `SELECT * FROM c
+                WHERE c.customerId = @customerId`,
+        parameters: [{ name: '@customerId', value: customerId }],
+      })
+      .fetchAll();
+    return resources.sort((a, b) => {
+      const slotCompare = b.slotDate.localeCompare(a.slotDate) || b.slotWindow.localeCompare(a.slotWindow);
+      return slotCompare || b.createdAt.localeCompare(a.createdAt);
+    });
+  },
+
   async requestAddOn(id: string, addOn: PendingAddOn): Promise<BookingDoc | null> {
     const existing = await this.getById(id);
     if (!existing || existing.status !== 'IN_PROGRESS') return null;

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -163,6 +163,44 @@ const getBookingInner: CustomerHttpHandler = async (req, _ctx, customer) => {
 };
 export const getBookingHandler: HttpHandler = requireCustomer(getBookingInner);
 
+const getMyBookingsInner: CustomerHttpHandler = async (_req, ctx, customer) => {
+  try {
+    const bookings = await bookingRepo.getByCustomerId(customer.customerId);
+    const serviceNames = new Map<string, string>();
+
+    await Promise.all(
+      [...new Set(bookings.map((booking) => booking.serviceId))].map(async (serviceId) => {
+        const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
+        serviceNames.set(serviceId, service?.name ?? serviceId);
+      }),
+    );
+
+    return {
+      status: 200,
+      jsonBody: {
+        bookings: bookings.map((booking) => ({
+          bookingId: booking.id,
+          serviceId: booking.serviceId,
+          serviceName: serviceNames.get(booking.serviceId) ?? booking.serviceId,
+          addressText: booking.addressText,
+          addressLatLng: booking.addressLatLng,
+          status: booking.status,
+          slotDate: booking.slotDate,
+          slotWindow: booking.slotWindow,
+          amount: booking.finalAmount ?? booking.amount,
+          paymentMethod: booking.paymentMethod ?? 'RAZORPAY',
+          createdAt: booking.createdAt,
+        })),
+      },
+    };
+  } catch (err: unknown) {
+    Sentry.captureException(err);
+    ctx.error('getMyBookings failed', err);
+    return { status: 500, jsonBody: { code: 'INTERNAL_ERROR' } };
+  }
+};
+export const getMyBookingsHandler: HttpHandler = requireCustomer(getMyBookingsInner);
+
 export const requestAddonHandler: HttpHandler = async (req, _ctx) => {
   let uid: string;
   try { ({ uid } = await verifyTechnicianToken(req)); }
@@ -199,6 +237,7 @@ export const approveFinalPriceHandler: HttpHandler = requireCustomer(approveFina
 
 app.http('createBooking', { route: 'v1/bookings', methods: ['POST'], handler: createBookingHandler });
 app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: confirmBookingHandler });
+app.http('getMyBookings', { route: 'v1/bookings', methods: ['GET'], handler: getMyBookingsHandler });
 app.http('getBooking', { route: 'v1/bookings/{id}', methods: ['GET'], handler: getBookingHandler });
 app.http('requestAddon', { route: 'v1/bookings/{id}/request-addon', methods: ['POST'], handler: requestAddonHandler });
 app.http('approveFinalPrice', { route: 'v1/bookings/{id}/approve-final-price', methods: ['POST'], handler: approveFinalPriceHandler });

--- a/api/tests/bookings/list.test.ts
+++ b/api/tests/bookings/list.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HttpRequest, type HttpResponseInit, type InvocationContext } from '@azure/functions';
+
+vi.mock('../../src/middleware/requireCustomer.js', () => ({
+  requireCustomer: (handler: (req: HttpRequest, ctx: InvocationContext, claims: { customerId: string }) => Promise<unknown>) =>
+    (req: HttpRequest, ctx: InvocationContext) => handler(req, ctx, { customerId: 'cust-1' }),
+}));
+
+vi.mock('../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: { getByCustomerId: vi.fn() },
+}));
+
+vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
+  catalogueRepo: { getServiceByIdCrossPartition: vi.fn() },
+}));
+
+vi.mock('@sentry/node', () => ({ captureException: vi.fn() }));
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+function makeReq(): HttpRequest {
+  return new HttpRequest({
+    url: 'http://localhost/api/v1/bookings',
+    method: 'GET',
+    headers: { Authorization: 'Bearer test-token' },
+  });
+}
+
+const ctx = { error: vi.fn() } as unknown as InvocationContext;
+
+describe('GET /v1/bookings', () => {
+  let handler: typeof import('../../src/functions/bookings.js').getMyBookingsHandler;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    handler = (await import('../../src/functions/bookings.js')).getMyBookingsHandler;
+  });
+
+  it('returns current customer bookings with service names and final amount', async () => {
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    const { catalogueRepo } = await import('../../src/cosmos/catalogue-repository.js');
+    (bookingRepo.getByCustomerId as MockFn).mockResolvedValue([
+      {
+        id: 'bk-1',
+        customerId: 'cust-1',
+        serviceId: 'ac-deep-clean',
+        addressText: '101 Ayodhya',
+        addressLatLng: { lat: 26.79, lng: 82.2 },
+        status: 'ASSIGNED',
+        slotDate: '2026-05-05',
+        slotWindow: '10:00-12:00',
+        amount: 89900,
+        finalAmount: 99900,
+        paymentMethod: 'CASH_ON_SERVICE',
+        createdAt: '2026-05-03T10:00:00.000Z',
+      },
+    ]);
+    (catalogueRepo.getServiceByIdCrossPartition as MockFn).mockResolvedValue({ name: 'AC deep clean' });
+
+    const res = (await handler(makeReq(), ctx)) as HttpResponseInit;
+
+    expect(bookingRepo.getByCustomerId).toHaveBeenCalledWith('cust-1');
+    expect(res.status).toBe(200);
+    expect(res.jsonBody).toEqual({
+      bookings: [
+        {
+          bookingId: 'bk-1',
+          serviceId: 'ac-deep-clean',
+          serviceName: 'AC deep clean',
+          addressText: '101 Ayodhya',
+          addressLatLng: { lat: 26.79, lng: 82.2 },
+          status: 'ASSIGNED',
+          slotDate: '2026-05-05',
+          slotWindow: '10:00-12:00',
+          amount: 99900,
+          paymentMethod: 'CASH_ON_SERVICE',
+          createdAt: '2026-05-03T10:00:00.000Z',
+        },
+      ],
+    });
+  });
+
+  it('returns a structured 500 when customer booking lookup fails', async () => {
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    (bookingRepo.getByCustomerId as MockFn).mockRejectedValue(new Error('Cosmos timeout'));
+
+    const res = (await handler(makeReq(), ctx)) as HttpResponseInit;
+
+    expect(res.status).toBe(500);
+    expect(res.jsonBody).toEqual({ code: 'INTERNAL_ERROR' });
+  });
+});

--- a/api/tests/unit/cosmos/booking-repository.test.ts
+++ b/api/tests/unit/cosmos/booking-repository.test.ts
@@ -57,3 +57,19 @@ describe('bookingRepo.getAssignedBookingsBefore (includes NO_SHOW_REDISPATCH)', 
     expect(result).toEqual([]);
   });
 });
+
+describe('bookingRepo.getByCustomerId', () => {
+  it('queries customer bookings and orders them by scheduled slot in memory', async () => {
+    const older = { ...BASE, id: 'bk-older', slotDate: '2026-05-01', slotWindow: '09:00-11:00', createdAt: '2026-04-25T04:00:00.000Z' };
+    const newer = { ...BASE, id: 'bk-newer', slotDate: '2026-05-05', slotWindow: '10:00-12:00', createdAt: '2026-04-26T04:00:00.000Z' };
+    mockQueryFetchAll.mockResolvedValue({ resources: [older, newer] });
+
+    const result = await bookingRepo.getByCustomerId('cust-1');
+
+    expect(result.map((booking) => booking.id)).toEqual(['bk-newer', 'bk-older']);
+    const querySpec = mockQuery.mock.calls[0]![0] as { query: string; parameters: unknown[] };
+    expect(querySpec.query).toContain('c.customerId = @customerId');
+    expect(querySpec.query).not.toContain('ORDER BY');
+    expect(querySpec.parameters).toContainEqual({ name: '@customerId', value: 'cust-1' });
+  });
+});

--- a/customer-app/app/build.gradle.kts
+++ b/customer-app/app/build.gradle.kts
@@ -274,6 +274,12 @@ kover {
                     "*.BookingSummaryScreenKt\$*",
                     "*.BookingConfirmedScreenKt",
                     "*.BookingConfirmedScreenKt\$*",
+                    // Customer bookings list Compose screen, same rationale as other *Kt screen classes
+                    "*.CustomerBookingsScreenKt",
+                    "*.CustomerBookingsScreenKt\$*",
+                    // CustomerBookingsUiState sealed class, data holders with no logic branches
+                    "*.CustomerBookingsUiState",
+                    "*.CustomerBookingsUiState\$*",
                     // BookingUiState sealed class — data holders, no logic branches
                     "*.BookingUiState",
                     "*.BookingUiState\$*",

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt
@@ -3,11 +3,14 @@ package com.homeservices.customer.data.booking
 import com.homeservices.customer.domain.booking.model.AddOnDecision
 import com.homeservices.customer.domain.booking.model.BookingRequest
 import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.CustomerBooking
 import com.homeservices.customer.domain.booking.model.PendingAddOn
 import kotlinx.coroutines.flow.Flow
 
 public interface BookingRepository {
     public fun createBooking(request: BookingRequest): Flow<Result<BookingResult>>
+
+    public fun getMyBookings(): Flow<Result<List<CustomerBooking>>>
 
     public fun confirmBooking(
         bookingId: String,

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.homeservices.customer.data.booking.remote.dto.LatLngDto
 import com.homeservices.customer.domain.booking.model.AddOnDecision
 import com.homeservices.customer.domain.booking.model.BookingRequest
 import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.CustomerBooking
 import com.homeservices.customer.domain.booking.model.PendingAddOn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -37,6 +38,11 @@ internal class BookingRepositoryImpl
                             ).toDomain()
                     },
                 )
+            }
+
+        override fun getMyBookings(): Flow<Result<List<CustomerBooking>>> =
+            flow {
+                emit(runCatching { api.getMyBookings().bookings.map { it.toDomain() } })
             }
 
         override fun confirmBooking(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
@@ -6,6 +6,7 @@ import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingRequestDt
 import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingResponseDto
 import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
 import com.homeservices.customer.data.booking.remote.dto.CreateBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.CustomerBookingsResponseDto
 import com.homeservices.customer.data.booking.remote.dto.GetBookingResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -28,6 +29,9 @@ public interface BookingApiService {
     public suspend fun getBooking(
         @Path("id") bookingId: String,
     ): GetBookingResponseDto
+
+    @GET("v1/bookings")
+    public suspend fun getMyBookings(): CustomerBookingsResponseDto
 
     @POST("v1/bookings/{id}/approve-final-price")
     public suspend fun approveFinalPrice(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/BookingDtos.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/BookingDtos.kt
@@ -2,6 +2,8 @@ package com.homeservices.customer.data.booking.remote.dto
 
 import com.homeservices.customer.domain.booking.model.BookingPaymentMethod
 import com.homeservices.customer.domain.booking.model.BookingResult
+import com.homeservices.customer.domain.booking.model.CustomerBooking
+import com.homeservices.customer.domain.booking.model.CustomerBookingStatus
 import com.homeservices.customer.domain.booking.model.PendingAddOn
 import com.squareup.moshi.JsonClass
 
@@ -91,3 +93,42 @@ public data class ApproveFinalPriceResponseDto(
     val status: String,
     val finalAmount: Int?,
 )
+
+@JsonClass(generateAdapter = true)
+public data class CustomerBookingsResponseDto(
+    val bookings: List<CustomerBookingDto> = emptyList(),
+)
+
+@JsonClass(generateAdapter = true)
+public data class CustomerBookingDto(
+    val bookingId: String,
+    val serviceId: String,
+    val serviceName: String,
+    val addressText: String,
+    val status: String,
+    val slotDate: String,
+    val slotWindow: String,
+    val amount: Long,
+    val paymentMethod: String? = null,
+    val createdAt: String,
+) {
+    public fun toDomain(): CustomerBooking =
+        CustomerBooking(
+            bookingId = bookingId,
+            serviceId = serviceId,
+            serviceName = serviceName,
+            addressText = addressText,
+            status =
+                runCatching {
+                    CustomerBookingStatus.valueOf(status)
+                }.getOrDefault(CustomerBookingStatus.UNKNOWN),
+            slotDate = slotDate,
+            slotWindow = slotWindow,
+            amountPaise = amount,
+            paymentMethod =
+                paymentMethod
+                    ?.let { runCatching { BookingPaymentMethod.valueOf(it) }.getOrNull() }
+                    ?: BookingPaymentMethod.RAZORPAY,
+            createdAt = createdAt,
+        )
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImpl.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImpl.kt
@@ -1,11 +1,14 @@
 package com.homeservices.customer.data.tracking
 
+import com.homeservices.customer.data.booking.remote.BookingApiService
 import com.homeservices.customer.domain.tracking.TrackingRepository
 import com.homeservices.customer.domain.tracking.model.BookingStatus
 import com.homeservices.customer.domain.tracking.model.LiveLocation
 import com.homeservices.customer.domain.tracking.model.TrackingState
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.scan
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,25 +18,36 @@ public class TrackingRepositoryImpl
     @Inject
     constructor(
         private val eventBus: TrackingEventBus,
+        private val bookingApi: BookingApiService,
     ) : TrackingRepository {
         public override fun trackBooking(bookingId: String): Flow<TrackingState> =
-            eventBus.events
-                .filter { it.bookingId == bookingId }
-                .scan(TrackingState(location = null, status = BookingStatus.EnRoute)) { state, event ->
-                    when (event) {
-                        is TrackingEvent.LocationUpdate ->
-                            state.copy(
-                                location =
-                                    LiveLocation(
-                                        lat = event.lat,
-                                        lng = event.lng,
-                                        etaMinutes = event.etaMinutes,
-                                        techName = event.techName,
-                                        techPhotoUrl = event.techPhotoUrl,
-                                    ),
-                            )
-                        is TrackingEvent.StatusUpdate ->
-                            state.copy(status = BookingStatus.fromFcmString(event.status))
-                    }
-                }
+            flow {
+                val initialStatus =
+                    runCatching {
+                        BookingStatus.fromFcmString(bookingApi.getBooking(bookingId).status)
+                    }.getOrDefault(BookingStatus.Unknown)
+                val initialState = TrackingState(location = null, status = initialStatus)
+
+                emitAll(
+                    eventBus.events
+                        .filter { it.bookingId == bookingId }
+                        .scan(initialState) { state, event ->
+                            when (event) {
+                                is TrackingEvent.LocationUpdate ->
+                                    state.copy(
+                                        location =
+                                            LiveLocation(
+                                                lat = event.lat,
+                                                lng = event.lng,
+                                                etaMinutes = event.etaMinutes,
+                                                techName = event.techName,
+                                                techPhotoUrl = event.techPhotoUrl,
+                                            ),
+                                    )
+                                is TrackingEvent.StatusUpdate ->
+                                    state.copy(status = BookingStatus.fromFcmString(event.status))
+                            }
+                        },
+                )
+            }
     }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/GetCustomerBookingsUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/GetCustomerBookingsUseCase.kt
@@ -1,0 +1,14 @@
+package com.homeservices.customer.domain.booking
+
+import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.domain.booking.model.CustomerBooking
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+public class GetCustomerBookingsUseCase
+    @Inject
+    public constructor(
+        private val repository: BookingRepository,
+    ) {
+        public operator fun invoke(): Flow<Result<List<CustomerBooking>>> = repository.getMyBookings()
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/CustomerBooking.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/CustomerBooking.kt
@@ -1,0 +1,31 @@
+package com.homeservices.customer.domain.booking.model
+
+public data class CustomerBooking(
+    val bookingId: String,
+    val serviceId: String,
+    val serviceName: String,
+    val addressText: String,
+    val status: CustomerBookingStatus,
+    val slotDate: String,
+    val slotWindow: String,
+    val amountPaise: Long,
+    val paymentMethod: BookingPaymentMethod,
+    val createdAt: String,
+)
+
+public enum class CustomerBookingStatus {
+    PENDING_PAYMENT,
+    PAID,
+    SEARCHING,
+    ASSIGNED,
+    EN_ROUTE,
+    REACHED,
+    IN_PROGRESS,
+    AWAITING_PRICE_APPROVAL,
+    COMPLETED,
+    CLOSED,
+    UNFULFILLED,
+    CUSTOMER_CANCELLED,
+    NO_SHOW_REDISPATCH,
+    UNKNOWN,
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/tracking/model/BookingStatus.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/tracking/model/BookingStatus.kt
@@ -1,6 +1,14 @@
 package com.homeservices.customer.domain.tracking.model
 
 public sealed class BookingStatus {
+    public object PendingPayment : BookingStatus()
+
+    public object Paid : BookingStatus()
+
+    public object Searching : BookingStatus()
+
+    public object Assigned : BookingStatus()
+
     public object EnRoute : BookingStatus()
 
     public object Reached : BookingStatus()
@@ -9,20 +17,31 @@ public sealed class BookingStatus {
 
     public object Completed : BookingStatus()
 
+    public object AwaitingPriceApproval : BookingStatus()
+
     public object Cancelled : BookingStatus()
 
     public object Closed : BookingStatus()
+
+    public object Unfulfilled : BookingStatus()
 
     public object Unknown : BookingStatus()
 
     public companion object {
         public fun fromFcmString(value: String): BookingStatus =
             when (value) {
+                "PENDING_PAYMENT" -> PendingPayment
+                "PAID" -> Paid
+                "SEARCHING" -> Searching
+                "ASSIGNED" -> Assigned
                 "EN_ROUTE" -> EnRoute
                 "REACHED" -> Reached
                 "IN_PROGRESS" -> InProgress
+                "AWAITING_PRICE_APPROVAL" -> AwaitingPriceApproval
                 "COMPLETED" -> Completed
-                "CANCELLED" -> Cancelled
+                "CUSTOMER_CANCELLED", "CANCELLED" -> Cancelled
+                "UNFULFILLED" -> Unfulfilled
+                "NO_SHOW_REDISPATCH" -> Searching
                 "CLOSED" -> Closed
                 else -> Unknown
             }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
@@ -37,6 +37,7 @@ internal fun NavGraphBuilder.mainGraph(navController: NavController) {
                 onCategoryClick = { id -> navController.navigate(CatalogueRoutes.serviceList(id)) },
                 onSettingsClick = { navController.navigate(LocaleRoutes.SETTINGS) },
                 onProfileLanguageClick = { navController.navigate(LocaleRoutes.LANGUAGE_SETTINGS) },
+                onTrackBooking = { id -> navController.navigate(BookingRoutes.liveTrackingRoute(id)) },
             )
         }
         composable(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsScreen.kt
@@ -1,0 +1,338 @@
+package com.homeservices.customer.ui.bookings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BookOnline
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Payments
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.homeservices.customer.domain.booking.model.BookingPaymentMethod
+import com.homeservices.customer.domain.booking.model.CustomerBooking
+import com.homeservices.customer.domain.booking.model.CustomerBookingStatus
+import com.homeservices.designsystem.components.HsPrimaryButton
+import com.homeservices.designsystem.components.HsSecondaryButton
+
+private val Ink = Color(0xFF18231F)
+private val Muted = Color(0xFF5F6C66)
+private val DeepGreen = Color(0xFF0B3D2E)
+private val SoftGreen = Color(0xFFE8F1EC)
+private val Warning = Color(0xFFB68A2C)
+private val WarningSoft = Color(0xFFF2E7CF)
+
+@Composable
+internal fun CustomerBookingsScreen(
+    onTrackBooking: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CustomerBookingsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    CustomerBookingsContent(
+        uiState = uiState,
+        onTrackBooking = onTrackBooking,
+        onRefresh = viewModel::refresh,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun CustomerBookingsContent(
+    uiState: CustomerBookingsUiState,
+    onTrackBooking: (String) -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 18.dp, top = 18.dp, end = 18.dp, bottom = 118.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Bookings",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = Ink,
+                    )
+                    Text(
+                        text = "Upcoming and completed service visits",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Muted,
+                    )
+                }
+                IconButton(onClick = onRefresh) {
+                    Icon(Icons.Default.Refresh, contentDescription = "Refresh bookings")
+                }
+            }
+        }
+
+        when (uiState) {
+            CustomerBookingsUiState.Loading -> item { LoadingCard() }
+            CustomerBookingsUiState.Error -> item { ErrorCard(onRefresh = onRefresh) }
+            is CustomerBookingsUiState.Ready ->
+                if (uiState.bookings.isEmpty()) {
+                    item { EmptyBookingsCard() }
+                } else {
+                    items(uiState.bookings, key = { it.bookingId }) { booking ->
+                        BookingCard(booking = booking, onTrackBooking = onTrackBooking)
+                    }
+                }
+        }
+    }
+}
+
+@Composable
+private fun BookingCard(
+    booking: CustomerBooking,
+    onTrackBooking: (String) -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = Color.White,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                StatusPill(label = booking.status.label(), active = booking.status.isTrackable())
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = formatRupees(booking.amountPaise),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Ink,
+                )
+            }
+            Text(
+                text = booking.serviceName,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = Ink,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            InfoLine(icon = Icons.Default.CalendarToday, text = booking.slotDate)
+            InfoLine(icon = Icons.Default.Schedule, text = booking.slotWindow)
+            InfoLine(icon = Icons.Default.LocationOn, text = booking.addressText)
+            InfoLine(icon = Icons.Default.Payments, text = booking.paymentMethod.label())
+            if (booking.status.canOpenTracking()) {
+                HsPrimaryButton(
+                    text = if (booking.status.isLiveTracking()) "Track technician" else "View status",
+                    onClick = { onTrackBooking(booking.bookingId) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoLine(
+    icon: ImageVector,
+    text: String,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(icon, contentDescription = null, tint = Muted, modifier = Modifier.size(18.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Muted,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun StatusPill(
+    label: String,
+    active: Boolean,
+) {
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = if (active) SoftGreen else WarningSoft,
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = if (active) DeepGreen else Warning,
+        )
+    }
+}
+
+@Composable
+private fun LoadingCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = Color.White,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            repeat(3) {
+                Surface(
+                    modifier = Modifier.fillMaxWidth().height(18.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                ) {}
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorCard(onRefresh: () -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = Color.White,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = "Could not refresh bookings",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Ink,
+            )
+            Text(
+                text = "Your latest booking is still saved. Retry when the network is stable.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Muted,
+            )
+            HsSecondaryButton(text = "Retry", onClick = onRefresh, modifier = Modifier.fillMaxWidth())
+        }
+    }
+}
+
+@Composable
+private fun EmptyBookingsCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = Color.White,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Icon(Icons.Default.BookOnline, contentDescription = null, tint = DeepGreen)
+            Text(
+                text = "No bookings yet",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Ink,
+            )
+            Text(
+                text = "Confirmed bookings will appear here with service date, status, and tracking access.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Muted,
+            )
+        }
+    }
+}
+
+private fun CustomerBookingStatus.label(): String =
+    when (this) {
+        CustomerBookingStatus.PENDING_PAYMENT -> "Payment pending"
+        CustomerBookingStatus.PAID -> "Confirmed"
+        CustomerBookingStatus.SEARCHING -> "Finding technician"
+        CustomerBookingStatus.ASSIGNED -> "Technician assigned"
+        CustomerBookingStatus.EN_ROUTE -> "En route"
+        CustomerBookingStatus.REACHED -> "Arrived"
+        CustomerBookingStatus.IN_PROGRESS -> "In progress"
+        CustomerBookingStatus.AWAITING_PRICE_APPROVAL -> "Price approval"
+        CustomerBookingStatus.COMPLETED -> "Completed"
+        CustomerBookingStatus.CLOSED -> "Closed"
+        CustomerBookingStatus.UNFULFILLED -> "Unfulfilled"
+        CustomerBookingStatus.CUSTOMER_CANCELLED -> "Cancelled"
+        CustomerBookingStatus.NO_SHOW_REDISPATCH -> "Reassigning"
+        CustomerBookingStatus.UNKNOWN -> "Updated"
+    }
+
+private fun CustomerBookingStatus.canOpenTracking(): Boolean =
+    this in
+        setOf(
+            CustomerBookingStatus.PAID,
+            CustomerBookingStatus.SEARCHING,
+            CustomerBookingStatus.ASSIGNED,
+            CustomerBookingStatus.EN_ROUTE,
+            CustomerBookingStatus.REACHED,
+            CustomerBookingStatus.IN_PROGRESS,
+            CustomerBookingStatus.AWAITING_PRICE_APPROVAL,
+            CustomerBookingStatus.NO_SHOW_REDISPATCH,
+        )
+
+private fun CustomerBookingStatus.isTrackable(): Boolean =
+    this in
+        setOf(
+            CustomerBookingStatus.ASSIGNED,
+            CustomerBookingStatus.EN_ROUTE,
+            CustomerBookingStatus.REACHED,
+            CustomerBookingStatus.IN_PROGRESS,
+            CustomerBookingStatus.AWAITING_PRICE_APPROVAL,
+        )
+
+private fun CustomerBookingStatus.isLiveTracking(): Boolean =
+    this in
+        setOf(
+            CustomerBookingStatus.EN_ROUTE,
+            CustomerBookingStatus.REACHED,
+            CustomerBookingStatus.IN_PROGRESS,
+        )
+
+private fun BookingPaymentMethod.label(): String =
+    when (this) {
+        BookingPaymentMethod.RAZORPAY -> "Paid online"
+        BookingPaymentMethod.CASH_ON_SERVICE -> "Cash on service"
+    }
+
+private fun formatRupees(paise: Long): String = "Rs %,.0f".format(paise / 100.0)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsUiState.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsUiState.kt
@@ -1,0 +1,13 @@
+package com.homeservices.customer.ui.bookings
+
+import com.homeservices.customer.domain.booking.model.CustomerBooking
+
+internal sealed class CustomerBookingsUiState {
+    data object Loading : CustomerBookingsUiState()
+
+    data class Ready(
+        val bookings: List<CustomerBooking>,
+    ) : CustomerBookingsUiState()
+
+    data object Error : CustomerBookingsUiState()
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsViewModel.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsViewModel.kt
@@ -1,0 +1,39 @@
+package com.homeservices.customer.ui.bookings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homeservices.customer.domain.booking.GetCustomerBookingsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+internal class CustomerBookingsViewModel
+    @Inject
+    constructor(
+        private val getBookings: GetCustomerBookingsUseCase,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<CustomerBookingsUiState>(CustomerBookingsUiState.Loading)
+        val uiState: StateFlow<CustomerBookingsUiState> = _uiState.asStateFlow()
+
+        init {
+            refresh()
+        }
+
+        fun refresh() {
+            viewModelScope.launch {
+                _uiState.value = CustomerBookingsUiState.Loading
+                _uiState.value =
+                    getBookings()
+                        .first()
+                        .fold(
+                            onSuccess = { CustomerBookingsUiState.Ready(it) },
+                            onFailure = { CustomerBookingsUiState.Error },
+                        )
+            }
+        }
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/CatalogueHomeScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/CatalogueHomeScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.homeservices.customer.R
 import com.homeservices.customer.domain.catalogue.model.Category
+import com.homeservices.customer.ui.bookings.CustomerBookingsScreen
 import kotlinx.coroutines.delay
 
 // ── Colour tokens (Codex-refined) ────────────────────────────────────────────
@@ -174,6 +175,7 @@ internal fun CatalogueHomeScreen(
     onCategoryClick: (String) -> Unit,
     onSettingsClick: () -> Unit,
     onProfileLanguageClick: () -> Unit,
+    onTrackBooking: (String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     CatalogueHomeContent(
@@ -181,6 +183,7 @@ internal fun CatalogueHomeScreen(
         onCategoryClick = onCategoryClick,
         onSettingsClick = onSettingsClick,
         onProfileLanguageClick = onProfileLanguageClick,
+        onTrackBooking = onTrackBooking,
     )
 }
 
@@ -190,6 +193,7 @@ internal fun CatalogueHomeContent(
     onCategoryClick: (String) -> Unit,
     onSettingsClick: () -> Unit,
     onProfileLanguageClick: () -> Unit,
+    onTrackBooking: (String) -> Unit,
 ) {
     var selectedNav by remember { mutableIntStateOf(0) }
 
@@ -240,10 +244,8 @@ internal fun CatalogueHomeContent(
                     }
                 }
             1 ->
-                ComingSoonTab(
-                    icon = Icons.Default.Book,
-                    title = "आपकी बुकिंग",
-                    subtitle = "बुकिंग करने के बाद यहाँ दिखेगी",
+                CustomerBookingsScreen(
+                    onTrackBooking = onTrackBooking,
                     modifier = Modifier.fillMaxSize().padding(scaffoldPadding),
                 )
             2 ->

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/tracking/LiveTrackingScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/tracking/LiveTrackingScreen.kt
@@ -232,10 +232,10 @@ private fun StatusTimeline(currentStatus: BookingStatus) {
             BookingStatus.InProgress to "Working",
             BookingStatus.Completed to "Done",
         )
-    val activeIndex = stages.indexOfFirst { (status, _) -> status == currentStatus }.coerceAtLeast(0)
+    val activeIndex = stages.indexOfFirst { (status, _) -> status == currentStatus }
 
     stages.forEachIndexed { index, (_, label) ->
-        val isActive = index <= activeIndex
+        val isActive = activeIndex >= 0 && index <= activeIndex
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 3.dp)) {
             Surface(
                 modifier = Modifier.size(if (isActive) 14.dp else 10.dp),
@@ -259,11 +259,17 @@ private fun StatusTimeline(currentStatus: BookingStatus) {
 
 private fun statusLabel(status: BookingStatus): String =
     when (status) {
+        BookingStatus.PendingPayment -> "Payment pending"
+        BookingStatus.Paid -> "Booking confirmed"
+        BookingStatus.Searching -> "Finding technician"
+        BookingStatus.Assigned -> "Technician assigned"
         BookingStatus.EnRoute -> "Technician on the way"
         BookingStatus.Reached -> "Technician arrived"
         BookingStatus.InProgress -> "Work in progress"
+        BookingStatus.AwaitingPriceApproval -> "Price approval needed"
         BookingStatus.Completed -> "Service completed"
         BookingStatus.Closed -> "Booking closed"
         BookingStatus.Cancelled -> "Booking cancelled"
+        BookingStatus.Unfulfilled -> "Technician unavailable"
         BookingStatus.Unknown -> "Status unavailable"
     }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImplTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImplTest.kt
@@ -1,5 +1,14 @@
 package com.homeservices.customer.data.tracking
 
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.homeservices.customer.data.booking.remote.dto.ApproveFinalPriceRequestDto
+import com.homeservices.customer.data.booking.remote.dto.ApproveFinalPriceResponseDto
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.ConfirmBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
+import com.homeservices.customer.data.booking.remote.dto.CreateBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.CustomerBookingsResponseDto
+import com.homeservices.customer.data.booking.remote.dto.GetBookingResponseDto
 import com.homeservices.customer.domain.tracking.model.BookingStatus
 import com.homeservices.customer.domain.tracking.model.TrackingState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,6 +21,33 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class TrackingRepositoryImplTest {
+    private class FakeBookingApiService(
+        var status: String = "ASSIGNED",
+    ) : BookingApiService {
+        override suspend fun createBooking(body: CreateBookingRequestDto): CreateBookingResponseDto = error("not used")
+
+        override suspend fun confirmBooking(
+            bookingId: String,
+            body: ConfirmBookingRequestDto,
+        ): ConfirmBookingResponseDto = error("not used")
+
+        override suspend fun getBooking(bookingId: String): GetBookingResponseDto =
+            GetBookingResponseDto(
+                bookingId = bookingId,
+                status = status,
+                amount = 59900,
+                finalAmount = null,
+                pendingAddOns = emptyList(),
+            )
+
+        override suspend fun getMyBookings(): CustomerBookingsResponseDto = error("not used")
+
+        override suspend fun approveFinalPrice(
+            bookingId: String,
+            body: ApproveFinalPriceRequestDto,
+        ): ApproveFinalPriceResponseDto = error("not used")
+    }
+
     @Test
     public fun `BookingStatus fromFcmString maps EN_ROUTE`() {
         assertThat(BookingStatus.fromFcmString("EN_ROUTE")).isEqualTo(BookingStatus.EnRoute)
@@ -38,6 +74,16 @@ public class TrackingRepositoryImplTest {
     }
 
     @Test
+    public fun `BookingStatus fromFcmString maps ASSIGNED without marking en route`() {
+        assertThat(BookingStatus.fromFcmString("ASSIGNED")).isEqualTo(BookingStatus.Assigned)
+    }
+
+    @Test
+    public fun `BookingStatus fromFcmString maps PAID as confirmed`() {
+        assertThat(BookingStatus.fromFcmString("PAID")).isEqualTo(BookingStatus.Paid)
+    }
+
+    @Test
     public fun `BookingStatus fromFcmString returns Unknown for unrecognised string`() {
         assertThat(BookingStatus.fromFcmString("GARBAGE")).isEqualTo(BookingStatus.Unknown)
     }
@@ -45,7 +91,8 @@ public class TrackingRepositoryImplTest {
     // ── scan logic ─────────────────────────────────────────────────────────────
 
     private val bus: TrackingEventBus = TrackingEventBus()
-    private val repo: TrackingRepositoryImpl = TrackingRepositoryImpl(bus)
+    private val api = FakeBookingApiService()
+    private val repo: TrackingRepositoryImpl = TrackingRepositoryImpl(bus, api)
 
     @Test
     public fun `location update populates LiveLocation in state`(): Unit =
@@ -68,11 +115,11 @@ public class TrackingRepositoryImplTest {
             assertThat(results).hasSize(2)
             // seed
             assertThat(results[0].location).isNull()
-            assertThat(results[0].status).isEqualTo(BookingStatus.EnRoute)
+            assertThat(results[0].status).isEqualTo(BookingStatus.Assigned)
             // after location update
             assertThat(results[1].location?.lat).isEqualTo(12.97)
             assertThat(results[1].location?.techName).isEqualTo("Suresh")
-            assertThat(results[1].status).isEqualTo(BookingStatus.EnRoute)
+            assertThat(results[1].status).isEqualTo(BookingStatus.Assigned)
         }
 
     @Test
@@ -87,7 +134,7 @@ public class TrackingRepositoryImplTest {
             assertThat(results).hasSize(2)
             // seed
             assertThat(results[0].location).isNull()
-            assertThat(results[0].status).isEqualTo(BookingStatus.EnRoute)
+            assertThat(results[0].status).isEqualTo(BookingStatus.Assigned)
             // after status update
             assertThat(results[1].status).isEqualTo(BookingStatus.Reached)
             assertThat(results[1].location).isNull()
@@ -105,7 +152,7 @@ public class TrackingRepositoryImplTest {
             job.cancel()
             assertThat(results).hasSize(2)
             // seed
-            assertThat(results[0].status).isEqualTo(BookingStatus.EnRoute)
+            assertThat(results[0].status).isEqualTo(BookingStatus.Assigned)
             // after IN_PROGRESS for "b3"
             assertThat(results[1].status).isEqualTo(BookingStatus.InProgress)
         }
@@ -123,12 +170,24 @@ public class TrackingRepositoryImplTest {
             assertThat(results).hasSize(3)
             // seed
             assertThat(results[0].location).isNull()
-            assertThat(results[0].status).isEqualTo(BookingStatus.EnRoute)
+            assertThat(results[0].status).isEqualTo(BookingStatus.Assigned)
             // after LocationUpdate
             assertThat(results[1].location?.techName).isEqualTo("Suresh")
-            assertThat(results[1].status).isEqualTo(BookingStatus.EnRoute)
+            assertThat(results[1].status).isEqualTo(BookingStatus.Assigned)
             // after StatusUpdate
             assertThat(results[2].location?.techName).isEqualTo("Suresh")
             assertThat(results[2].status).isEqualTo(BookingStatus.Reached)
+        }
+
+    @Test
+    public fun `trackBooking emits Unknown seed when booking lookup fails`(): Unit =
+        runTest {
+            api.status = "NOT_A_REAL_STATUS"
+            val results = mutableListOf<TrackingState>()
+            val job = launch { repo.trackBooking("b5").collect { results.add(it) } }
+            yield()
+            job.cancel()
+            assertThat(results).hasSize(1)
+            assertThat(results[0].status).isEqualTo(BookingStatus.Unknown)
         }
 }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsViewModelTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/bookings/CustomerBookingsViewModelTest.kt
@@ -1,0 +1,73 @@
+package com.homeservices.customer.ui.bookings
+
+import com.homeservices.customer.domain.booking.GetCustomerBookingsUseCase
+import com.homeservices.customer.domain.booking.model.BookingPaymentMethod
+import com.homeservices.customer.domain.booking.model.CustomerBooking
+import com.homeservices.customer.domain.booking.model.CustomerBookingStatus
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class CustomerBookingsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val getBookings: GetCustomerBookingsUseCase = mockk()
+
+    @Before
+    public fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    public fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    public fun `loads customer bookings on init`(): Unit =
+        runTest {
+            val booking = sampleBooking()
+            every { getBookings() } returns flowOf(Result.success(listOf(booking)))
+
+            val vm = CustomerBookingsViewModel(getBookings)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value).isEqualTo(CustomerBookingsUiState.Ready(listOf(booking)))
+        }
+
+    @Test
+    public fun `shows error when loading bookings fails`(): Unit =
+        runTest {
+            every { getBookings() } returns flowOf(Result.failure(IllegalStateException("network")))
+
+            val vm = CustomerBookingsViewModel(getBookings)
+            advanceUntilIdle()
+
+            assertThat(vm.uiState.value).isEqualTo(CustomerBookingsUiState.Error)
+        }
+
+    private fun sampleBooking(): CustomerBooking =
+        CustomerBooking(
+            bookingId = "bk-1",
+            serviceId = "svc-1",
+            serviceName = "AC repair",
+            addressText = "101 Ayodhya",
+            status = CustomerBookingStatus.ASSIGNED,
+            slotDate = "2026-05-05",
+            slotWindow = "10:00-12:00",
+            amountPaise = 59900,
+            paymentMethod = BookingPaymentMethod.CASH_ON_SERVICE,
+            createdAt = "2026-05-03T10:00:00.000Z",
+        )
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/CatalogueHomeScreenTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/CatalogueHomeScreenTest.kt
@@ -23,6 +23,7 @@ public class CatalogueHomeScreenTest {
                     onCategoryClick = {},
                     onSettingsClick = {},
                     onProfileLanguageClick = {},
+                    onTrackBooking = {},
                 )
             }
         }
@@ -45,6 +46,7 @@ public class CatalogueHomeScreenTest {
                     onCategoryClick = {},
                     onSettingsClick = {},
                     onProfileLanguageClick = {},
+                    onTrackBooking = {},
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Add customer booking list API and wire the customer Bookings tab to it.
- Seed live tracking status from the booking record instead of defaulting every booking to EN_ROUTE.
- Add focused API and customer unit coverage for bookings and status mapping.

## Verification
- pnpm build
- pnpm lint
- pnpm test
- pnpm run openapi:build
- pnpm run openapi:lint
- pnpm -C admin-web typecheck
- pnpm -C admin-web test
- pnpm -C admin-web build
- customer-app: .\\gradlew.bat :app:ktlintCheck :app:testDebugUnitTest :app:assembleDebug --no-configuration-cache