### PR TITLE
feat(E12-S01): KYC IDOR fix + equalsHexHmac helper + ETag on payment writes

### DIFF
--- a/api/src/cosmos/booking-repository.ts
+++ b/api/src/cosmos/booking-repository.ts
@@ -47,11 +47,25 @@ export const bookingRepo = {
     paymentId: string,
     paymentSignature: string,
   ): Promise<BookingDoc | null> {
-    const existing = await this.getById(id);
+    const { resource: existing, etag } = await getBookingsContainer().item(id, id).read<BookingDoc>();
     if (!existing) return null;
     if (existing.status === 'PAID') return existing; // webhook already processed — idempotent success
     if (existing.status !== 'PENDING_PAYMENT') return null;
     const updated: BookingDoc = { ...existing, status: 'SEARCHING', paymentId, paymentSignature };
+    const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+    if (useEtag) {
+      try {
+        const { resource } = await getBookingsContainer()
+          .item(id, id)
+          .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+        return resource ?? null;
+      } catch (e: unknown) {
+        if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: number }).code === 412) {
+          return null; // lost ETag race — idempotent by design
+        }
+        throw e;
+      }
+    }
     const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
     return resource!;
   },
@@ -67,9 +81,23 @@ export const bookingRepo = {
   },
 
   async markPaid(id: string, paymentId: string): Promise<BookingDoc | null> {
-    const existing = await this.getById(id);
+    const { resource: existing, etag } = await getBookingsContainer().item(id, id).read<BookingDoc>();
     if (!existing || (existing.status !== 'SEARCHING' && existing.status !== 'PENDING_PAYMENT')) return null;
     const updated: BookingDoc = { ...existing, status: 'PAID', paymentId };
+    const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+    if (useEtag) {
+      try {
+        const { resource } = await getBookingsContainer()
+          .item(id, id)
+          .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+        return resource ?? null;
+      } catch (e: unknown) {
+        if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: number }).code === 412) {
+          return null; // lost ETag race — idempotent by design
+        }
+        throw e;
+      }
+    }
     const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
     return resource!;
   },

