### PR TITLE
feat(E11-S01a): Truecaller server-side verification (flag default-OFF, anonymous path preserved)

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -23,6 +23,52 @@
   ],
   "components": {
     "schemas": {
+      "TruecallerVerifyRequest": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "string",
+            "minLength": 1,
+            "example": "base64encodedPayload=="
+          },
+          "signature": {
+            "type": "string",
+            "minLength": 1,
+            "example": "base64encodedSignature=="
+          },
+          "signatureAlgorithm": {
+            "type": "string",
+            "minLength": 1,
+            "example": "SHA512withRSA"
+          },
+          "fcmToken": {
+            "type": "string",
+            "example": "fcm-token-abc123"
+          }
+        },
+        "required": [
+          "payload",
+          "signature",
+          "signatureAlgorithm"
+        ]
+      },
+      "TruecallerVerifyResponse": {
+        "type": "object",
+        "properties": {
+          "firebaseCustomToken": {
+            "type": "string",
+            "example": "eyJhbGci..."
+          },
+          "sessionExpiresAt": {
+            "type": "number",
+            "example": 1700000000000
+          }
+        },
+        "required": [
+          "firebaseCustomToken",
+          "sessionExpiresAt"
+        ]
+      },
       "HealthResponse": {
         "type": "object",
         "properties": {
@@ -1480,6 +1526,40 @@
     "parameters": {}
   },
   "paths": {
+    "/v1/auth/truecaller/verify": {
+      "post": {
+        "operationId": "verifyTruecaller",
+        "tags": [
+          "auth"
+        ],
+        "summary": "Verify Truecaller profile signature and mint Firebase custom token",
+        "description": "Verifies the Truecaller SDK RSA payload/signature against the Truecaller public key API (cached 24h in Cosmos). On success, mints a Firebase custom token for the verified phone number. Called by customer-app when truecaller_server_verify_v2 flag is ON.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TruecallerVerifyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signature valid — Firebase custom token issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TruecallerVerifyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error or invalid signature"
+          }
+        }
+      }
+    },
     "/v1/health": {
       "get": {
         "operationId": "getHealth",

--- a/api/src/cosmos/client.ts
+++ b/api/src/cosmos/client.ts
@@ -61,6 +61,10 @@ export function getWebhookEventsContainer(): Container {
   return getCosmosClient().database(DB_NAME).container('webhook_events');
 }
 
+export function getSystemContainer(): Container {
+  return getCosmosClient().database(DB_NAME).container('system');
+}
+
 /** Inject a mock CosmosClient in tests. */
 export function _setCosmosClientForTest(mock: CosmosClient): void {
   _client = mock;

--- a/api/src/functions/auth/truecaller-verify.ts
+++ b/api/src/functions/auth/truecaller-verify.ts
@@ -11,7 +11,7 @@
  * ADR-0005 Phase 2 implementation.
  */
 
-import '../../../bootstrap.js';
+import '../../bootstrap.js';
 import { app } from '@azure/functions';
 import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
 import { createVerify } from 'node:crypto';

--- a/api/src/functions/auth/truecaller-verify.ts
+++ b/api/src/functions/auth/truecaller-verify.ts
@@ -1,0 +1,138 @@
+/**
+ * POST /v1/auth/truecaller/verify
+ *
+ * Verifies a Truecaller profile payload against Truecaller's RSA public key.
+ * On successful verification, mints a Firebase custom token for the verified
+ * phone number and returns it to the client.
+ *
+ * Called by customer-app after Truecaller SDK callback when the
+ * `truecaller_server_verify_v2` GrowthBook feature flag is ON (default OFF).
+ *
+ * ADR-0005 Phase 2 implementation.
+ */
+
+import '../../../bootstrap.js';
+import { app } from '@azure/functions';
+import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { createVerify } from 'node:crypto';
+import { z } from 'zod';
+import { getTruecallerPublicKey } from '../../services/truecaller.service.js';
+import { getFirebaseAdmin } from '../../services/firebaseAdmin.js';
+
+// ── Request schema ────────────────────────────────────────────────────────────
+
+const TruecallerVerifyRequestSchema = z.object({
+  payload: z.string().min(1),
+  signature: z.string().min(1),
+  signatureAlgorithm: z.string().min(1),
+  fcmToken: z.string().optional(),
+});
+
+// ── Algorithm mapping ─────────────────────────────────────────────────────────
+
+const ALGORITHM_MAP: Record<string, string> = {
+  SHA512withRSA: 'RSA-SHA512',
+  SHA256withRSA: 'RSA-SHA256',
+  SHA384withRSA: 'RSA-SHA384',
+};
+
+function toNodeAlgorithm(javaAlgorithm: string): string {
+  return ALGORITHM_MAP[javaAlgorithm] ?? javaAlgorithm;
+}
+
+// ── Signature verification ────────────────────────────────────────────────────
+
+async function verifyTruecallerSignature(
+  payload: string,       // base64-encoded payload bytes
+  signature: string,     // base64-encoded signature bytes
+  algorithm: string,     // e.g. "SHA512withRSA"
+): Promise<boolean> {
+  const publicKey = await getTruecallerPublicKey();
+  const nodeAlgorithm = toNodeAlgorithm(algorithm);
+
+  try {
+    const verifier = createVerify(nodeAlgorithm);
+    verifier.update(Buffer.from(payload, 'base64'));
+    return verifier.verify(publicKey, Buffer.from(signature, 'base64'));
+  } catch {
+    // Unsupported algorithm or malformed key/signature — treat as invalid
+    return false;
+  }
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export async function truecallerVerifyHandler(
+  req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return { status: 400, jsonBody: { code: 'INVALID_JSON' } };
+  }
+
+  const parsed = TruecallerVerifyRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      status: 400,
+      jsonBody: {
+        code: 'VALIDATION_ERROR',
+        issues: parsed.error.issues.map((i) => ({
+          path: i.path,
+          message: i.message,
+          code: i.code,
+        })),
+      },
+    };
+  }
+
+  const { payload, signature, signatureAlgorithm } = parsed.data;
+
+  // Verify Truecaller RSA signature
+  const isValid = await verifyTruecallerSignature(payload, signature, signatureAlgorithm);
+  if (!isValid) {
+    return { status: 400, jsonBody: { code: 'TRUECALLER_SIGNATURE_INVALID' } };
+  }
+
+  // Decode payload to extract phone number
+  let phoneNumber: string;
+  try {
+    const payloadJson = JSON.parse(Buffer.from(payload, 'base64').toString('utf8')) as {
+      phoneNumber?: string;
+    };
+    if (!payloadJson.phoneNumber) {
+      return { status: 400, jsonBody: { code: 'PAYLOAD_MISSING_PHONE' } };
+    }
+    phoneNumber = payloadJson.phoneNumber;
+  } catch {
+    return { status: 400, jsonBody: { code: 'PAYLOAD_DECODE_ERROR' } };
+  }
+
+  // Mint Firebase custom token
+  // TODO(E11-S01b): Migrate UID from phoneNumber to stable internal user ID to
+  // survive phone number format changes. For now, phoneNumber is the UID.
+  // See ADR-0005 follow-up note.
+  const customToken = await getFirebaseAdmin().auth().createCustomToken(phoneNumber);
+
+  // Session expires in 1 hour (Firebase custom tokens expire in 1h by default)
+  const sessionExpiresAt = Date.now() + 60 * 60 * 1000;
+
+  return {
+    status: 200,
+    jsonBody: {
+      firebaseCustomToken: customToken,
+      sessionExpiresAt,
+    },
+  };
+}
+
+// ── Azure Functions registration ──────────────────────────────────────────────
+
+app.http('truecallerVerify', {
+  methods: ['POST'],
+  route: 'v1/auth/truecaller/verify',
+  authLevel: 'anonymous',
+  handler: truecallerVerifyHandler,
+});

--- a/api/src/openapi/registry.ts
+++ b/api/src/openapi/registry.ts
@@ -42,6 +42,49 @@ extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
 
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+const TruecallerVerifyRequestSchema = z.object({
+  payload: z.string().min(1).openapi({ example: 'base64encodedPayload==' }),
+  signature: z.string().min(1).openapi({ example: 'base64encodedSignature==' }),
+  signatureAlgorithm: z.string().min(1).openapi({ example: 'SHA512withRSA' }),
+  fcmToken: z.string().optional().openapi({ example: 'fcm-token-abc123' }),
+}).openapi('TruecallerVerifyRequest');
+
+const TruecallerVerifyResponseSchema = z.object({
+  firebaseCustomToken: z.string().openapi({ example: 'eyJhbGci...' }),
+  sessionExpiresAt: z.number().openapi({ example: 1700000000000 }),
+}).openapi('TruecallerVerifyResponse');
+
+registry.register('TruecallerVerifyRequest', TruecallerVerifyRequestSchema);
+registry.register('TruecallerVerifyResponse', TruecallerVerifyResponseSchema);
+
+registry.registerPath({
+  method: 'post',
+  path: '/v1/auth/truecaller/verify',
+  operationId: 'verifyTruecaller',
+  tags: ['auth'],
+  summary: 'Verify Truecaller profile signature and mint Firebase custom token',
+  description:
+    'Verifies the Truecaller SDK RSA payload/signature against the Truecaller public key API ' +
+    '(cached 24h in Cosmos). On success, mints a Firebase custom token for the verified phone number. ' +
+    'Called by customer-app when truecaller_server_verify_v2 flag is ON.',
+  request: {
+    body: {
+      content: { 'application/json': { schema: TruecallerVerifyRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Signature valid — Firebase custom token issued',
+      content: { 'application/json': { schema: TruecallerVerifyResponseSchema } },
+    },
+    400: {
+      description: 'Validation error or invalid signature',
+    },
+  },
+});
+
 const HealthResponse = HealthResponseSchema.openapi('HealthResponse');
 registry.register('HealthResponse', HealthResponse);
 

--- a/api/src/services/truecaller.service.ts
+++ b/api/src/services/truecaller.service.ts
@@ -1,0 +1,89 @@
+/**
+ * truecaller.service.ts
+ *
+ * Manages fetching and caching the Truecaller RSA public key used for
+ * server-side signature verification.
+ *
+ * The key is cached in Cosmos DB under the `system` partition with a 24-hour TTL.
+ * An in-process memory cache reduces Cosmos reads for hot-path requests.
+ */
+
+import { getSystemContainer } from '../cosmos/client.js';
+
+const TRUECALLER_KEY_API = 'https://api4.truecaller.com/v1/key';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const COSMOS_DOC_ID = 'truecaller-pubkey';
+
+interface TruecallerKeyDoc {
+  id: string;
+  publicKey: string;
+  fetchedAt: number;
+}
+
+/** In-process memory cache — avoids Cosmos round-trip for the hot path. */
+let _memCache: { publicKey: string; fetchedAt: number } | null = null;
+
+/** Reset in-process cache — used by tests only. */
+export function _resetCacheForTest(): void {
+  _memCache = null;
+}
+
+/**
+ * Returns the Truecaller RSA public key, using a tiered cache:
+ * 1. In-process memory (fastest — no I/O)
+ * 2. Cosmos DB cache (survives function cold-starts)
+ * 3. Truecaller API (only on cache miss or stale entry)
+ */
+export async function getTruecallerPublicKey(): Promise<string> {
+  const now = Date.now();
+
+  // 1. In-process cache
+  if (_memCache && now - _memCache.fetchedAt < CACHE_TTL_MS) {
+    return _memCache.publicKey;
+  }
+
+  // 2. Cosmos cache
+  const container = getSystemContainer();
+  const { resource } = await container.item(COSMOS_DOC_ID, COSMOS_DOC_ID).read<TruecallerKeyDoc>();
+
+  if (resource && now - resource.fetchedAt < CACHE_TTL_MS) {
+    _memCache = { publicKey: resource.publicKey, fetchedAt: resource.fetchedAt };
+    return resource.publicKey;
+  }
+
+  // 3. Fetch from Truecaller API
+  const freshKey = await fetchFromTruecallerApi();
+
+  const doc: TruecallerKeyDoc = {
+    id: COSMOS_DOC_ID,
+    publicKey: freshKey,
+    fetchedAt: now,
+  };
+
+  // Persist to Cosmos (fire-and-forget is acceptable — worst case, next request re-fetches)
+  await container.items.upsert(doc);
+
+  // Update in-process cache
+  _memCache = { publicKey: freshKey, fetchedAt: now };
+
+  return freshKey;
+}
+
+async function fetchFromTruecallerApi(): Promise<string> {
+  const response = await fetch(TRUECALLER_KEY_API, {
+    method: 'GET',
+    headers: { 'Accept': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Truecaller public key fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const json = (await response.json()) as { response?: string };
+  if (!json.response) {
+    throw new Error('Truecaller public key response missing "response" field');
+  }
+  return json.response;
+}

--- a/api/tests/functions/auth/truecaller-verify.test.ts
+++ b/api/tests/functions/auth/truecaller-verify.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpRequest } from '@azure/functions';
+import type { InvocationContext, HttpResponseInit } from '@azure/functions';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../src/services/truecaller.service.js', () => ({
+  getTruecallerPublicKey: vi.fn(),
+  _resetCacheForTest: vi.fn(),
+}));
+
+vi.mock('../../../src/services/firebaseAdmin.js', () => ({
+  getFirebaseAdmin: vi.fn(),
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { truecallerVerifyHandler } from '../../../src/functions/auth/truecaller-verify.js';
+import { getTruecallerPublicKey } from '../../../src/services/truecaller.service.js';
+import { getFirebaseAdmin } from '../../../src/services/firebaseAdmin.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockCtx = {} as InvocationContext;
+
+function makeRequest(body: unknown) {
+  return new HttpRequest({
+    url: 'http://localhost/api/v1/auth/truecaller/verify',
+    method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+// A minimal RSA-SHA512 payload/signature pair we can control in tests.
+// We do NOT need a real Truecaller key — we test the signature path by mocking
+// the crypto verify result via the service mock.
+const VALID_PAYLOAD = Buffer.from(
+  JSON.stringify({ phoneNumber: '+919876543210', requestNonce: 'abc' }),
+).toString('base64');
+
+const VALID_SIG = Buffer.from('fake-sig').toString('base64');
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /v1/auth/truecaller/verify', () => {
+  const mockCreateCustomToken = vi.fn().mockResolvedValue('firebase-custom-token-abc');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: public key available
+    vi.mocked(getTruecallerPublicKey).mockResolvedValue(
+      '-----BEGIN PUBLIC KEY-----\nMIIB...\n-----END PUBLIC KEY-----',
+    );
+
+    // Default: Firebase Admin mock
+    vi.mocked(getFirebaseAdmin).mockReturnValue({
+      auth: () => ({ createCustomToken: mockCreateCustomToken }),
+    } as unknown as ReturnType<typeof getFirebaseAdmin>);
+  });
+
+  it('returns 400 VALIDATION_ERROR when required fields are missing', async () => {
+    const res = (await truecallerVerifyHandler(
+      makeRequest({ payload: 'x' }), // missing signature and signatureAlgorithm
+      mockCtx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 VALIDATION_ERROR for empty strings', async () => {
+    const res = (await truecallerVerifyHandler(
+      makeRequest({ payload: '', signature: 'x', signatureAlgorithm: 'SHA512withRSA' }),
+      mockCtx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 TRUECALLER_SIGNATURE_INVALID when crypto.verify rejects signature', async () => {
+    // To make the signature fail, use a payload/sig that will not verify
+    // against our fake key. We use the actual crypto module but with a garbage key,
+    // so verify() will return false (or throw). The handler should map that to 400.
+    const res = (await truecallerVerifyHandler(
+      makeRequest({
+        payload: VALID_PAYLOAD,
+        signature: VALID_SIG,
+        signatureAlgorithm: 'SHA512withRSA',
+      }),
+      mockCtx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('TRUECALLER_SIGNATURE_INVALID');
+  });
+
+  it('returns 200 with firebaseCustomToken when signature is valid', async () => {
+    // To get a passing signature test, we need to generate a real RSA key pair
+    // and sign the payload. This is the integration-style test path.
+    const { generateKeyPairSync, createSign } = await import('node:crypto');
+
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+
+    const payloadObj = { phoneNumber: '+919876543210', requestNonce: 'nonce-test' };
+    const payloadB64 = Buffer.from(JSON.stringify(payloadObj)).toString('base64');
+
+    const signer = createSign('RSA-SHA512');
+    signer.update(Buffer.from(payloadB64, 'base64'));
+    const signatureB64 = signer.sign(privateKey, 'base64');
+
+    vi.mocked(getTruecallerPublicKey).mockResolvedValue(publicKeyPem);
+
+    const res = (await truecallerVerifyHandler(
+      makeRequest({
+        payload: payloadB64,
+        signature: signatureB64,
+        signatureAlgorithm: 'SHA512withRSA',
+      }),
+      mockCtx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as { firebaseCustomToken: string; sessionExpiresAt: number };
+    expect(body.firebaseCustomToken).toBe('firebase-custom-token-abc');
+    expect(typeof body.sessionExpiresAt).toBe('number');
+
+    // Should have minted the custom token with the phone number as UID
+    expect(mockCreateCustomToken).toHaveBeenCalledWith('+919876543210');
+  });
+
+  it('returns 200 and includes fcmToken passthrough in debug fields (fcmToken optional)', async () => {
+    const { generateKeyPairSync, createSign } = await import('node:crypto');
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+
+    const payloadObj = { phoneNumber: '+919876543210', requestNonce: 'nonce-2' };
+    const payloadB64 = Buffer.from(JSON.stringify(payloadObj)).toString('base64');
+    const signer = createSign('RSA-SHA512');
+    signer.update(Buffer.from(payloadB64, 'base64'));
+    const signatureB64 = signer.sign(privateKey, 'base64');
+
+    vi.mocked(getTruecallerPublicKey).mockResolvedValue(publicKeyPem);
+
+    const res = (await truecallerVerifyHandler(
+      makeRequest({
+        payload: payloadB64,
+        signature: signatureB64,
+        signatureAlgorithm: 'SHA512withRSA',
+        fcmToken: 'fcm-token-xyz',
+      }),
+      mockCtx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/api/tests/services/truecaller.service.test.ts
+++ b/api/tests/services/truecaller.service.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../src/cosmos/client.js', () => ({
+  getCosmosClient: vi.fn(),
+  DB_NAME: 'homeservices',
+  getSystemContainer: vi.fn(),
+}));
+
+// node-fetch is used by the service to fetch the Truecaller public key.
+// We mock the global fetch to avoid real network calls.
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+import { getTruecallerPublicKey, _resetCacheForTest } from '../../src/services/truecaller.service.js';
+import { getSystemContainer } from '../../src/cosmos/client.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const FAKE_PUB_KEY = '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkq...\n-----END PUBLIC KEY-----';
+const NOW = 1_700_000_000_000; // fixed epoch ms
+
+function makeCosmosContainer(storedItem: unknown) {
+  return {
+    item: vi.fn().mockReturnValue({
+      read: vi.fn().mockResolvedValue(storedItem ? { resource: storedItem } : { resource: undefined }),
+    }),
+    items: {
+      upsert: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('truecaller.service — getTruecallerPublicKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.setSystemTime(NOW);
+    _resetCacheForTest();
+  });
+
+  it('returns cached key from Cosmos when within TTL (24h)', async () => {
+    const fetchedAt = NOW - 1000 * 60 * 60; // 1 hour ago — within 24h TTL
+    const container = makeCosmosContainer({
+      id: 'truecaller-pubkey',
+      publicKey: FAKE_PUB_KEY,
+      fetchedAt,
+    });
+    vi.mocked(getSystemContainer).mockReturnValue(container as unknown as ReturnType<typeof getSystemContainer>);
+
+    const key = await getTruecallerPublicKey();
+
+    expect(key).toBe(FAKE_PUB_KEY);
+    // Should NOT have called the Truecaller API
+    expect(mockFetch).not.toHaveBeenCalled();
+    // Should NOT have written back to Cosmos
+    expect(container.items.upsert).not.toHaveBeenCalled();
+  });
+
+  it('fetches from Truecaller API when no entry exists in Cosmos (cache miss)', async () => {
+    // Cosmos returns no item
+    const container = makeCosmosContainer(null);
+    vi.mocked(getSystemContainer).mockReturnValue(container as unknown as ReturnType<typeof getSystemContainer>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ response: FAKE_PUB_KEY }),
+    });
+
+    const key = await getTruecallerPublicKey();
+
+    expect(key).toBe(FAKE_PUB_KEY);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api4.truecaller.com/v1/key',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(container.items.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'truecaller-pubkey',
+        publicKey: FAKE_PUB_KEY,
+        fetchedAt: NOW,
+      }),
+    );
+  });
+
+  it('re-fetches from Truecaller API when cached entry is stale (>24h)', async () => {
+    const fetchedAt = NOW - 1000 * 60 * 60 * 25; // 25 hours ago — stale
+    const container = makeCosmosContainer({
+      id: 'truecaller-pubkey',
+      publicKey: 'OLD_KEY',
+      fetchedAt,
+    });
+    vi.mocked(getSystemContainer).mockReturnValue(container as unknown as ReturnType<typeof getSystemContainer>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ response: FAKE_PUB_KEY }),
+    });
+
+    const key = await getTruecallerPublicKey();
+
+    expect(key).toBe(FAKE_PUB_KEY);
+    expect(mockFetch).toHaveBeenCalled();
+    expect(container.items.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: FAKE_PUB_KEY, fetchedAt: NOW }),
+    );
+  });
+
+  it('throws when Truecaller API returns non-ok response', async () => {
+    const container = makeCosmosContainer(null);
+    vi.mocked(getSystemContainer).mockReturnValue(container as unknown as ReturnType<typeof getSystemContainer>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+
+    await expect(getTruecallerPublicKey()).rejects.toThrow(/Truecaller public key fetch failed/);
+  });
+});

--- a/customer-app/app/build.gradle.kts
+++ b/customer-app/app/build.gradle.kts
@@ -250,6 +250,11 @@ kover {
                     "*.navigation.*",
                     // Hilt DI modules — @Provides methods are framework wiring
                     "*.data.auth.di.*",
+                    // data.auth.remote.di — AuthApiModule (@Provides for AuthApi Retrofit + @PublicOkHttpClient),
+                    // same rationale as data.auth.di.* and data.booking.di.*
+                    "*.data.auth.remote.di.*",
+                    // domain.flags.di — FeatureFlagsModule (@Binds), same rationale as other DI modules
+                    "*.domain.flags.di.*",
                     "*.data.catalogue.di.*",
                     // Stub home screen — placeholder Compose composable, no logic
                     "*.ui.home.*",
@@ -345,6 +350,11 @@ kover {
                     // Booking remote DTOs — Moshi @JsonClass data holders with toDomain() mappers;
                     // mapping is exercised indirectly via repository integration tests, not JVM unit tests
                     "*.data.booking.remote.dto.*",
+                    // Auth remote DTOs — Moshi @JsonClass data holders (TruecallerVerifyRequest/Response),
+                    // same rationale as *.data.booking.remote.dto.*
+                    "*.data.auth.remote.dto.*",
+                    // BuildConfigFeatureFlags — reads a compile-time constant; no branches to test
+                    "*.BuildConfigFeatureFlags",
                     // RazorpayPaymentUseCase.open() — uses callbackFlow + Razorpay Checkout SDK which
                     // requires a real Activity; same rationale as FirebaseOtpUseCase (callbackFlow + SDK)
                     "*.RazorpayPaymentUseCase",

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/AuthApi.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/AuthApi.kt
@@ -1,0 +1,13 @@
+package com.homeservices.customer.data.auth.remote
+
+import com.homeservices.customer.data.auth.remote.dto.TruecallerVerifyRequest
+import com.homeservices.customer.data.auth.remote.dto.TruecallerVerifyResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+public interface AuthApi {
+    @POST("v1/auth/truecaller/verify")
+    public suspend fun verifyTruecaller(
+        @Body body: TruecallerVerifyRequest,
+    ): TruecallerVerifyResponse
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/di/AuthApiModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/di/AuthApiModule.kt
@@ -1,0 +1,58 @@
+package com.homeservices.customer.data.auth.remote.di
+
+import com.homeservices.customer.BuildConfig
+import com.homeservices.customer.data.auth.remote.AuthApi
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+/**
+ * Qualifier for an OkHttpClient that carries NO authentication tokens.
+ * Used for public / pre-auth API endpoints (e.g. Truecaller verify).
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+public annotation class PublicOkHttpClient
+
+@Module
+@InstallIn(SingletonComponent::class)
+public object AuthApiModule {
+    @Provides
+    @Singleton
+    @PublicOkHttpClient
+    public fun providePublicOkHttpClient(): OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level =
+                        if (BuildConfig.DEBUG) {
+                            HttpLoggingInterceptor.Level.BODY
+                        } else {
+                            HttpLoggingInterceptor.Level.NONE
+                        }
+                },
+            ).build()
+
+    @Provides
+    @Singleton
+    public fun provideAuthApi(
+        @PublicOkHttpClient okHttpClient: OkHttpClient,
+        moshi: Moshi,
+    ): AuthApi =
+        Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.API_BASE_URL + "/")
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(okHttpClient)
+            .build()
+            .create(AuthApi::class.java)
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/dto/TruecallerVerifyRequest.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/dto/TruecallerVerifyRequest.kt
@@ -1,0 +1,11 @@
+package com.homeservices.customer.data.auth.remote.dto
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+public data class TruecallerVerifyRequest(
+    val payload: String,
+    val signature: String,
+    val signatureAlgorithm: String,
+    val fcmToken: String? = null,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/dto/TruecallerVerifyResponse.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/auth/remote/dto/TruecallerVerifyResponse.kt
@@ -1,0 +1,9 @@
+package com.homeservices.customer.data.auth.remote.dto
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+public data class TruecallerVerifyResponse(
+    val firebaseCustomToken: String,
+    val sessionExpiresAt: Long,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/AuthOrchestrator.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/AuthOrchestrator.kt
@@ -13,6 +13,7 @@ import com.homeservices.customer.domain.auth.model.AuthResult
 import com.homeservices.customer.domain.auth.model.GoogleSignInResult
 import com.homeservices.customer.domain.auth.model.OtpSendResult
 import com.homeservices.customer.domain.auth.model.TruecallerAuthResult
+import com.homeservices.customer.domain.flags.FeatureFlags
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.flow
@@ -30,6 +31,8 @@ public class AuthOrchestrator
         private val googleSignInUseCase: GoogleSignInUseCase,
         private val emailPasswordUseCase: EmailPasswordUseCase,
         private val firebaseAuth: FirebaseAuth,
+        private val verifyTruecallerUseCase: VerifyTruecallerUseCase,
+        private val featureFlags: FeatureFlags,
     ) {
         public sealed class StartResult {
             public data object TruecallerLaunched : StartResult()
@@ -66,7 +69,43 @@ public class AuthOrchestrator
         public fun signInWithCredential(credential: PhoneAuthCredential): Flow<AuthResult> =
             firebaseOtpUseCase.signInWithCredential(credential)
 
-        public suspend fun completeWithTruecaller(phoneNumber: String): AuthResult = saveSessionUseCase.saveAnonymousWithPhone(phoneNumber)
+        /**
+         * Completes the Truecaller auth flow.
+         *
+         * When [FeatureFlags.truecallerServerVerify] is ON (Phase 2), posts the
+         * payload+signature to the backend for RSA verification, then signs into
+         * Firebase with the returned custom token.
+         *
+         * When the flag is OFF (Phase 1 — default), falls back to the original
+         * anonymous sign-in path. The anonymous path is intentionally preserved
+         * until E11-S01b removes it after a 7-day soak gate.
+         *
+         * @param truecallerSuccess the SDK success result carrying payload, signature,
+         *   signatureAlgorithm, and phoneLastFour
+         */
+        @Suppress("TooGenericExceptionCaught")
+        public suspend fun completeWithTruecaller(truecallerSuccess: TruecallerAuthResult.Success): AuthResult {
+            if (featureFlags.truecallerServerVerify()) {
+                // Phase 2: server-side RSA verification → Firebase custom token
+                val result = verifyTruecallerUseCase.invoke(
+                    payload = truecallerSuccess.payload,
+                    signature = truecallerSuccess.signature,
+                    signatureAlgorithm = truecallerSuccess.signatureAlgorithm,
+                )
+                return if (result.isSuccess) {
+                    val user = result.getOrThrow()
+                    saveSessionUseCase.save(user, truecallerSuccess.phoneLastFour)
+                    AuthResult.Success(user)
+                } else {
+                    AuthResult.Error.General(
+                        result.exceptionOrNull() ?: Exception("Truecaller server verify failed"),
+                    )
+                }
+            }
+            // Phase 1 (flag OFF): anonymous sign-in — intentionally preserved.
+            // Removal tracked in E11-S01b (Wave 3, 7-day soak gate after Phase 2 stable).
+            return saveSessionUseCase.saveAnonymousWithPhone(truecallerSuccess.phoneLastFour)
+        }
 
         public suspend fun completeWithFirebase(
             user: FirebaseUser,

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/TruecallerLoginUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/TruecallerLoginUseCase.kt
@@ -24,7 +24,14 @@ public class TruecallerLoginUseCase
         internal val sdkCallback: ITrueCallback =
             object : ITrueCallback {
                 override fun onSuccessProfileShared(profile: TrueProfile) {
-                    _resultFlow.tryEmit(TruecallerAuthResult.Success(profile.phoneNumber.takeLast(4)))
+                    _resultFlow.tryEmit(
+                        TruecallerAuthResult.Success(
+                            payload = profile.payload ?: "",
+                            signature = profile.signature ?: "",
+                            signatureAlgorithm = profile.signatureAlgorithm ?: "",
+                            phoneLastFour = profile.phoneNumber.takeLast(4),
+                        ),
+                    )
                 }
 
                 override fun onFailureProfileShared(error: TrueError) {

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCase.kt
@@ -1,0 +1,65 @@
+package com.homeservices.customer.domain.auth
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.homeservices.customer.data.auth.remote.AuthApi
+import com.homeservices.customer.data.auth.remote.dto.TruecallerVerifyRequest
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Phase 2 Truecaller auth use case (ADR-0005).
+ *
+ * POSTs the Truecaller SDK-provided (payload, signature, signatureAlgorithm) to
+ * `POST /v1/auth/truecaller/verify`. The API verifies the RSA signature against
+ * the Truecaller public key and returns a Firebase custom token. This use case
+ * then signs into Firebase using that custom token.
+ *
+ * This use case is invoked from [AuthViewModel] when the GrowthBook flag
+ * `truecaller_server_verify_v2` is ON. The anonymous sign-in fallback path
+ * (Phase 1) remains active when the flag is OFF.
+ */
+@Singleton
+public class VerifyTruecallerUseCase
+    @Inject
+    constructor(
+        private val authApi: AuthApi,
+        private val firebaseAuth: FirebaseAuth,
+    ) {
+        /**
+         * Verifies the Truecaller profile server-side and signs into Firebase.
+         *
+         * @param payload base64-encoded Truecaller profile payload from SDK callback
+         * @param signature base64-encoded RSA signature from SDK callback
+         * @param signatureAlgorithm algorithm string (e.g. "SHA512withRSA")
+         * @return [Result.success] with the signed-in [FirebaseUser], or
+         *         [Result.failure] with the upstream exception.
+         */
+        @Suppress("TooGenericExceptionCaught")
+        public suspend fun invoke(
+            payload: String,
+            signature: String,
+            signatureAlgorithm: String,
+        ): Result<FirebaseUser> =
+            try {
+                val response =
+                    authApi.verifyTruecaller(
+                        TruecallerVerifyRequest(
+                            payload = payload,
+                            signature = signature,
+                            signatureAlgorithm = signatureAlgorithm,
+                        ),
+                    )
+
+                val authResult = firebaseAuth.signInWithCustomToken(response.firebaseCustomToken).await()
+                val user =
+                    authResult.user
+                        ?: return Result.failure(
+                            IllegalStateException("null user after custom token sign-in"),
+                        )
+                Result.success(user)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/model/TruecallerAuthResult.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/auth/model/TruecallerAuthResult.kt
@@ -1,7 +1,20 @@
 package com.homeservices.customer.domain.auth.model
 
 public sealed class TruecallerAuthResult {
+    /**
+     * Truecaller SDK callback succeeded.
+     *
+     * [payload], [signature], and [signatureAlgorithm] are forwarded to the
+     * server-side verification endpoint when the `truecaller_server_verify_v2`
+     * flag is ON (Phase 2 path — ADR-0005).
+     *
+     * [phoneLastFour] is retained for the anonymous sign-in fallback path
+     * (Phase 1, flag OFF) and for display in the UI.
+     */
     public data class Success(
+        val payload: String,
+        val signature: String,
+        val signatureAlgorithm: String,
         val phoneLastFour: String,
     ) : TruecallerAuthResult()
 

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/flags/FeatureFlags.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/flags/FeatureFlags.kt
@@ -1,0 +1,39 @@
+package com.homeservices.customer.domain.flags
+
+/**
+ * Feature flag abstraction.
+ *
+ * Default implementation reads from BuildConfig boolean constants (always returns
+ * `false` for flags not yet set to `true` in build.gradle). This keeps CI green
+ * without requiring a live GrowthBook connection.
+ *
+ * The GrowthBook-backed implementation is wired in E13-S05 (Wave 2).
+ */
+public interface FeatureFlags {
+    /**
+     * When `true`, the Truecaller auth flow uses server-side RSA signature
+     * verification (ADR-0005 Phase 2). When `false`, the original anonymous
+     * sign-in path is used.
+     *
+     * Flag name: `truecaller_server_verify_v2`
+     * Default: OFF (false)
+     */
+    public fun truecallerServerVerify(): Boolean
+}
+
+/**
+ * Default implementation: reads BuildConfig flags. Returns `false` for all
+ * flags until overridden. Safe for CI, unit tests, and the flag-OFF prod path.
+ */
+public class BuildConfigFeatureFlags : FeatureFlags {
+    override fun truecallerServerVerify(): Boolean = TRUECALLER_SERVER_VERIFY_V2_ENABLED
+
+    private companion object {
+        /**
+         * Set via build.gradle `buildConfigField` when the flag should be hardcoded ON
+         * for testing builds. Production defaults to false; the live value comes from
+         * GrowthBook once E13-S05 wires the GrowthBook FeatureFlags impl.
+         */
+        const val TRUECALLER_SERVER_VERIFY_V2_ENABLED: Boolean = false
+    }
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/flags/FeatureFlags.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/flags/FeatureFlags.kt
@@ -1,5 +1,7 @@
 package com.homeservices.customer.domain.flags
 
+import javax.inject.Inject
+
 /**
  * Feature flag abstraction.
  *
@@ -25,7 +27,9 @@ public interface FeatureFlags {
  * Default implementation: reads BuildConfig flags. Returns `false` for all
  * flags until overridden. Safe for CI, unit tests, and the flag-OFF prod path.
  */
-public class BuildConfigFeatureFlags : FeatureFlags {
+public class BuildConfigFeatureFlags
+    @Inject
+    constructor() : FeatureFlags {
     override fun truecallerServerVerify(): Boolean = TRUECALLER_SERVER_VERIFY_V2_ENABLED
 
     private companion object {

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/flags/di/FeatureFlagsModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/flags/di/FeatureFlagsModule.kt
@@ -1,0 +1,17 @@
+package com.homeservices.customer.domain.flags.di
+
+import com.homeservices.customer.domain.flags.BuildConfigFeatureFlags
+import com.homeservices.customer.domain.flags.FeatureFlags
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+public abstract class FeatureFlagsModule {
+    @Binds
+    @Singleton
+    public abstract fun bindFeatureFlags(impl: BuildConfigFeatureFlags): FeatureFlags
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/auth/AuthViewModel.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/auth/AuthViewModel.kt
@@ -61,7 +61,10 @@ public class AuthViewModel
             when (result) {
                 is TruecallerAuthResult.Success -> {
                     viewModelScope.launch {
-                        val authResult = orchestrator.completeWithTruecaller(result.phoneLastFour)
+                        // Pass the full Success object so the orchestrator can choose between
+                        // Phase 1 (anonymous sign-in) and Phase 2 (server-side RSA verify)
+                        // based on the truecaller_server_verify_v2 feature flag.
+                        val authResult = orchestrator.completeWithTruecaller(result)
                         if (authResult is AuthResult.Error) {
                             _uiState.value =
                                 AuthUiState.Error(

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/AuthOrchestratorTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/AuthOrchestratorTest.kt
@@ -13,6 +13,7 @@ import com.homeservices.customer.domain.auth.model.AuthResult
 import com.homeservices.customer.domain.auth.model.GoogleSignInResult
 import com.homeservices.customer.domain.auth.model.OtpSendResult
 import com.homeservices.customer.domain.auth.model.TruecallerAuthResult
+import com.homeservices.customer.domain.flags.FeatureFlags
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -33,6 +34,8 @@ public class AuthOrchestratorTest {
     private val googleSignInUseCase: GoogleSignInUseCase = mockk()
     private val emailPasswordUseCase: EmailPasswordUseCase = mockk()
     private val firebaseAuth: FirebaseAuth = mockk()
+    private val verifyTruecallerUseCase: VerifyTruecallerUseCase = mockk()
+    private val featureFlags: FeatureFlags = mockk()
     private lateinit var orchestrator: AuthOrchestrator
 
     @BeforeEach
@@ -40,6 +43,8 @@ public class AuthOrchestratorTest {
         truecallerUseCase = mockk(relaxed = true)
         firebaseOtpUseCase = mockk(relaxed = true)
         saveSessionUseCase = mockk(relaxed = true)
+        // Feature flag OFF by default — exercises the anonymous sign-in path
+        every { featureFlags.truecallerServerVerify() } returns false
         orchestrator =
             AuthOrchestrator(
                 truecallerUseCase = truecallerUseCase,
@@ -48,6 +53,8 @@ public class AuthOrchestratorTest {
                 googleSignInUseCase = googleSignInUseCase,
                 emailPasswordUseCase = emailPasswordUseCase,
                 firebaseAuth = firebaseAuth,
+                verifyTruecallerUseCase = verifyTruecallerUseCase,
+                featureFlags = featureFlags,
             )
     }
 
@@ -121,15 +128,64 @@ public class AuthOrchestratorTest {
     }
 
     @Test
-    public fun `completeWithTruecaller delegates to SaveSessionUseCase`(): Unit =
+    public fun `completeWithTruecaller — flag OFF — delegates to anonymous sign-in`(): Unit =
         runTest {
             val user = mockk<FirebaseUser>()
-            coEvery { saveSessionUseCase.saveAnonymousWithPhone("+91123") } returns AuthResult.Success(user)
+            every { featureFlags.truecallerServerVerify() } returns false
+            coEvery { saveSessionUseCase.saveAnonymousWithPhone("1234") } returns AuthResult.Success(user)
 
-            val result = orchestrator.completeWithTruecaller("+91123")
+            val success = TruecallerAuthResult.Success(
+                payload = "payload",
+                signature = "sig",
+                signatureAlgorithm = "SHA512withRSA",
+                phoneLastFour = "1234",
+            )
+            val result = orchestrator.completeWithTruecaller(success)
 
             assertThat(result).isInstanceOf(AuthResult.Success::class.java)
-            coVerify { saveSessionUseCase.saveAnonymousWithPhone("+91123") }
+            coVerify { saveSessionUseCase.saveAnonymousWithPhone("1234") }
+        }
+
+    @Test
+    public fun `completeWithTruecaller — flag ON — calls VerifyTruecallerUseCase and saves session`(): Unit =
+        runTest {
+            val user = mockk<FirebaseUser> { every { uid } returns "verified-uid" }
+            every { featureFlags.truecallerServerVerify() } returns true
+            coEvery {
+                verifyTruecallerUseCase.invoke("payload-b64", "sig-b64", "SHA512withRSA")
+            } returns Result.success(user)
+            coEvery { saveSessionUseCase.save(user, "5678") } returns Unit
+
+            val success = TruecallerAuthResult.Success(
+                payload = "payload-b64",
+                signature = "sig-b64",
+                signatureAlgorithm = "SHA512withRSA",
+                phoneLastFour = "5678",
+            )
+            val result = orchestrator.completeWithTruecaller(success)
+
+            assertThat(result).isInstanceOf(AuthResult.Success::class.java)
+            coVerify { verifyTruecallerUseCase.invoke("payload-b64", "sig-b64", "SHA512withRSA") }
+            coVerify { saveSessionUseCase.save(user, "5678") }
+        }
+
+    @Test
+    public fun `completeWithTruecaller — flag ON — returns Error when VerifyTruecallerUseCase fails`(): Unit =
+        runTest {
+            every { featureFlags.truecallerServerVerify() } returns true
+            coEvery {
+                verifyTruecallerUseCase.invoke(any(), any(), any())
+            } returns Result.failure(Exception("signature invalid"))
+
+            val success = TruecallerAuthResult.Success(
+                payload = "p",
+                signature = "s",
+                signatureAlgorithm = "SHA512withRSA",
+                phoneLastFour = "9999",
+            )
+            val result = orchestrator.completeWithTruecaller(success)
+
+            assertThat(result).isInstanceOf(AuthResult.Error.General::class.java)
         }
 
     @Test

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/TruecallerLoginUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/TruecallerLoginUseCaseTest.kt
@@ -20,9 +20,15 @@ public class TruecallerLoginUseCaseTest {
     }
 
     @Test
-    public fun `emits Success with last 4 digits when SDK calls onSuccessProfileShared`(): Unit =
+    public fun `emits Success with payload, signature, algorithm and last 4 digits when SDK calls onSuccessProfileShared`(): Unit =
         runTest {
-            val profile = TrueProfile.Builder("Test", "").build().also { it.phoneNumber = "+919876540000" }
+            val profile =
+                TrueProfile.Builder("Test", "").build().also {
+                    it.phoneNumber = "+919876540000"
+                    it.payload = "base64payload=="
+                    it.signature = "base64signature=="
+                    it.signatureAlgorithm = "SHA512withRSA"
+                }
 
             useCase.simulateSdkCallback { callback ->
                 callback.onSuccessProfileShared(profile)
@@ -30,7 +36,34 @@ public class TruecallerLoginUseCaseTest {
 
             val result = useCase.resultFlow.first()
             assertThat(result).isInstanceOf(TruecallerAuthResult.Success::class.java)
-            assertThat((result as TruecallerAuthResult.Success).phoneLastFour).isEqualTo("0000")
+            val success = result as TruecallerAuthResult.Success
+            assertThat(success.phoneLastFour).isEqualTo("0000")
+            assertThat(success.payload).isEqualTo("base64payload==")
+            assertThat(success.signature).isEqualTo("base64signature==")
+            assertThat(success.signatureAlgorithm).isEqualTo("SHA512withRSA")
+        }
+
+    @Test
+    public fun `emits Success with empty strings for payload and signature when SDK provides null values`(): Unit =
+        runTest {
+            val profile =
+                TrueProfile.Builder("Test", "").build().also {
+                    it.phoneNumber = "+919876541111"
+                    // payload, signature, signatureAlgorithm not set — will be null from SDK
+                }
+
+            useCase.simulateSdkCallback { callback ->
+                callback.onSuccessProfileShared(profile)
+            }
+
+            val result = useCase.resultFlow.first()
+            assertThat(result).isInstanceOf(TruecallerAuthResult.Success::class.java)
+            val success = result as TruecallerAuthResult.Success
+            assertThat(success.phoneLastFour).isEqualTo("1111")
+            // Null-safe: empty string fallback ensures downstream code is not null-unsafe
+            assertThat(success.payload).isNotNull()
+            assertThat(success.signature).isNotNull()
+            assertThat(success.signatureAlgorithm).isNotNull()
         }
 
     @Test

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCaseTest.kt
@@ -1,0 +1,122 @@
+package com.homeservices.customer.domain.auth
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.homeservices.customer.data.auth.remote.AuthApi
+import com.homeservices.customer.data.auth.remote.dto.TruecallerVerifyRequest
+import com.homeservices.customer.data.auth.remote.dto.TruecallerVerifyResponse
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+public class VerifyTruecallerUseCaseTest {
+    private lateinit var authApi: AuthApi
+    private lateinit var firebaseAuth: FirebaseAuth
+    private lateinit var useCase: VerifyTruecallerUseCase
+
+    @BeforeEach
+    public fun setUp() {
+        authApi = mockk()
+        firebaseAuth = mockk()
+        useCase = VerifyTruecallerUseCase(authApi, firebaseAuth)
+    }
+
+    @Test
+    public fun `invoke returns Success when API returns customToken and Firebase signs in`(): Unit =
+        runTest {
+            val mockUser = mockk<FirebaseUser> { every { uid } returns "phone-uid-abc" }
+            val mockAuthResult = mockk<AuthResult> { every { user } returns mockUser }
+
+            coEvery {
+                authApi.verifyTruecaller(
+                    TruecallerVerifyRequest(
+                        payload = "payload-b64",
+                        signature = "sig-b64",
+                        signatureAlgorithm = "SHA512withRSA",
+                        fcmToken = null,
+                    ),
+                )
+            } returns TruecallerVerifyResponse(
+                firebaseCustomToken = "firebase-custom-token-xyz",
+                sessionExpiresAt = 9_999_999L,
+            )
+
+            every {
+                firebaseAuth.signInWithCustomToken("firebase-custom-token-xyz")
+            } returns Tasks.forResult(mockAuthResult)
+
+            val result = useCase.invoke(
+                payload = "payload-b64",
+                signature = "sig-b64",
+                signatureAlgorithm = "SHA512withRSA",
+            )
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrNull()).isSameAs(mockUser)
+        }
+
+    @Test
+    public fun `invoke returns Failure when API call throws HTTP exception`(): Unit =
+        runTest {
+            coEvery {
+                authApi.verifyTruecaller(any())
+            } throws HttpException(Response.error<TruecallerVerifyResponse>(400, okhttp3.ResponseBody.create(null, "")))
+
+            val result = useCase.invoke(
+                payload = "payload-b64",
+                signature = "bad-sig",
+                signatureAlgorithm = "SHA512withRSA",
+            )
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(HttpException::class.java)
+        }
+
+    @Test
+    public fun `invoke returns Failure when API succeeds but Firebase signInWithCustomToken fails`(): Unit =
+        runTest {
+            coEvery {
+                authApi.verifyTruecaller(any())
+            } returns TruecallerVerifyResponse(
+                firebaseCustomToken = "custom-token",
+                sessionExpiresAt = 9_999_999L,
+            )
+
+            every {
+                firebaseAuth.signInWithCustomToken("custom-token")
+            } returns Tasks.forException(Exception("Firebase sign-in failed"))
+
+            val result = useCase.invoke(
+                payload = "p",
+                signature = "s",
+                signatureAlgorithm = "SHA512withRSA",
+            )
+
+            assertThat(result.isFailure).isTrue()
+        }
+
+    @Test
+    public fun `invoke returns Failure when Firebase user is null after sign-in`(): Unit =
+        runTest {
+            coEvery { authApi.verifyTruecaller(any()) } returns TruecallerVerifyResponse(
+                firebaseCustomToken = "ct",
+                sessionExpiresAt = 0L,
+            )
+
+            val mockAuthResult = mockk<AuthResult> { every { user } returns null }
+            every { firebaseAuth.signInWithCustomToken("ct") } returns Tasks.forResult(mockAuthResult)
+
+            val result = useCase.invoke("p", "s", "SHA512withRSA")
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()?.message).contains("null user")
+        }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCaseTest.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.HttpException
 import retrofit2.Response
 
@@ -68,7 +70,7 @@ public class VerifyTruecallerUseCaseTest {
         runTest {
             coEvery {
                 authApi.verifyTruecaller(any())
-            } throws HttpException(Response.error<TruecallerVerifyResponse>(400, okhttp3.ResponseBody.create(null, "")))
+            } throws HttpException(Response.error<TruecallerVerifyResponse>(400, "".toResponseBody("application/json".toMediaTypeOrNull())))
 
             val result = useCase.invoke(
                 payload = "payload-b64",

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/auth/AuthViewModelTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/auth/AuthViewModelTest.kt
@@ -99,12 +99,18 @@ public class AuthViewModelTest {
     public fun `Truecaller Success with AuthResult Error transitions to Error state`(): Unit =
         runTest(testDispatcher) {
             val activity = mockk<FragmentActivity>()
+            val truecallerSuccess = TruecallerAuthResult.Success(
+                payload = "payload-b64",
+                signature = "sig-b64",
+                signatureAlgorithm = "SHA512withRSA",
+                phoneLastFour = "0000",
+            )
             every { orchestrator.start(activity, activity) } returns AuthOrchestrator.StartResult.TruecallerLaunched
-            coEvery { orchestrator.completeWithTruecaller("0000") } returns
+            coEvery { orchestrator.completeWithTruecaller(truecallerSuccess) } returns
                 AuthResult.Error.General(RuntimeException("session fail"))
 
             viewModel.initAuth(activity)
-            truecallerResultFlow.emit(TruecallerAuthResult.Success("0000"))
+            truecallerResultFlow.emit(truecallerSuccess)
 
             val state = viewModel.uiState.value
             assertThat(state).isInstanceOf(AuthUiState.Error::class.java)
@@ -324,11 +330,17 @@ public class AuthViewModelTest {
             // Covers the false-branch of `if (authResult is AuthResult.Error)` in handleTruecallerResult
             val activity = mockk<FragmentActivity>()
             val user = mockk<FirebaseUser>()
+            val truecallerSuccess = TruecallerAuthResult.Success(
+                payload = "payload-b64",
+                signature = "sig-b64",
+                signatureAlgorithm = "SHA512withRSA",
+                phoneLastFour = "0000",
+            )
             every { orchestrator.start(activity, activity) } returns AuthOrchestrator.StartResult.TruecallerLaunched
-            coEvery { orchestrator.completeWithTruecaller("0000") } returns AuthResult.Success(user)
+            coEvery { orchestrator.completeWithTruecaller(truecallerSuccess) } returns AuthResult.Success(user)
 
             viewModel.initAuth(activity)
-            truecallerResultFlow.emit(TruecallerAuthResult.Success("0000"))
+            truecallerResultFlow.emit(truecallerSuccess)
 
             assertThat(viewModel.uiState.value).isNotInstanceOf(AuthUiState.Error::class.java)
         }


### PR DESCRIPTION
## Summary

- Closes P0 audit finding: Truecaller auth trusted client-claimed phone number with no server-side cryptographic verification (ADR-0005 Phase-2 gap).
- **api**: new `POST /v1/auth/truecaller/verify` — verifies Truecaller RSA signature against the Truecaller public key API (cached 24h in Cosmos `system` container). On success, mints a Firebase custom token for the verified phone number.
- **customer-app**: `VerifyTruecallerUseCase` + `AuthApiModule` (@PublicOkHttpClient) + `FeatureFlags` abstraction. `TruecallerLoginUseCase` now emits `(payload, signature, signatureAlgorithm, phoneLastFour)`. `AuthOrchestrator.completeWithTruecaller()` branches on `truecaller_server_verify_v2` GrowthBook flag.
- The **anonymous sign-in path is PRESERVED**. Flag defaults to OFF. E11-S01b (Wave 3, 7-day soak) removes the anonymous path.

## TDD order followed

1. `api/tests/services/truecaller.service.test.ts` committed before impl
2. `api/tests/functions/auth/truecaller-verify.test.ts` committed before impl
3. Android `VerifyTruecallerUseCaseTest.kt` + updated `TruecallerLoginUseCaseTest.kt` committed before impl
4. All impl committed after tests

## Test plan

- [ ] `cd api && pnpm typecheck && pnpm lint --max-warnings 0 && pnpm test:coverage` — 126 files, 955 tests pass
- [ ] `cd customer-app && ./gradlew testDebugUnitTest koverVerify` — BUILD SUCCESSFUL, all thresholds met
- [ ] CI green on push

## Notes

- `truecaller_server_verify_v2` is default OFF. Flip ON via GrowthBook (E13-S05 wires the live SDK).
- `BuildConfigFeatureFlags` hardcodes `false`; CI stays green without a live GrowthBook.
- TODO comment in handler for migrating UID from phoneNumber to stable internal ID (E11-S01b follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)