--- a/api/src/functions/kyc/submit-aadhaar.ts
+++ b/api/src/functions/kyc/submit-aadhaar.ts
@@ -9,8 +9,9 @@ export async function submitAadhaar(
   req: HttpRequest,
   _ctx: InvocationContext
 ): Promise<HttpResponseInit> {
+  let decoded: { uid: string };
   try {
-    await verifyTechnicianToken(req);
+    decoded = await verifyTechnicianToken(req);
   } catch {
     return { status: 401, jsonBody: { error: 'Unauthorized' } };
   }
@@ -28,6 +29,12 @@ export async function submitAadhaar(
   }
 
   const { technicianId, authCode, redirectUri } = parsed.data;
+
+  // P0: caller may only update their own KYC record (IDOR guard)
+  if (decoded.uid !== technicianId) {
+    return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+  }
+
   const aadhaarResult = await exchangeCodeForAadhaar(authCode, redirectUri);
 
   if (!aadhaarResult) {

--- a/api/src/functions/webhooks.ts
+++ b/api/src/functions/webhooks.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import type { HttpHandler, Timer } from '@azure/functions';
 import { type InvocationContext, app } from '@azure/functions';
 import * as Sentry from '@sentry/node';
@@ -7,16 +7,7 @@ import { bookingRepo } from '../cosmos/booking-repository.js';
 import { dispatcherService } from '../services/dispatcher.service.js';
 import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 import { getWebhookEventsContainer } from '../cosmos/client.js';
-
-// Compare buffer lengths (not string lengths) so non-hex chars in `provided`
-// that produce shorter buffers are caught without timingSafeEqual throwing.
-function isValidSignature(payload: string, provided: string, secret: string): boolean {
-  const expected = createHmac('sha256', secret).update(payload).digest('hex');
-  const expectedBuf = Buffer.from(expected, 'hex');
-  const providedBuf = Buffer.from(provided, 'hex');
-  if (expectedBuf.length !== providedBuf.length) return false;
-  return timingSafeEqual(expectedBuf, providedBuf);
-}
+import { equalsHexHmac } from '../shared/timing-safe.js';
 
 export const razorpayWebhookHandler: HttpHandler = async (req, _ctx) => {
   const secret = process.env['RAZORPAY_WEBHOOK_SECRET'];
@@ -25,7 +16,7 @@ export const razorpayWebhookHandler: HttpHandler = async (req, _ctx) => {
   const signature = req.headers.get('x-razorpay-signature') ?? '';
   const rawBody = await req.text();
 
-  if (!isValidSignature(rawBody, signature, secret)) {
+  if (!equalsHexHmac(secret, rawBody, signature)) {
     return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
   }
 

--- a/api/src/services/razorpay.service.ts
+++ b/api/src/services/razorpay.service.ts
@@ -1,5 +1,5 @@
 import Razorpay from 'razorpay';
-import { createHmac } from 'node:crypto';
+import { equalsHexHmac } from '../shared/timing-safe.js';
 
 let _rzp: Razorpay | null = null;
 
@@ -25,10 +25,11 @@ export function verifyPaymentSignature(opts: {
 }): boolean {
   const secret = process.env.RAZORPAY_KEY_SECRET;
   if (!secret) throw new Error('Missing RAZORPAY_KEY_SECRET');
-  const expected = createHmac('sha256', secret)
-    .update(`${opts.razorpayOrderId}|${opts.razorpayPaymentId}`)
-    .digest('hex');
-  return expected === opts.razorpaySignature;
+  return equalsHexHmac(
+    secret,
+    `${opts.razorpayOrderId}|${opts.razorpayPaymentId}`,
+    opts.razorpaySignature,
+  );
 }
 
 export async function createTransfer(opts: {

--- a/api/src/shared/timing-safe.ts
+++ b/api/src/shared/timing-safe.ts
@@ -1,0 +1,24 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Timing-safe HMAC-SHA256 comparison.
+ *
+ * Computes HMAC-SHA256(secret, payload) and compares it against providedHex
+ * using a constant-time comparison to prevent timing-oracle attacks.
+ *
+ * Returns false if:
+ *  - the provided string does not decode to the same byte-length as the digest
+ *    (guards against non-hex input that Buffer.from parses to fewer bytes)
+ *  - the digest does not match
+ */
+export function equalsHexHmac(
+  secret: string,
+  payload: string,
+  providedHex: string,
+): boolean {
+  const expected = createHmac('sha256', secret).update(payload).digest('hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const providedBuf = Buffer.from(providedHex, 'hex');
+  if (expectedBuf.length !== providedBuf.length) return false;
+  return timingSafeEqual(expectedBuf, providedBuf);
+}

--- a/api/tests/cosmos/booking-repository-etag.test.ts
+++ b/api/tests/cosmos/booking-repository-etag.test.ts
@@ -1,0 +1,205 @@
+/**
+ * ETag guard tests for bookingRepo.confirmPayment and bookingRepo.markPaid
+ *
+ * Tests the BOOKINGS_ETAG_GUARDS=on path introduced in E12-S01:
+ *  - 412 Precondition Failed from Cosmos → returns null (idempotent by design)
+ *  - already-PAID idempotent guard still fires BEFORE replace attempt
+ *  - flag-off path falls through to the original unconditional replace
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { BookingDoc } from '../../src/schemas/booking.js';
+
+const mockReplace = vi.fn();
+const mockRead = vi.fn();
+const mockItem = vi.fn(() => ({ read: mockRead, replace: mockReplace }));
+
+vi.mock('../../src/cosmos/client.js', () => ({
+  getBookingsContainer: () => ({
+    items: { query: vi.fn(() => ({ fetchAll: vi.fn() })), create: vi.fn() },
+    item: mockItem,
+  }),
+  getCosmosClient: vi.fn(),
+  DB_NAME: 'homeservices',
+}));
+
+import { bookingRepo } from '../../src/cosmos/booking-repository.js';
+
+const BASE: BookingDoc = {
+  id: 'bk-etag-test',
+  customerId: 'cust-1',
+  serviceId: 'svc-1',
+  categoryId: 'cat-1',
+  slotDate: '2026-05-01',
+  slotWindow: '10:00-12:00',
+  addressText: '1 Main St',
+  addressLatLng: { lat: 26.79, lng: 82.19 },
+  status: 'PENDING_PAYMENT',
+  paymentOrderId: 'order_etag',
+  paymentId: null,
+  paymentSignature: null,
+  amount: 59900,
+  createdAt: '2026-05-01T10:00:00.000Z',
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// confirmPayment — ETag ON
+// ────────────────────────────────────────────────────────────────────────────
+describe('bookingRepo.confirmPayment — BOOKINGS_ETAG_GUARDS=on', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('BOOKINGS_ETAG_GUARDS', 'on');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('succeeds: replaces with IfMatch accessCondition and returns updated doc', async () => {
+    const pendingDoc: BookingDoc = { ...BASE, status: 'PENDING_PAYMENT' };
+    const updatedDoc: BookingDoc = { ...pendingDoc, status: 'SEARCHING', paymentId: 'pay_etag', paymentSignature: 'sig_etag' };
+
+    mockRead.mockResolvedValue({ resource: pendingDoc, etag: '"etag-abc"' });
+    mockReplace.mockResolvedValue({ resource: updatedDoc });
+
+    const result = await bookingRepo.confirmPayment('bk-etag-test', 'pay_etag', 'sig_etag');
+
+    expect(result).toEqual(updatedDoc);
+    expect(mockReplace).toHaveBeenCalledOnce();
+    const replaceOpts = (mockReplace.mock.calls as unknown[][])[0]![1] as Record<string, unknown>;
+    expect(replaceOpts).toMatchObject({
+      accessCondition: { type: 'IfMatch', condition: '"etag-abc"' },
+    });
+  });
+
+  it('returns null on 412 Precondition Failed — idempotent ETag race', async () => {
+    const pendingDoc: BookingDoc = { ...BASE, status: 'PENDING_PAYMENT' };
+    mockRead.mockResolvedValue({ resource: pendingDoc, etag: '"etag-stale"' });
+    const cosmosError = Object.assign(new Error('Precondition Failed'), { code: 412 });
+    mockReplace.mockRejectedValue(cosmosError);
+
+    const result = await bookingRepo.confirmPayment('bk-etag-test', 'pay_etag', 'sig_etag');
+
+    expect(result).toBeNull();
+  });
+
+  it('propagates non-412 errors from Cosmos', async () => {
+    const pendingDoc: BookingDoc = { ...BASE, status: 'PENDING_PAYMENT' };
+    mockRead.mockResolvedValue({ resource: pendingDoc, etag: '"etag-abc"' });
+    mockReplace.mockRejectedValue(new Error('500 Service Unavailable'));
+
+    await expect(bookingRepo.confirmPayment('bk-etag-test', 'pay_etag', 'sig_etag')).rejects.toThrow('500 Service Unavailable');
+  });
+
+  it('idempotent-success guard: returns existing PAID doc without replace even with ETag on', async () => {
+    const paidDoc: BookingDoc = { ...BASE, status: 'PAID', paymentId: 'pay_webhook', paymentSignature: 'sig_wh' };
+    mockRead.mockResolvedValue({ resource: paidDoc, etag: '"etag-paid"' });
+
+    const result = await bookingRepo.confirmPayment('bk-etag-test', 'pay_client', 'sig_client');
+
+    expect(result).toEqual(paidDoc);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// confirmPayment — ETag OFF (flag=off, legacy path)
+// ────────────────────────────────────────────────────────────────────────────
+describe('bookingRepo.confirmPayment — BOOKINGS_ETAG_GUARDS=off', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('BOOKINGS_ETAG_GUARDS', 'off');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('still transitions PENDING_PAYMENT → SEARCHING via unconditional replace', async () => {
+    const pendingDoc: BookingDoc = { ...BASE, status: 'PENDING_PAYMENT' };
+    const updatedDoc: BookingDoc = { ...pendingDoc, status: 'SEARCHING', paymentId: 'pay_legacy', paymentSignature: 'sig_legacy' };
+    mockRead.mockResolvedValue({ resource: pendingDoc, etag: '"etag-xyz"' });
+    mockReplace.mockResolvedValue({ resource: updatedDoc });
+
+    const result = await bookingRepo.confirmPayment('bk-etag-test', 'pay_legacy', 'sig_legacy');
+
+    expect(result).toEqual(updatedDoc);
+    expect(mockReplace).toHaveBeenCalledOnce();
+    // Legacy path should NOT include accessCondition
+    const replaceOpts = (mockReplace.mock.calls as unknown[][])[0]?.[1];
+    expect(replaceOpts).toBeUndefined();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// markPaid — ETag ON
+// ────────────────────────────────────────────────────────────────────────────
+describe('bookingRepo.markPaid — BOOKINGS_ETAG_GUARDS=on', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('BOOKINGS_ETAG_GUARDS', 'on');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('succeeds: replaces with IfMatch accessCondition and returns updated doc', async () => {
+    const searchingDoc: BookingDoc = { ...BASE, status: 'SEARCHING', paymentId: 'pay_existing', paymentSignature: 'sig_existing' };
+    const updatedDoc: BookingDoc = { ...searchingDoc, status: 'PAID', paymentId: 'pay_webhook' };
+    mockRead.mockResolvedValue({ resource: searchingDoc, etag: '"etag-search"' });
+    mockReplace.mockResolvedValue({ resource: updatedDoc });
+
+    const result = await bookingRepo.markPaid('bk-etag-test', 'pay_webhook');
+
+    expect(result).toEqual(updatedDoc);
+    expect(mockReplace).toHaveBeenCalledOnce();
+    const replaceOpts = (mockReplace.mock.calls as unknown[][])[0]![1] as Record<string, unknown>;
+    expect(replaceOpts).toMatchObject({
+      accessCondition: { type: 'IfMatch', condition: '"etag-search"' },
+    });
+  });
+
+  it('returns null on 412 Precondition Failed — idempotent ETag race', async () => {
+    const searchingDoc: BookingDoc = { ...BASE, status: 'SEARCHING', paymentId: null, paymentSignature: null };
+    mockRead.mockResolvedValue({ resource: searchingDoc, etag: '"etag-stale"' });
+    const cosmosError = Object.assign(new Error('Precondition Failed'), { code: 412 });
+    mockReplace.mockRejectedValue(cosmosError);
+
+    const result = await bookingRepo.markPaid('bk-etag-test', 'pay_webhook');
+
+    expect(result).toBeNull();
+  });
+
+  it('propagates non-412 errors from Cosmos', async () => {
+    const searchingDoc: BookingDoc = { ...BASE, status: 'SEARCHING', paymentId: null, paymentSignature: null };
+    mockRead.mockResolvedValue({ resource: searchingDoc, etag: '"etag-abc"' });
+    mockReplace.mockRejectedValue(new Error('429 Too Many Requests'));
+
+    await expect(bookingRepo.markPaid('bk-etag-test', 'pay_webhook')).rejects.toThrow('429 Too Many Requests');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// markPaid — ETag OFF (flag=off, legacy path)
+// ────────────────────────────────────────────────────────────────────────────
+describe('bookingRepo.markPaid — BOOKINGS_ETAG_GUARDS=off', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('BOOKINGS_ETAG_GUARDS', 'off');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('transitions SEARCHING → PAID via unconditional replace', async () => {
+    const searchingDoc: BookingDoc = { ...BASE, status: 'SEARCHING', paymentId: 'pay_prev', paymentSignature: 'sig_prev' };
+    const updatedDoc: BookingDoc = { ...searchingDoc, status: 'PAID', paymentId: 'pay_legacy' };
+    mockRead.mockResolvedValue({ resource: searchingDoc, etag: '"etag-legacy"' });
+    mockReplace.mockResolvedValue({ resource: updatedDoc });
+
+    const result = await bookingRepo.markPaid('bk-etag-test', 'pay_legacy');
+
+    expect(result).toEqual(updatedDoc);
+    expect(mockReplace).toHaveBeenCalledOnce();
+    // Legacy path should NOT include accessCondition
+    const replaceOpts = (mockReplace.mock.calls as unknown[][])[0]?.[1];
+    expect(replaceOpts).toBeUndefined();
+  });
+});

--- a/api/tests/kyc/submit-aadhaar-idor.test.ts
+++ b/api/tests/kyc/submit-aadhaar-idor.test.ts
@@ -1,0 +1,109 @@
+/**
+ * IDOR guard tests for POST /v1/kyc/aadhaar
+ *
+ * Verifies that an authenticated technician (tech-A) cannot mark a different
+ * technician's (tech-B) Aadhaar as verified — the P0 IDOR fix in E12-S01.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpRequest, InvocationContext } from '@azure/functions';
+
+vi.mock('../../src/cosmos/technician-repository.js', () => ({
+  upsertKycStatus: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../src/middleware/verifyTechnicianToken.js', () => ({
+  verifyTechnicianToken: vi.fn(),
+}));
+vi.mock('../../src/services/digilocker.service.js', () => ({
+  exchangeCodeForAadhaar: vi.fn(),
+}));
+vi.mock('../../src/services/kycAudit.service.js', () => ({
+  kycAuditEntry: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('POST /v1/kyc/aadhaar — IDOR guard', () => {
+  let handler: typeof import('../../src/functions/kyc/submit-aadhaar.js').submitAadhaar;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import('../../src/functions/kyc/submit-aadhaar.js');
+    handler = mod.submitAadhaar;
+  });
+
+  it('returns 403 when authenticated uid (tech-A) differs from body technicianId (tech-B)', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-A' });
+
+    const req = new HttpRequest({
+      method: 'POST',
+      url: 'http://localhost/v1/kyc/aadhaar',
+      headers: { Authorization: 'Bearer valid' },
+      body: {
+        string: JSON.stringify({
+          technicianId: 'tech-B',   // different from authenticated uid
+          authCode: 'some-code',
+          redirectUri: 'https://homeservices.app/digilocker',
+        }),
+      },
+    });
+
+    const res = await handler(req, new InvocationContext());
+
+    expect(res.status).toBe(403);
+    const body = res.jsonBody as Record<string, unknown>;
+    expect(body['code']).toBe('FORBIDDEN');
+  });
+
+  it('proceeds normally when authenticated uid matches body technicianId', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { exchangeCodeForAadhaar } = await import('../../src/services/digilocker.service.js');
+    const { upsertKycStatus } = await import('../../src/cosmos/technician-repository.js');
+
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-A' });
+    vi.mocked(exchangeCodeForAadhaar).mockResolvedValue({ maskedNumber: 'XXXX-XXXX-1234' });
+    vi.mocked(upsertKycStatus).mockResolvedValue(undefined);
+
+    const req = new HttpRequest({
+      method: 'POST',
+      url: 'http://localhost/v1/kyc/aadhaar',
+      headers: { Authorization: 'Bearer valid' },
+      body: {
+        string: JSON.stringify({
+          technicianId: 'tech-A',   // same as authenticated uid — allowed
+          authCode: 'some-code',
+          redirectUri: 'https://homeservices.app/digilocker',
+        }),
+      },
+    });
+
+    const res = await handler(req, new InvocationContext());
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as Record<string, unknown>;
+    expect(body['kycStatus']).toBe('AADHAAR_DONE');
+  });
+
+  it('upsertKycStatus is never called for the forbidden (tech-B) case', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { upsertKycStatus } = await import('../../src/cosmos/technician-repository.js');
+
+    vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-A' });
+
+    const req = new HttpRequest({
+      method: 'POST',
+      url: 'http://localhost/v1/kyc/aadhaar',
+      headers: { Authorization: 'Bearer valid' },
+      body: {
+        string: JSON.stringify({
+          technicianId: 'tech-B',
+          authCode: 'some-code',
+          redirectUri: 'https://homeservices.app/digilocker',
+        }),
+      },
+    });
+
+    await handler(req, new InvocationContext());
+
+    expect(vi.mocked(upsertKycStatus)).not.toHaveBeenCalled();
+  });
+});

--- a/api/tests/shared/timing-safe.test.ts
+++ b/api/tests/shared/timing-safe.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { equalsHexHmac } from '../../src/shared/timing-safe.js';
+
+const SECRET = 'test-secret-key';
+const PAYLOAD = 'order_123|pay_456';
+
+function validHex(secret: string, payload: string): string {
+  return createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+describe('equalsHexHmac', () => {
+  it('returns true for correct HMAC', () => {
+    const hex = validHex(SECRET, PAYLOAD);
+    expect(equalsHexHmac(SECRET, PAYLOAD, hex)).toBe(true);
+  });
+
+  it('returns false for wrong digest (same length)', () => {
+    // Flip the first byte of a valid hex; length stays the same
+    const valid = validHex(SECRET, PAYLOAD);
+    const flipped = (valid[0] === 'a' ? 'b' : 'a') + valid.slice(1);
+    expect(equalsHexHmac(SECRET, PAYLOAD, flipped)).toBe(false);
+  });
+
+  it('returns false when lengths differ (non-hex chars shorten the buffer)', () => {
+    // A string with non-hex chars like 'zz' is still parsed by Buffer.from
+    // but produces fewer bytes than a 64-char hex string, so lengths differ.
+    const shortProvided = 'deadbeef'; // 4 bytes vs 32 bytes expected
+    expect(equalsHexHmac(SECRET, PAYLOAD, shortProvided)).toBe(false);
+  });
+
+  it('returns false for empty string signature', () => {
+    expect(equalsHexHmac(SECRET, PAYLOAD, '')).toBe(false);
+  });
+
+  it('does not throw for completely non-hex input', () => {
+    expect(() => equalsHexHmac(SECRET, PAYLOAD, 'not-valid-hex-!!!')).not.toThrow();
+  });
+
+  it('returns false for all-zero digest of correct length', () => {
+    const zeros = '0'.repeat(64);
+    expect(equalsHexHmac(SECRET, PAYLOAD, zeros)).toBe(false);
+  });
+
+  it('is not vulnerable to early-exit: equal-length wrong digest returns false', () => {
+    const wrong = validHex('different-secret', PAYLOAD);
+    expect(equalsHexHmac(SECRET, PAYLOAD, wrong)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **P0 KYC IDOR** — `submit-aadhaar.ts` was discarding the decoded JWT uid and trusting the request body `technicianId`, allowing any authenticated technician to mark another technician's Aadhaar as verified. Fixed by capturing `decoded` from `verifyTechnicianToken` and adding a 403 guard (`decoded.uid !== technicianId`), identical to the pattern already in `submit-pan-ocr.ts:35` and `get-kyc-status.ts:22`.
- **P1 Non-constant-time HMAC** — `razorpay.service.ts` used `expected === opts.razorpaySignature` (string equality, timing-oracle vulnerable). Extracted `equalsHexHmac(secret, payload, providedHex)` into `api/src/shared/timing-safe.ts` using `timingSafeEqual` with buffer-length pre-check. Both `razorpay.service.ts` and `webhooks.ts` (which had its own inline copy) now use the shared helper, removing duplication.
- **P1 Missing ETag on payment writes** — `confirmPayment` and `markPaid` used unconditional Cosmos `replace` with no optimistic concurrency. Both now read the ETag in a single `read()` call and pass `accessCondition: { type: 'IfMatch' }` on replace when `BOOKINGS_ETAG_GUARDS=on`. A 412 returns `null` (idempotent by design). The legacy unconditional-replace path remains compiled for rollback via env-var flip. The `status === 'PAID'` idempotent-success guard in `confirmPayment` is preserved before the replace.

## Test plan

- [ ] `api/tests/shared/timing-safe.test.ts` — 7 cases: correct HMAC, wrong digest (equal-length), short input (length mismatch), empty string, non-hex input (no throw), all-zeros, wrong-secret
- [ ] `api/tests/kyc/submit-aadhaar-idor.test.ts` — 3 cases: 403 on uid mismatch, 200 on uid match, `upsertKycStatus` not called on forbidden path
- [ ] `api/tests/cosmos/booking-repository-etag.test.ts` — 8 cases: ETag on/off for both `confirmPayment` and `markPaid`, including 412→null, non-412 propagation, PAID idempotency guard, legacy path has no `accessCondition`
- [ ] All existing tests still pass (127 files / 965 tests)
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint --max-warnings 0` — clean
- [ ] Pre-codex smoke gate — `=== API smoke gate PASSED ===`

**Deferred (Razorpay account not yet provisioned):**
- [ ] Live HMAC end-to-end through dev → webhook → equalsHexHmac
- [ ] ETag 412 race confirmed via real concurrent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)