### PR TITLE
feat(E11-S03): Play Integrity attestation on MARK_REACHED + payment-confirm + KYC

### DIFF
--- a/api/src/functions/active-job.ts
+++ b/api/src/functions/active-job.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { type HttpHandler, type InvocationContext, app } from '@azure/functions';
 import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
+import { requireIntegrity } from '../middleware/requireIntegrity.js';
 import { bookingRepo, updateBookingFields } from '../cosmos/booking-repository.js';
 import { bookingEventRepo } from '../cosmos/booking-event-repository.js';
 import { catalogueRepo } from '../cosmos/catalogue-repository.js';
@@ -155,5 +156,8 @@ app.http('getActiveJob', {
 app.http('transitionActiveJobStatus', {
   route: 'v1/technicians/active-job/{bookingId}/transition',
   methods: ['PATCH'],
-  handler: transitionStatusHandler,
+  // requireIntegrity is applied to the REACHED (and all) status transitions.
+  // Non-strict by default: absent/invalid token warns to Sentry but allows through.
+  // Set PLAY_INTEGRITY_STRICT=true in production to enforce rejection.
+  handler: requireIntegrity(transitionStatusHandler),
 });

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -3,6 +3,7 @@ import type { HttpHandler } from '@azure/functions';
 import { app } from '@azure/functions';
 import * as Sentry from '@sentry/node';
 import { withRateLimit } from '../middleware/withRateLimit.js';
+import { requireIntegrity } from '../middleware/requireIntegrity.js';
 import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
 import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
 import { RequestAddOnBodySchema, ApproveAddOnsBodySchema } from '../schemas/addon-approval.js';
@@ -277,7 +278,7 @@ const createBookingRateLimiter = withRateLimit({
 });
 
 app.http('createBooking', { route: 'v1/bookings', methods: ['POST'], handler: createBookingRateLimiter(createBookingHandler) });
-app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: confirmBookingHandler });
+app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: requireIntegrity(confirmBookingHandler) });
 app.http('getMyBookings', { route: 'v1/bookings', methods: ['GET'], handler: getMyBookingsHandler });
 app.http('getBooking', { route: 'v1/bookings/{id}', methods: ['GET'], handler: getBookingHandler });
 app.http('requestAddon', { route: 'v1/bookings/{id}/request-addon', methods: ['POST'], handler: requestAddonHandler });

--- a/api/src/functions/integrity/nonce.ts
+++ b/api/src/functions/integrity/nonce.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from 'node:crypto';
+import { app, type HttpHandler, type HttpRequest, type HttpResponseInit, type InvocationContext } from '@azure/functions';
+import '../../bootstrap.js';
+import { withRateLimit } from '../../middleware/withRateLimit.js';
+
+/**
+ * GET /v1/integrity/nonce
+ *
+ * Returns a one-time UUID nonce the mobile client must include when requesting a Play Integrity
+ * token.  The resulting token (with `requestHash = nonce`) is then sent back on the
+ * high-value mutation as the X-Integrity-Token header.
+ *
+ * Rate-limited to 20 requests per minute per IP to prevent abuse of the nonce issuance path.
+ */
+export const getNonceHandler: HttpHandler = async (
+  _req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> => {
+  return {
+    status: 200,
+    jsonBody: { nonce: randomUUID() },
+  };
+};
+
+app.http('integrityNonce', {
+  route: 'v1/integrity/nonce',
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  handler: withRateLimit({
+    buckets: { ip: { capacity: 20, refillPerSec: 20 / 60 } },
+  })(getNonceHandler),
+});

--- a/api/src/middleware/requireIntegrity.ts
+++ b/api/src/middleware/requireIntegrity.ts
@@ -1,0 +1,142 @@
+import type { HttpHandler, HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import * as Sentry from '@sentry/node';
+
+/**
+ * Options passed to individual route wrappers.
+ */
+export interface RequireIntegrityOptions {
+  /**
+   * The nonce value that was issued for this specific request.
+   * When provided, the middleware checks that the token's `requestHash` matches.
+   * If omitted, the nonce match check is skipped (useful for stateless verification).
+   */
+  expectedNonce?: string;
+}
+
+interface PlayIntegrityVerdict {
+  tokenPayloadExternal?: {
+    requestDetails?: {
+      requestPackageName?: string;
+      requestHash?: string;
+    };
+    appIntegrity?: {
+      appRecognitionVerdict?: string;
+    };
+  };
+}
+
+const DEBUG_BYPASS_TOKEN = 'debug-bypass';
+const STRICT_ENV_VAR = 'PLAY_INTEGRITY_STRICT';
+const PACKAGE_NAME_ENV_VAR = 'PLAY_INTEGRITY_PACKAGE_NAME';
+
+function isStrictMode(): boolean {
+  return process.env[STRICT_ENV_VAR] === 'true';
+}
+
+function isDevEnv(): boolean {
+  return process.env[STRICT_ENV_VAR] !== 'true';
+}
+
+async function decodeIntegrityToken(
+  token: string,
+): Promise<PlayIntegrityVerdict> {
+  const packageName =
+    process.env[PACKAGE_NAME_ENV_VAR] ?? 'com.homeservices';
+  const url = `https://playintegrity.googleapis.com/v1/${packageName}:decodeIntegrityToken`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ integrity_token: token }),
+  });
+  if (!response.ok) {
+    throw new Error(`Play Integrity API returned HTTP ${response.status}`);
+  }
+  return response.json() as Promise<PlayIntegrityVerdict>;
+}
+
+/**
+ * Middleware that validates the X-Integrity-Token header using the Play Integrity API.
+ *
+ * Behaviour:
+ * - In strict mode (`PLAY_INTEGRITY_STRICT=true`): absent or invalid tokens are rejected (403).
+ * - In non-strict mode (default/dev/staging): absent tokens warn to Sentry but allow through.
+ *   The `debug-bypass` token value is always accepted in non-strict mode without calling Google.
+ * - On Google API errors: fail-open (warn to Sentry, allow through) to avoid 503-ing real traffic.
+ *
+ * @param handler - The inner handler to wrap.
+ * @param opts    - Per-route options (e.g. expected nonce for this request).
+ */
+export function requireIntegrity(
+  handler: HttpHandler,
+  opts: RequireIntegrityOptions = {},
+): HttpHandler {
+  return async (req: HttpRequest, ctx: InvocationContext): Promise<HttpResponseInit> => {
+    const token = req.headers.get('x-integrity-token');
+    const strict = isStrictMode();
+
+    // ── Token absent ─────────────────────────────────────────────────────────
+    if (!token) {
+      if (strict) {
+        return {
+          status: 403,
+          jsonBody: { code: 'INTEGRITY_MISSING', message: 'Play Integrity token required' },
+        };
+      }
+      // Non-strict: warn + allow
+      Sentry.withScope((scope) => {
+        scope.setLevel('warning');
+        Sentry.captureMessage('Play Integrity token missing on high-value mutation (non-strict mode)');
+      });
+      return handler(req, ctx) as Promise<HttpResponseInit>;
+    }
+
+    // ── Debug bypass (non-strict dev/staging only) ────────────────────────────
+    if (token === DEBUG_BYPASS_TOKEN && isDevEnv()) {
+      return handler(req, ctx) as Promise<HttpResponseInit>;
+    }
+
+    // ── Verify token with Google ──────────────────────────────────────────────
+    try {
+      const verdict = await decodeIntegrityToken(token);
+      const payload = verdict.tokenPayloadExternal;
+      const appVerdict = payload?.appIntegrity?.appRecognitionVerdict;
+      const requestHash = payload?.requestDetails?.requestHash;
+
+      // Check nonce if provided
+      const nonceOk =
+        opts.expectedNonce == null || requestHash === opts.expectedNonce;
+
+      const appOk = appVerdict != null && appVerdict !== 'UNAPPROACHABLE';
+
+      if (!appOk || !nonceOk) {
+        if (strict) {
+          return {
+            status: 403,
+            jsonBody: {
+              code: 'INTEGRITY_FAILED',
+              message: 'Play Integrity token validation failed',
+            },
+          };
+        }
+        // Non-strict: warn + allow
+        Sentry.withScope((scope) => {
+          scope.setLevel('warning');
+          Sentry.captureMessage(
+            `Play Integrity validation failed (non-strict): verdict=${appVerdict ?? 'unknown'}, nonceOk=${nonceOk}`,
+          );
+        });
+      }
+
+      return handler(req, ctx) as Promise<HttpResponseInit>;
+    } catch (err: unknown) {
+      // Fail-open: Google API errors must not 503 real traffic
+      Sentry.withScope((scope) => {
+        scope.setLevel('warning');
+        Sentry.captureMessage(
+          `Play Integrity API call failed (fail-open): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+      return handler(req, ctx) as Promise<HttpResponseInit>;
+    }
+  };
+}

--- a/api/tests/functions/integrity/nonce.test.ts
+++ b/api/tests/functions/integrity/nonce.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpRequest, InvocationContext, type HttpResponseInit } from '@azure/functions';
+
+vi.mock('../../../src/middleware/withRateLimit.js', () => ({
+  withRateLimit:
+    (_options: unknown) =>
+    <T>(handler: T): T =>
+      handler,
+}));
+
+vi.mock('../../../src/cosmos/rate-limit-repository.js', () => ({
+  consume: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+describe('GET /v1/integrity/nonce', () => {
+  let getNonceHandler: typeof import('../../../src/functions/integrity/nonce.js').getNonceHandler;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const mod = await import('../../../src/functions/integrity/nonce.js');
+    getNonceHandler = mod.getNonceHandler;
+  });
+
+  it('returns 200 with a nonce field that is a valid UUID v4', async () => {
+    const req = new HttpRequest({
+      url: 'http://localhost/api/v1/integrity/nonce',
+      method: 'GET',
+      headers: {},
+    });
+
+    const res = (await getNonceHandler(req, new InvocationContext())) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as { nonce: string };
+    expect(body).toHaveProperty('nonce');
+    // UUID v4 regex
+    expect(body.nonce).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('returns a different nonce on every call', async () => {
+    const req = () =>
+      new HttpRequest({
+        url: 'http://localhost/api/v1/integrity/nonce',
+        method: 'GET',
+        headers: {},
+      });
+
+    const res1 = (await getNonceHandler(req(), new InvocationContext())) as HttpResponseInit;
+    const res2 = (await getNonceHandler(req(), new InvocationContext())) as HttpResponseInit;
+
+    const nonce1 = (res1.jsonBody as { nonce: string }).nonce;
+    const nonce2 = (res2.jsonBody as { nonce: string }).nonce;
+    expect(nonce1).not.toBe(nonce2);
+  });
+
+  it('is wrapped with rate limiting (20 req/min/ip bucket)', async () => {
+    // Verify the rate-limit wrapper was applied by checking the consume mock is invoked
+    // when withRateLimit is NOT mocked out (integration-level assertion).
+    // In this unit test the mock passthrough ensures the handler itself executes.
+    // The rate-limit integration is covered by withRateLimit middleware unit tests.
+    const req = new HttpRequest({
+      url: 'http://localhost/api/v1/integrity/nonce',
+      method: 'GET',
+      headers: { 'x-forwarded-for': '1.2.3.4' },
+    });
+
+    const res = (await getNonceHandler(req, new InvocationContext())) as HttpResponseInit;
+    expect(res.status).toBe(200);
+  });
+});

--- a/api/tests/middleware/requireIntegrity.test.ts
+++ b/api/tests/middleware/requireIntegrity.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HttpRequest, InvocationContext, type HttpResponseInit } from '@azure/functions';
+
+// Mock Sentry before import
+vi.mock('@sentry/node', () => ({
+  withScope: vi.fn((_cb: (scope: { setLevel: () => void }) => void) =>
+    _cb({ setLevel: vi.fn() }),
+  ),
+  captureMessage: vi.fn(),
+}));
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+/**
+ * Build a minimal PATCH request with an optional X-Integrity-Token header.
+ */
+function makeReq(opts: {
+  url?: string;
+  token?: string;
+  headers?: Record<string, string>;
+}): HttpRequest {
+  return new HttpRequest({
+    url: opts.url ?? 'http://localhost/api/v1/technicians/active-job/bk-1/transition',
+    method: 'PATCH',
+    headers: {
+      ...(opts.token ? { 'x-integrity-token': opts.token } : {}),
+      ...(opts.headers ?? {}),
+    },
+    body: { string: '{}' },
+  });
+}
+
+/** Dummy handler that always returns 200 OK. */
+const okHandler = vi.fn().mockResolvedValue({ status: 200, jsonBody: { ok: true } });
+
+describe('requireIntegrity middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    // Default: non-strict mode (PLAY_INTEGRITY_STRICT not set to "true")
+    delete process.env['PLAY_INTEGRITY_STRICT'];
+    delete process.env['PLAY_INTEGRITY_PACKAGE_NAME'];
+  });
+
+  afterEach(() => {
+    delete process.env['PLAY_INTEGRITY_STRICT'];
+    delete process.env['PLAY_INTEGRITY_PACKAGE_NAME'];
+  });
+
+  // ─── Non-strict mode (default / dev / staging) ───────────────────────────
+
+  it('absent token + non-strict → warns to Sentry and allows (200)', async () => {
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+    const { captureMessage } = await import('@sentry/node');
+
+    const wrapped = requireIntegrity(okHandler);
+    const res = (await wrapped(makeReq({}), new InvocationContext())) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect(captureMessage).toHaveBeenCalledOnce();
+    const msg = (captureMessage as MockFn).mock.calls[0]![0] as string;
+    expect(msg).toMatch(/missing/i);
+  });
+
+  it('debug-bypass token + non-strict → allows (200) without calling Google API', async () => {
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+
+    const wrapped = requireIntegrity(okHandler);
+    const res = (await wrapped(
+      makeReq({ token: 'debug-bypass' }),
+      new InvocationContext(),
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+  });
+
+  it('debug-bypass token + strict=false env → allows (200)', async () => {
+    process.env['PLAY_INTEGRITY_STRICT'] = 'false';
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+
+    const wrapped = requireIntegrity(okHandler);
+    const res = (await wrapped(
+      makeReq({ token: 'debug-bypass' }),
+      new InvocationContext(),
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+  });
+
+  // ─── Strict mode ─────────────────────────────────────────────────────────
+
+  it('absent token + strict mode → rejects with 403 INTEGRITY_MISSING', async () => {
+    process.env['PLAY_INTEGRITY_STRICT'] = 'true';
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+
+    const wrapped = requireIntegrity(okHandler);
+    const res = (await wrapped(makeReq({}), new InvocationContext())) as HttpResponseInit;
+
+    expect(res.status).toBe(403);
+    expect((res.jsonBody as { code: string }).code).toBe('INTEGRITY_MISSING');
+  });
+
+  it('invalid token (Google API returns bad verdict) + strict → rejects 403 INTEGRITY_FAILED', async () => {
+    process.env['PLAY_INTEGRITY_STRICT'] = 'true';
+    process.env['PLAY_INTEGRITY_PACKAGE_NAME'] = 'com.homeservices.technician';
+
+    // Mock the Google decodeIntegrityToken fetch call to return an UNAPPROACHABLE verdict
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tokenPayloadExternal: {
+          requestDetails: { requestPackageName: 'com.homeservices.technician', requestHash: 'wrong-nonce' },
+          appIntegrity: { appRecognitionVerdict: 'UNAPPROACHABLE' },
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+
+    const wrapped = requireIntegrity(okHandler, { expectedNonce: 'correct-nonce' });
+    const res = (await wrapped(
+      makeReq({ token: 'some-real-looking-token' }),
+      new InvocationContext(),
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(403);
+    expect((res.jsonBody as { code: string }).code).toBe('INTEGRITY_FAILED');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('valid token with matching nonce + strict → allows (200)', async () => {
+    process.env['PLAY_INTEGRITY_STRICT'] = 'true';
+    process.env['PLAY_INTEGRITY_PACKAGE_NAME'] = 'com.homeservices.technician';
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tokenPayloadExternal: {
+          requestDetails: {
+            requestPackageName: 'com.homeservices.technician',
+            requestHash: 'matching-nonce',
+          },
+          appIntegrity: { appRecognitionVerdict: 'PLAY_RECOGNIZED' },
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+
+    const wrapped = requireIntegrity(okHandler, { expectedNonce: 'matching-nonce' });
+    const res = (await wrapped(
+      makeReq({ token: 'valid-token' }),
+      new InvocationContext(),
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+
+  // ─── Fail-open on Google API errors ──────────────────────────────────────
+
+  it('Google API throws + non-strict → warns and allows (200)', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network error'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { requireIntegrity } = await import('../../src/middleware/requireIntegrity.js');
+    const { captureMessage } = await import('@sentry/node');
+
+    const wrapped = requireIntegrity(okHandler, { expectedNonce: 'some-nonce' });
+    const res = (await wrapped(
+      makeReq({ token: 'some-token' }),
+      new InvocationContext(),
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect(captureMessage).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/customer-app/app/build.gradle.kts
+++ b/customer-app/app/build.gradle.kts
@@ -423,6 +423,10 @@ kover {
                     // ProfileScreen — Compose UI composable, same rationale as other *Kt screen classes
                     "*.ProfileScreenKt",
                     "*.ProfileScreenKt\$*",
+                    // IntegrityModule — Hilt @Provides DI wiring for Play Integrity SDK setup
+                    "*.domain.integrity.di.*",
+                    // IntegrityApiService — Retrofit interface, methods invoked by Retrofit runtime
+                    "*.data.integrity.IntegrityApiService",
                 )
             }
         }
@@ -494,6 +498,9 @@ dependencies {
     implementation(libs.moshi.kotlin)
     ksp(libs.moshi.kotlin.codegen)
     implementation(libs.coil.compose)
+
+    // Play Integrity API
+    implementation(libs.play.integrity)
 
     // Payments + Maps
     implementation(libs.razorpay.checkout)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepository.kt
@@ -17,6 +17,7 @@ public interface BookingRepository {
         paymentId: String,
         orderId: String,
         signature: String,
+        integrityToken: String? = null,
     ): Flow<Result<String>>
 
     public fun getPendingAddOns(bookingId: String): Flow<Result<List<PendingAddOn>>>

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/BookingRepositoryImpl.kt
@@ -50,6 +50,7 @@ internal class BookingRepositoryImpl
             paymentId: String,
             orderId: String,
             signature: String,
+            integrityToken: String?,
         ): Flow<Result<String>> =
             flow {
                 emit(
@@ -62,6 +63,7 @@ internal class BookingRepositoryImpl
                                     razorpayOrderId = orderId,
                                     razorpaySignature = signature,
                                 ),
+                                integrityToken = integrityToken,
                             ).bookingId
                     },
                 )

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
@@ -10,6 +10,7 @@ import com.homeservices.customer.data.booking.remote.dto.CustomerBookingsRespons
 import com.homeservices.customer.data.booking.remote.dto.GetBookingResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 
@@ -23,6 +24,7 @@ public interface BookingApiService {
     public suspend fun confirmBooking(
         @Path("id") bookingId: String,
         @Body body: ConfirmBookingRequestDto,
+        @Header("X-Integrity-Token") integrityToken: String? = null,
     ): ConfirmBookingResponseDto
 
     @GET("v1/bookings/{id}")

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/integrity/IntegrityApiService.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/integrity/IntegrityApiService.kt
@@ -1,0 +1,12 @@
+package com.homeservices.customer.data.integrity
+
+import retrofit2.http.GET
+
+public interface IntegrityApiService {
+    @GET("v1/integrity/nonce")
+    public suspend fun getNonce(): IntegrityNonceResponseDto
+}
+
+public data class IntegrityNonceResponseDto(
+    val nonce: String,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCase.kt
@@ -1,18 +1,41 @@
 package com.homeservices.customer.domain.booking
 
 import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.data.integrity.IntegrityApiService
+import com.homeservices.customer.domain.integrity.IntegrityAttestor
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 public class ConfirmBookingUseCase
     @Inject
     constructor(
         private val repo: BookingRepository,
+        private val integrityAttestor: IntegrityAttestor,
+        private val integrityApiService: IntegrityApiService,
     ) {
         public operator fun invoke(
             bookingId: String,
             paymentId: String,
             orderId: String,
             signature: String,
-        ): Flow<Result<String>> = repo.confirmBooking(bookingId, paymentId, orderId, signature)
+        ): Flow<Result<String>> =
+            flow {
+                // Fetch nonce → attest → attach integrity token.
+                // If attestation fails, proceed without the token (fail-open, server will warn but allow).
+                val integrityToken: String? =
+                    runCatching {
+                        val nonce = integrityApiService.getNonce().nonce
+                        integrityAttestor.attest(nonce).getOrThrow()
+                    }.getOrNull()
+
+                val result = repo.confirmBooking(
+                    bookingId = bookingId,
+                    paymentId = paymentId,
+                    orderId = orderId,
+                    signature = signature,
+                    integrityToken = integrityToken,
+                )
+                result.collect { emit(it) }
+            }
     }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCase.kt
@@ -29,13 +29,14 @@ public class ConfirmBookingUseCase
                         integrityAttestor.attest(nonce).getOrThrow()
                     }.getOrNull()
 
-                val result = repo.confirmBooking(
-                    bookingId = bookingId,
-                    paymentId = paymentId,
-                    orderId = orderId,
-                    signature = signature,
-                    integrityToken = integrityToken,
-                )
+                val result =
+                    repo.confirmBooking(
+                        bookingId = bookingId,
+                        paymentId = paymentId,
+                        orderId = orderId,
+                        signature = signature,
+                        integrityToken = integrityToken,
+                    )
                 result.collect { emit(it) }
             }
     }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/IntegrityAttestor.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/IntegrityAttestor.kt
@@ -1,0 +1,5 @@
+package com.homeservices.customer.domain.integrity
+
+public interface IntegrityAttestor {
+    public suspend fun attest(nonce: String): Result<String>
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestor.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestor.kt
@@ -1,0 +1,34 @@
+package com.homeservices.customer.domain.integrity
+
+import android.content.Context
+import com.google.android.play.core.integrity.IntegrityManagerFactory
+import com.google.android.play.core.integrity.IntegrityTokenRequest
+import kotlinx.coroutines.tasks.await
+import javax.inject.Singleton
+
+/**
+ * Production implementation of [IntegrityAttestor] backed by the Play Integrity API.
+ *
+ * Debug-bypass mode (injected via Hilt in debug builds, or set directly in tests):
+ * when [debugBypass] is true, [attest] returns `Result.success("debug-bypass")` immediately
+ * without calling the Play Integrity SDK. The API server accepts this value when
+ * `PLAY_INTEGRITY_STRICT=false` (staging/dev environments).
+ */
+@Singleton
+public class PlayIntegrityAttestor(
+    private val context: Context,
+    private val debugBypass: Boolean = false,
+) : IntegrityAttestor {
+
+        override suspend fun attest(nonce: String): Result<String> {
+            if (debugBypass) return Result.success("debug-bypass")
+            return runCatching {
+                val manager = IntegrityManagerFactory.create(context)
+                val request =
+                    IntegrityTokenRequest.builder()
+                        .setNonce(nonce)
+                        .build()
+                manager.requestIntegrityToken(request).await().token()
+            }
+        }
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestor.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestor.kt
@@ -19,16 +19,16 @@ public class PlayIntegrityAttestor(
     private val context: Context,
     private val debugBypass: Boolean = false,
 ) : IntegrityAttestor {
-
-        override suspend fun attest(nonce: String): Result<String> {
-            if (debugBypass) return Result.success("debug-bypass")
-            return runCatching {
-                val manager = IntegrityManagerFactory.create(context)
-                val request =
-                    IntegrityTokenRequest.builder()
-                        .setNonce(nonce)
-                        .build()
-                manager.requestIntegrityToken(request).await().token()
-            }
+    override suspend fun attest(nonce: String): Result<String> {
+        if (debugBypass) return Result.success("debug-bypass")
+        return runCatching {
+            val manager = IntegrityManagerFactory.create(context)
+            val request =
+                IntegrityTokenRequest
+                    .builder()
+                    .setNonce(nonce)
+                    .build()
+            manager.requestIntegrityToken(request).await().token()
         }
     }
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/di/IntegrityModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/di/IntegrityModule.kt
@@ -1,0 +1,47 @@
+package com.homeservices.customer.domain.integrity.di
+
+import android.content.Context
+import com.homeservices.customer.BuildConfig
+import com.homeservices.customer.data.booking.di.AuthOkHttpClient
+import com.homeservices.customer.data.integrity.IntegrityApiService
+import com.homeservices.customer.domain.integrity.IntegrityAttestor
+import com.homeservices.customer.domain.integrity.PlayIntegrityAttestor
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+public object IntegrityModule {
+
+    @Provides
+    @Singleton
+    public fun providePlayIntegrityAttestor(
+        @ApplicationContext context: Context,
+    ): PlayIntegrityAttestor = PlayIntegrityAttestor(context, debugBypass = BuildConfig.DEBUG)
+
+    @Provides
+    @Singleton
+    public fun provideIntegrityAttestor(impl: PlayIntegrityAttestor): IntegrityAttestor = impl
+
+    @Provides
+    @Singleton
+    public fun provideIntegrityApiService(
+        @AuthOkHttpClient client: OkHttpClient,
+        moshi: Moshi,
+    ): IntegrityApiService =
+        Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.API_BASE_URL + "/")
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(client)
+            .build()
+            .create(IntegrityApiService::class.java)
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/di/IntegrityModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/integrity/di/IntegrityModule.kt
@@ -20,7 +20,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 public object IntegrityModule {
-
     @Provides
     @Singleton
     public fun providePlayIntegrityAttestor(

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImplTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImplTest.kt
@@ -29,6 +29,7 @@ public class TrackingRepositoryImplTest {
         override suspend fun confirmBooking(
             bookingId: String,
             body: ConfirmBookingRequestDto,
+            integrityToken: String?,
         ): ConfirmBookingResponseDto = error("not used")
 
         override suspend fun getBooking(bookingId: String): GetBookingResponseDto =

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/AuthOrchestratorTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/AuthOrchestratorTest.kt
@@ -134,12 +134,13 @@ public class AuthOrchestratorTest {
             every { featureFlags.truecallerServerVerify() } returns false
             coEvery { saveSessionUseCase.saveAnonymousWithPhone("1234") } returns AuthResult.Success(user)
 
-            val success = TruecallerAuthResult.Success(
-                payload = "payload",
-                signature = "sig",
-                signatureAlgorithm = "SHA512withRSA",
-                phoneLastFour = "1234",
-            )
+            val success =
+                TruecallerAuthResult.Success(
+                    payload = "payload",
+                    signature = "sig",
+                    signatureAlgorithm = "SHA512withRSA",
+                    phoneLastFour = "1234",
+                )
             val result = orchestrator.completeWithTruecaller(success)
 
             assertThat(result).isInstanceOf(AuthResult.Success::class.java)
@@ -156,12 +157,13 @@ public class AuthOrchestratorTest {
             } returns Result.success(user)
             coEvery { saveSessionUseCase.save(user, "5678") } returns Unit
 
-            val success = TruecallerAuthResult.Success(
-                payload = "payload-b64",
-                signature = "sig-b64",
-                signatureAlgorithm = "SHA512withRSA",
-                phoneLastFour = "5678",
-            )
+            val success =
+                TruecallerAuthResult.Success(
+                    payload = "payload-b64",
+                    signature = "sig-b64",
+                    signatureAlgorithm = "SHA512withRSA",
+                    phoneLastFour = "5678",
+                )
             val result = orchestrator.completeWithTruecaller(success)
 
             assertThat(result).isInstanceOf(AuthResult.Success::class.java)
@@ -177,12 +179,13 @@ public class AuthOrchestratorTest {
                 verifyTruecallerUseCase.invoke(any(), any(), any())
             } returns Result.failure(Exception("signature invalid"))
 
-            val success = TruecallerAuthResult.Success(
-                payload = "p",
-                signature = "s",
-                signatureAlgorithm = "SHA512withRSA",
-                phoneLastFour = "9999",
-            )
+            val success =
+                TruecallerAuthResult.Success(
+                    payload = "p",
+                    signature = "s",
+                    signatureAlgorithm = "SHA512withRSA",
+                    phoneLastFour = "9999",
+                )
             val result = orchestrator.completeWithTruecaller(success)
 
             assertThat(result).isInstanceOf(AuthResult.Error.General::class.java)

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/auth/VerifyTruecallerUseCaseTest.kt
@@ -11,11 +11,11 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.HttpException
 import retrofit2.Response
 
@@ -46,20 +46,22 @@ public class VerifyTruecallerUseCaseTest {
                         fcmToken = null,
                     ),
                 )
-            } returns TruecallerVerifyResponse(
-                firebaseCustomToken = "firebase-custom-token-xyz",
-                sessionExpiresAt = 9_999_999L,
-            )
+            } returns
+                TruecallerVerifyResponse(
+                    firebaseCustomToken = "firebase-custom-token-xyz",
+                    sessionExpiresAt = 9_999_999L,
+                )
 
             every {
                 firebaseAuth.signInWithCustomToken("firebase-custom-token-xyz")
             } returns Tasks.forResult(mockAuthResult)
 
-            val result = useCase.invoke(
-                payload = "payload-b64",
-                signature = "sig-b64",
-                signatureAlgorithm = "SHA512withRSA",
-            )
+            val result =
+                useCase.invoke(
+                    payload = "payload-b64",
+                    signature = "sig-b64",
+                    signatureAlgorithm = "SHA512withRSA",
+                )
 
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).isSameAs(mockUser)
@@ -72,11 +74,12 @@ public class VerifyTruecallerUseCaseTest {
                 authApi.verifyTruecaller(any())
             } throws HttpException(Response.error<TruecallerVerifyResponse>(400, "".toResponseBody("application/json".toMediaTypeOrNull())))
 
-            val result = useCase.invoke(
-                payload = "payload-b64",
-                signature = "bad-sig",
-                signatureAlgorithm = "SHA512withRSA",
-            )
+            val result =
+                useCase.invoke(
+                    payload = "payload-b64",
+                    signature = "bad-sig",
+                    signatureAlgorithm = "SHA512withRSA",
+                )
 
             assertThat(result.isFailure).isTrue()
             assertThat(result.exceptionOrNull()).isInstanceOf(HttpException::class.java)
@@ -87,20 +90,22 @@ public class VerifyTruecallerUseCaseTest {
         runTest {
             coEvery {
                 authApi.verifyTruecaller(any())
-            } returns TruecallerVerifyResponse(
-                firebaseCustomToken = "custom-token",
-                sessionExpiresAt = 9_999_999L,
-            )
+            } returns
+                TruecallerVerifyResponse(
+                    firebaseCustomToken = "custom-token",
+                    sessionExpiresAt = 9_999_999L,
+                )
 
             every {
                 firebaseAuth.signInWithCustomToken("custom-token")
             } returns Tasks.forException(Exception("Firebase sign-in failed"))
 
-            val result = useCase.invoke(
-                payload = "p",
-                signature = "s",
-                signatureAlgorithm = "SHA512withRSA",
-            )
+            val result =
+                useCase.invoke(
+                    payload = "p",
+                    signature = "s",
+                    signatureAlgorithm = "SHA512withRSA",
+                )
 
             assertThat(result.isFailure).isTrue()
         }
@@ -108,10 +113,11 @@ public class VerifyTruecallerUseCaseTest {
     @Test
     public fun `invoke returns Failure when Firebase user is null after sign-in`(): Unit =
         runTest {
-            coEvery { authApi.verifyTruecaller(any()) } returns TruecallerVerifyResponse(
-                firebaseCustomToken = "ct",
-                sessionExpiresAt = 0L,
-            )
+            coEvery { authApi.verifyTruecaller(any()) } returns
+                TruecallerVerifyResponse(
+                    firebaseCustomToken = "ct",
+                    sessionExpiresAt = 0L,
+                )
 
             val mockAuthResult = mockk<AuthResult> { every { user } returns null }
             every { firebaseAuth.signInWithCustomToken("ct") } returns Tasks.forResult(mockAuthResult)

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/ConfirmBookingUseCaseTest.kt
@@ -2,9 +2,13 @@ package com.homeservices.customer.domain.booking
 
 import com.google.common.truth.Truth.assertThat
 import com.homeservices.customer.data.booking.BookingRepository
+import com.homeservices.customer.data.integrity.IntegrityApiService
+import com.homeservices.customer.data.integrity.IntegrityNonceResponseDto
+import com.homeservices.customer.domain.integrity.IntegrityAttestor
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -12,20 +16,49 @@ import org.junit.Test
 
 public class ConfirmBookingUseCaseTest {
     private val repo: BookingRepository = mockk()
-    private val sut = ConfirmBookingUseCase(repo)
+    private val integrityAttestor: IntegrityAttestor = mockk()
+    private val integrityApiService: IntegrityApiService = mockk()
+    private val sut = ConfirmBookingUseCase(repo, integrityAttestor, integrityApiService)
 
     @Test
     public fun `invoke returns confirmed bookingId on success`(): Unit =
         runTest {
-            every { repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1") } returns flowOf(Result.success("bk-1"))
+            coEvery { integrityApiService.getNonce() } returns IntegrityNonceResponseDto("nonce-1")
+            coEvery { integrityAttestor.attest("nonce-1") } returns Result.success("integrity-token-1")
+            every {
+                repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1", "integrity-token-1")
+            } returns flowOf(Result.success("bk-1"))
+
             assertThat(sut("bk-1", "pay_1", "order_1", "sig_1").first().getOrThrow()).isEqualTo("bk-1")
-            verify(exactly = 1) { repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1") }
+            coVerify(exactly = 1) {
+                repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1", "integrity-token-1")
+            }
         }
 
     @Test
     public fun `invoke propagates failure`(): Unit =
         runTest {
-            every { repo.confirmBooking(any(), any(), any(), any()) } returns flowOf(Result.failure(RuntimeException("confirm failed")))
+            coEvery { integrityApiService.getNonce() } returns IntegrityNonceResponseDto("nonce-1")
+            coEvery { integrityAttestor.attest(any()) } returns Result.success("token")
+            every { repo.confirmBooking(any(), any(), any(), any(), any()) } returns
+                flowOf(Result.failure(RuntimeException("confirm failed")))
+
             assertThat(sut("bk-1", "pay_1", "order_1", "sig_1").first().isFailure).isTrue()
+        }
+
+    @Test
+    public fun `invoke proceeds with null token when attestation fails (fail-open)`(): Unit =
+        runTest {
+            coEvery { integrityApiService.getNonce() } throws RuntimeException("nonce fetch failed")
+            every {
+                repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1", null)
+            } returns flowOf(Result.success("bk-1"))
+
+            // Should not throw — attestation failure is fail-open
+            val result = sut("bk-1", "pay_1", "order_1", "sig_1").first()
+            assertThat(result.isSuccess).isTrue()
+            coVerify(exactly = 1) {
+                repo.confirmBooking("bk-1", "pay_1", "order_1", "sig_1", null)
+            }
         }
 }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestorTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestorTest.kt
@@ -1,0 +1,82 @@
+package com.homeservices.customer.domain.integrity
+
+import android.content.Context
+import com.google.android.play.core.integrity.IntegrityManager
+import com.google.android.play.core.integrity.IntegrityTokenRequest
+import com.google.android.play.core.integrity.IntegrityTokenResponse
+import com.google.android.gms.tasks.Tasks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+public class PlayIntegrityAttestorTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val manager: IntegrityManager = mockk()
+
+    @BeforeEach
+    public fun setUp() {
+        mockkStatic("com.google.android.play.core.integrity.IntegrityManagerFactory")
+        every {
+            com.google.android.play.core.integrity.IntegrityManagerFactory.create(context)
+        } returns manager
+    }
+
+    @AfterEach
+    public fun tearDown() {
+        unmockkStatic("com.google.android.play.core.integrity.IntegrityManagerFactory")
+    }
+
+    @Test
+    public fun `attest — success path — returns Result success with token`(): Unit =
+        runTest {
+            val fakeToken = "fake-integrity-token"
+            val response: IntegrityTokenResponse = mockk {
+                every { token() } returns fakeToken
+            }
+            every {
+                manager.requestIntegrityToken(any<IntegrityTokenRequest>())
+            } returns Tasks.forResult(response)
+
+            val sut = PlayIntegrityAttestor(context)
+            val result = sut.attest("test-nonce")
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo(fakeToken)
+        }
+
+    @Test
+    public fun `attest — failure path — returns Result failure`(): Unit =
+        runTest {
+            val exception = RuntimeException("Play Integrity not available")
+            every {
+                manager.requestIntegrityToken(any<IntegrityTokenRequest>())
+            } returns Tasks.forException(exception)
+
+            val sut = PlayIntegrityAttestor(context)
+            val result = sut.attest("test-nonce")
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isEqualTo(exception)
+        }
+
+    @Test
+    public fun `attest — debug bypass — returns Result success with debug-bypass token`(): Unit =
+        runTest {
+            // In a real debug build, BuildConfig.DEBUG would be true.
+            // PlayIntegrityAttestor.attest() short-circuits to "debug-bypass" when
+            // the instance is constructed with debugBypass=true (injected via Hilt in debug).
+            // We test the bypass path directly by constructing with that flag.
+            val sut = PlayIntegrityAttestor(context, debugBypass = true)
+            val result = sut.attest("any-nonce")
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo("debug-bypass")
+        }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestorTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/integrity/PlayIntegrityAttestorTest.kt
@@ -1,10 +1,10 @@
 package com.homeservices.customer.domain.integrity
 
 import android.content.Context
+import com.google.android.gms.tasks.Tasks
 import com.google.android.play.core.integrity.IntegrityManager
 import com.google.android.play.core.integrity.IntegrityTokenRequest
 import com.google.android.play.core.integrity.IntegrityTokenResponse
-import com.google.android.gms.tasks.Tasks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 public class PlayIntegrityAttestorTest {
-
     private val context: Context = mockk(relaxed = true)
     private val manager: IntegrityManager = mockk()
 
@@ -24,7 +23,8 @@ public class PlayIntegrityAttestorTest {
     public fun setUp() {
         mockkStatic("com.google.android.play.core.integrity.IntegrityManagerFactory")
         every {
-            com.google.android.play.core.integrity.IntegrityManagerFactory.create(context)
+            com.google.android.play.core.integrity.IntegrityManagerFactory
+                .create(context)
         } returns manager
     }
 
@@ -37,9 +37,10 @@ public class PlayIntegrityAttestorTest {
     public fun `attest — success path — returns Result success with token`(): Unit =
         runTest {
             val fakeToken = "fake-integrity-token"
-            val response: IntegrityTokenResponse = mockk {
-                every { token() } returns fakeToken
-            }
+            val response: IntegrityTokenResponse =
+                mockk {
+                    every { token() } returns fakeToken
+                }
             every {
                 manager.requestIntegrityToken(any<IntegrityTokenRequest>())
             } returns Tasks.forResult(response)

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/auth/AuthViewModelTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/auth/AuthViewModelTest.kt
@@ -99,12 +99,13 @@ public class AuthViewModelTest {
     public fun `Truecaller Success with AuthResult Error transitions to Error state`(): Unit =
         runTest(testDispatcher) {
             val activity = mockk<FragmentActivity>()
-            val truecallerSuccess = TruecallerAuthResult.Success(
-                payload = "payload-b64",
-                signature = "sig-b64",
-                signatureAlgorithm = "SHA512withRSA",
-                phoneLastFour = "0000",
-            )
+            val truecallerSuccess =
+                TruecallerAuthResult.Success(
+                    payload = "payload-b64",
+                    signature = "sig-b64",
+                    signatureAlgorithm = "SHA512withRSA",
+                    phoneLastFour = "0000",
+                )
             every { orchestrator.start(activity, activity) } returns AuthOrchestrator.StartResult.TruecallerLaunched
             coEvery { orchestrator.completeWithTruecaller(truecallerSuccess) } returns
                 AuthResult.Error.General(RuntimeException("session fail"))
@@ -330,12 +331,13 @@ public class AuthViewModelTest {
             // Covers the false-branch of `if (authResult is AuthResult.Error)` in handleTruecallerResult
             val activity = mockk<FragmentActivity>()
             val user = mockk<FirebaseUser>()
-            val truecallerSuccess = TruecallerAuthResult.Success(
-                payload = "payload-b64",
-                signature = "sig-b64",
-                signatureAlgorithm = "SHA512withRSA",
-                phoneLastFour = "0000",
-            )
+            val truecallerSuccess =
+                TruecallerAuthResult.Success(
+                    payload = "payload-b64",
+                    signature = "sig-b64",
+                    signatureAlgorithm = "SHA512withRSA",
+                    phoneLastFour = "0000",
+                )
             every { orchestrator.start(activity, activity) } returns AuthOrchestrator.StartResult.TruecallerLaunched
             coEvery { orchestrator.completeWithTruecaller(truecallerSuccess) } returns AuthResult.Success(user)
 

--- a/technician-app/app/build.gradle.kts
+++ b/technician-app/app/build.gradle.kts
@@ -77,6 +77,11 @@ android {
         )
         buildConfigField(
             "String",
+            "API_BASE_URL",
+            "\"${System.getenv("API_BASE_URL") ?: "https://func-homeservices-prod.azurewebsites.net/api"}\"",
+        )
+        buildConfigField(
+            "String",
             "GIT_SHA",
             "\"${System.getenv("GIT_SHA") ?: "dev"}\"",
         )
@@ -421,6 +426,10 @@ kover {
                     // tests using mockk.
                     "*.PayoutCadenceViewModel\$saveCadence\$1",
                     "*.PayoutCadenceViewModel\$saveCadence\$1\$*",
+                    // IntegrityModule — Hilt @Provides DI wiring for Play Integrity SDK setup
+                    "*.domain.integrity.di.*",
+                    // IntegrityApiService — Retrofit interface, methods invoked by Retrofit runtime
+                    "*.data.integrity.IntegrityApiService",
                 )
             }
         }
@@ -482,6 +491,9 @@ dependencies {
     implementation(libs.play.services.location)
     implementation(libs.play.services.maps)
     implementation(libs.maps.compose)
+
+    // Play Integrity API
+    implementation(libs.play.integrity)
 
     // KYC networking + serialization
     implementation(libs.retrofit.core)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiService.kt
@@ -19,6 +19,7 @@ internal interface ActiveJobApiService {
         @Header("Authorization") authHeader: String,
         @Path("bookingId") bookingId: String,
         @Body body: TransitionRequest,
+        @Header("X-Integrity-Token") integrityToken: String? = null,
     ): Response<ActiveJobResponse>
 }
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/ActiveJobRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/ActiveJobRepositoryImpl.kt
@@ -48,6 +48,7 @@ public class ActiveJobRepositoryImpl
         override suspend fun transitionStatus(
             bookingId: String,
             targetStatus: ActiveJobStatus,
+            integrityToken: String?,
         ): Result<ActiveJob> {
             return try {
                 val token =
@@ -67,6 +68,7 @@ public class ActiveJobRepositoryImpl
                                     .getOrNull()
                                     ?.toDto(),
                         ),
+                        integrityToken = integrityToken,
                     )
                 if (response.isSuccessful) {
                     Result.success(response.body()!!.toDomain())

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/integrity/IntegrityApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/integrity/IntegrityApiService.kt
@@ -1,0 +1,15 @@
+package com.homeservices.technician.data.integrity
+
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+public interface IntegrityApiService {
+    @GET("v1/integrity/nonce")
+    public suspend fun getNonce(
+        @Header("Authorization") authHeader: String,
+    ): IntegrityNonceResponseDto
+}
+
+public data class IntegrityNonceResponseDto(
+    val nonce: String,
+)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/kyc/KycRepository.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/kyc/KycRepository.kt
@@ -8,6 +8,7 @@ public interface KycRepository {
     public suspend fun exchangeAadhaarCode(
         authCode: String,
         redirectUri: String,
+        integrityToken: String? = null,
     ): DigiLockerResult
 
     public suspend fun submitPanOcr(firebaseStoragePath: String): PanOcrResult

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/kyc/KycRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/kyc/KycRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.homeservices.technician.domain.kyc.model.KycStatus
 import com.homeservices.technician.domain.kyc.model.PanOcrResult
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import javax.inject.Inject
 
@@ -13,6 +14,7 @@ internal interface KycApiService {
     @POST("v1/kyc/aadhaar")
     suspend fun submitAadhaar(
         @Body body: AadhaarRequest,
+        @Header("X-Integrity-Token") integrityToken: String? = null,
     ): AadhaarResponse
 
     @POST("v1/kyc/pan-ocr")
@@ -60,9 +62,10 @@ public class KycRepositoryImpl
         override suspend fun exchangeAadhaarCode(
             authCode: String,
             redirectUri: String,
+            integrityToken: String?,
         ): DigiLockerResult =
             try {
-                val r = api.submitAadhaar(AadhaarRequest(authCode, redirectUri))
+                val r = api.submitAadhaar(AadhaarRequest(authCode, redirectUri), integrityToken)
                 if (r.aadhaarVerified && r.aadhaarMaskedNumber != null) {
                     DigiLockerResult.AadhaarVerified(r.aadhaarMaskedNumber)
                 } else {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/ActiveJobRepository.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/ActiveJobRepository.kt
@@ -12,6 +12,7 @@ public interface ActiveJobRepository {
     public suspend fun transitionStatus(
         bookingId: String,
         targetStatus: ActiveJobStatus,
+        integrityToken: String? = null,
     ): Result<ActiveJob>
 
     public suspend fun syncPendingTransitions()

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/MarkReachedUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/MarkReachedUseCase.kt
@@ -1,16 +1,40 @@
 package com.homeservices.technician.domain.activeJob
 
+import com.google.firebase.auth.FirebaseAuth
+import com.homeservices.technician.data.integrity.IntegrityApiService
 import com.homeservices.technician.domain.activeJob.model.ActiveJob
 import com.homeservices.technician.domain.activeJob.model.ActiveJobStatus
+import com.homeservices.technician.domain.integrity.IntegrityAttestor
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 public class MarkReachedUseCase
     @Inject
-    internal constructor(
+    constructor(
         private val repository: ActiveJobRepository,
+        private val integrityAttestor: IntegrityAttestor,
+        private val integrityApiService: IntegrityApiService,
+        private val firebaseAuth: FirebaseAuth,
     ) {
-        public suspend operator fun invoke(bookingId: String): Result<ActiveJob> =
-            repository.transitionStatus(bookingId, ActiveJobStatus.REACHED)
+        public suspend operator fun invoke(bookingId: String): Result<ActiveJob> {
+            val integrityToken: String? =
+                runCatching {
+                    val token =
+                        firebaseAuth.currentUser
+                            ?.getIdToken(false)
+                            ?.await()
+                            ?.token
+                    val nonce =
+                        if (token != null) {
+                            integrityApiService.getNonce("Bearer $token").nonce
+                        } else {
+                            integrityApiService.getNonce("").nonce
+                        }
+                    integrityAttestor.attest(nonce).getOrThrow()
+                }.getOrNull()
+
+            return repository.transitionStatus(bookingId, ActiveJobStatus.REACHED, integrityToken)
+        }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/IntegrityAttestor.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/IntegrityAttestor.kt
@@ -1,0 +1,5 @@
+package com.homeservices.technician.domain.integrity
+
+public interface IntegrityAttestor {
+    public suspend fun attest(nonce: String): Result<String>
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestor.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestor.kt
@@ -18,13 +18,13 @@ public class PlayIntegrityAttestor(
     private val context: Context,
     private val debugBypass: Boolean = false,
 ) : IntegrityAttestor {
-
     override suspend fun attest(nonce: String): Result<String> {
         if (debugBypass) return Result.success("debug-bypass")
         return runCatching {
             val manager = IntegrityManagerFactory.create(context)
             val request =
-                IntegrityTokenRequest.builder()
+                IntegrityTokenRequest
+                    .builder()
                     .setNonce(nonce)
                     .build()
             manager.requestIntegrityToken(request).await().token()

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestor.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestor.kt
@@ -1,0 +1,33 @@
+package com.homeservices.technician.domain.integrity
+
+import android.content.Context
+import com.google.android.play.core.integrity.IntegrityManagerFactory
+import com.google.android.play.core.integrity.IntegrityTokenRequest
+import kotlinx.coroutines.tasks.await
+import javax.inject.Singleton
+
+/**
+ * Production implementation of [IntegrityAttestor] backed by the Play Integrity API.
+ *
+ * Debug-bypass mode: when [debugBypass] is true, [attest] returns
+ * `Result.success("debug-bypass")` immediately without calling the Play Integrity SDK.
+ * The API server accepts this value when `PLAY_INTEGRITY_STRICT=false` (staging/dev).
+ */
+@Singleton
+public class PlayIntegrityAttestor(
+    private val context: Context,
+    private val debugBypass: Boolean = false,
+) : IntegrityAttestor {
+
+    override suspend fun attest(nonce: String): Result<String> {
+        if (debugBypass) return Result.success("debug-bypass")
+        return runCatching {
+            val manager = IntegrityManagerFactory.create(context)
+            val request =
+                IntegrityTokenRequest.builder()
+                    .setNonce(nonce)
+                    .build()
+            manager.requestIntegrityToken(request).await().token()
+        }
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/di/IntegrityModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/di/IntegrityModule.kt
@@ -1,0 +1,47 @@
+package com.homeservices.technician.domain.integrity.di
+
+import android.content.Context
+import com.homeservices.technician.BuildConfig
+import com.homeservices.technician.data.integrity.IntegrityApiService
+import com.homeservices.technician.domain.integrity.IntegrityAttestor
+import com.homeservices.technician.domain.integrity.PlayIntegrityAttestor
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+public object IntegrityModule {
+
+    @Provides
+    @Singleton
+    public fun providePlayIntegrityAttestor(
+        @ApplicationContext context: Context,
+    ): PlayIntegrityAttestor = PlayIntegrityAttestor(context, debugBypass = BuildConfig.DEBUG)
+
+    @Provides
+    @Singleton
+    public fun provideIntegrityAttestor(impl: PlayIntegrityAttestor): IntegrityAttestor = impl
+
+    @Provides
+    @Singleton
+    public fun provideIntegrityApiService(): IntegrityApiService {
+        val moshi = Moshi.Builder().addLast(KotlinJsonAdapterFactory()).build()
+        val client = OkHttpClient.Builder().build()
+        return Retrofit
+            .Builder()
+            .baseUrl(BuildConfig.API_BASE_URL + "/")
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(client)
+            .build()
+            .create(IntegrityApiService::class.java)
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/di/IntegrityModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/di/IntegrityModule.kt
@@ -20,7 +20,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 public object IntegrityModule {
-
     @Provides
     @Singleton
     public fun providePlayIntegrityAttestor(

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/kyc/DigiLockerConsentUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/kyc/DigiLockerConsentUseCase.kt
@@ -1,21 +1,45 @@
 package com.homeservices.technician.domain.kyc
 
+import com.google.firebase.auth.FirebaseAuth
+import com.homeservices.technician.data.integrity.IntegrityApiService
 import com.homeservices.technician.data.kyc.KycRepository
+import com.homeservices.technician.domain.integrity.IntegrityAttestor
 import com.homeservices.technician.domain.kyc.model.DigiLockerResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 public class DigiLockerConsentUseCase
     @Inject
     constructor(
         private val repository: KycRepository,
+        private val integrityAttestor: IntegrityAttestor,
+        private val integrityApiService: IntegrityApiService,
+        private val firebaseAuth: FirebaseAuth,
     ) {
         public operator fun invoke(
             authCode: String,
             redirectUri: String,
         ): Flow<DigiLockerResult> =
             flow {
-                emit(repository.exchangeAadhaarCode(authCode, redirectUri))
+                // Fetch nonce → attest → attach integrity token (fail-open on errors)
+                val integrityToken: String? =
+                    runCatching {
+                        val token =
+                            firebaseAuth.currentUser
+                                ?.getIdToken(false)
+                                ?.await()
+                                ?.token
+                        val nonce =
+                            if (token != null) {
+                                integrityApiService.getNonce("Bearer $token").nonce
+                            } else {
+                                integrityApiService.getNonce("").nonce
+                            }
+                        integrityAttestor.attest(nonce).getOrThrow()
+                    }.getOrNull()
+
+                emit(repository.exchangeAadhaarCode(authCode, redirectUri, integrityToken))
             }
     }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobRepositoryImplTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobRepositoryImplTest.kt
@@ -64,7 +64,7 @@ public class ActiveJobRepositoryImplTest {
     @Test
     public fun `transitionStatus success path — does NOT write PendingTransitionEntity`(): Unit =
         runTest {
-            coEvery { api.transitionStatus(any(), any(), any()) } returns Response.success(aResponse("EN_ROUTE"))
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } returns Response.success(aResponse("EN_ROUTE"))
 
             val result = repo.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE)
 
@@ -76,7 +76,7 @@ public class ActiveJobRepositoryImplTest {
     public fun `transitionStatus includes current GPS when available`(): Unit =
         runTest {
             coEvery { currentLocationProvider.currentLocation() } returns LatLng(26.8, 82.2)
-            coEvery { api.transitionStatus(any(), any(), any()) } returns Response.success(aResponse("EN_ROUTE"))
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } returns Response.success(aResponse("EN_ROUTE"))
 
             repo.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE)
 
@@ -88,6 +88,7 @@ public class ActiveJobRepositoryImplTest {
                         targetStatus = "EN_ROUTE",
                         currentLocation = LatLngDto(lat = 26.8, lng = 82.2),
                     ),
+                    integrityToken = null,
                 )
             }
         }
@@ -95,7 +96,7 @@ public class ActiveJobRepositoryImplTest {
     @Test
     public fun `transitionStatus network failure — writes PendingTransitionEntity to Room`(): Unit =
         runTest {
-            coEvery { api.transitionStatus(any(), any(), any()) } throws RuntimeException("network error")
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } throws RuntimeException("network error")
 
             val result = repo.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE)
 
@@ -112,7 +113,7 @@ public class ActiveJobRepositoryImplTest {
                     PendingTransitionEntity("id-2", "bk-1", "REACHED", createdAt = 2000L),
                 )
             coEvery { dao.getPending() } returns entries
-            coEvery { api.transitionStatus(any(), any(), any()) } returns Response.success(aResponse("EN_ROUTE"))
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } returns Response.success(aResponse("EN_ROUTE"))
 
             repo.syncPendingTransitions()
 
@@ -126,7 +127,7 @@ public class ActiveJobRepositoryImplTest {
         runTest {
             val entry = PendingTransitionEntity("id-1", "bk-1", "IN_PROGRESS", createdAt = 1000L)
             coEvery { dao.getPending() } returns listOf(entry)
-            coEvery { api.transitionStatus(any(), any(), any()) } returns
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } returns
                 Response.error(409, "".toResponseBody(null))
 
             repo.syncPendingTransitions()
@@ -162,7 +163,7 @@ public class ActiveJobRepositoryImplTest {
     @Test
     public fun `transitionStatus HTTP error (non-exception) — returns failure without Room write`(): Unit =
         runTest {
-            coEvery { api.transitionStatus(any(), any(), any()) } returns
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } returns
                 Response.error(400, "".toResponseBody(null))
 
             val result = repo.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE)
@@ -188,7 +189,7 @@ public class ActiveJobRepositoryImplTest {
 
             repo.syncPendingTransitions()
 
-            coVerify(exactly = 0) { api.transitionStatus(any(), any(), any()) }
+            coVerify(exactly = 0) { api.transitionStatus(any(), any(), any(), any()) }
         }
 
     @Test
@@ -196,7 +197,7 @@ public class ActiveJobRepositoryImplTest {
         runTest {
             val entry = PendingTransitionEntity("id-1", "bk-1", "EN_ROUTE", createdAt = 1000L)
             coEvery { dao.getPending() } returns listOf(entry)
-            coEvery { api.transitionStatus(any(), any(), any()) } throws RuntimeException("network")
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } throws RuntimeException("network")
 
             repo.syncPendingTransitions()
 
@@ -208,7 +209,7 @@ public class ActiveJobRepositoryImplTest {
         runTest {
             val entry = PendingTransitionEntity("id-1", "bk-1", "EN_ROUTE", createdAt = 1000L)
             coEvery { dao.getPending() } returns listOf(entry)
-            coEvery { api.transitionStatus(any(), any(), any()) } returns
+            coEvery { api.transitionStatus(any(), any(), any(), any()) } returns
                 Response.error(500, "".toResponseBody(null))
 
             repo.syncPendingTransitions()

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/kyc/KycRepositoryImplTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/kyc/KycRepositoryImplTest.kt
@@ -15,7 +15,7 @@ public class KycRepositoryImplTest {
     @Test
     public fun `exchangeAadhaarCode returns AadhaarVerified on success`(): Unit =
         runTest {
-            coEvery { api.submitAadhaar(any()) } returns
+            coEvery { api.submitAadhaar(any(), any()) } returns
                 AadhaarResponse(
                     kycStatus = "AADHAAR_DONE",
                     aadhaarMaskedNumber = "XXXX-XXXX-1234",
@@ -29,7 +29,7 @@ public class KycRepositoryImplTest {
     @Test
     public fun `exchangeAadhaarCode returns NetworkError on exception`(): Unit =
         runTest {
-            coEvery { api.submitAadhaar(any()) } throws RuntimeException("network")
+            coEvery { api.submitAadhaar(any(), any()) } throws RuntimeException("network")
             val result = sut.exchangeAadhaarCode("code", "https://redirect")
             assertThat(result).isInstanceOf(DigiLockerResult.NetworkError::class.java)
         }
@@ -37,7 +37,7 @@ public class KycRepositoryImplTest {
     @Test
     public fun `exchangeAadhaarCode returns ApiError when aadhaarVerified is false`(): Unit =
         runTest {
-            coEvery { api.submitAadhaar(any()) } returns
+            coEvery { api.submitAadhaar(any(), any()) } returns
                 AadhaarResponse(
                     kycStatus = "PENDING",
                     aadhaarMaskedNumber = null,

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/kyc/KycRepositoryTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/kyc/KycRepositoryTest.kt
@@ -22,7 +22,7 @@ public class KycRepositoryTest {
     @Test
     public fun `exchangeAadhaarCode returns AadhaarVerified on success`(): Unit =
         runTest {
-            coEvery { api.submitAadhaar(AadhaarRequest("code", "uri")) } returns
+            coEvery { api.submitAadhaar(AadhaarRequest("code", "uri"), any()) } returns
                 AadhaarResponse("AADHAAR_DONE", "XXXX-XXXX-1234", true)
 
             val result = repo.exchangeAadhaarCode("code", "uri")

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/CompleteJobUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/CompleteJobUseCaseTest.kt
@@ -30,12 +30,12 @@ public class CompleteJobUseCaseTest {
     @Test
     public fun `calls transitionStatus with COMPLETED — no photo check`(): Unit =
         runTest {
-            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.COMPLETED) } returns
+            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.COMPLETED, null) } returns
                 Result.success(aJob())
 
             val result = useCase("bk-1")
 
             assertThat(result.isSuccess).isTrue()
-            coVerify(exactly = 1) { repository.transitionStatus("bk-1", ActiveJobStatus.COMPLETED) }
+            coVerify(exactly = 1) { repository.transitionStatus("bk-1", ActiveJobStatus.COMPLETED, null) }
         }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/MarkReachedUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/MarkReachedUseCaseTest.kt
@@ -1,17 +1,41 @@
 package com.homeservices.technician.domain.activeJob
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import com.homeservices.technician.data.integrity.IntegrityApiService
+import com.homeservices.technician.data.integrity.IntegrityNonceResponseDto
 import com.homeservices.technician.domain.activeJob.model.ActiveJob
 import com.homeservices.technician.domain.activeJob.model.ActiveJobStatus
 import com.homeservices.technician.domain.activeJob.model.LatLng
+import com.homeservices.technician.domain.integrity.IntegrityAttestor
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 public class MarkReachedUseCaseTest {
     private val repository: ActiveJobRepository = mockk()
-    private val useCase = MarkReachedUseCase(repository)
+    private val integrityAttestor: IntegrityAttestor = mockk()
+    private val integrityApiService: IntegrityApiService = mockk()
+    private val firebaseAuth: FirebaseAuth = mockk()
+    private val firebaseUser: FirebaseUser = mockk()
+    private val tokenResult: GetTokenResult = mockk()
+    private val useCase = MarkReachedUseCase(repository, integrityAttestor, integrityApiService, firebaseAuth)
+
+    @BeforeEach
+    public fun setUp() {
+        every { firebaseAuth.currentUser } returns firebaseUser
+        every { firebaseUser.getIdToken(false) } returns Tasks.forResult(tokenResult)
+        every { tokenResult.token } returns "firebase-token"
+        coEvery { integrityApiService.getNonce(any()) } returns IntegrityNonceResponseDto("test-nonce")
+        coEvery { integrityAttestor.attest("test-nonce") } returns Result.success("integrity-token")
+    }
 
     private fun aJob() =
         ActiveJob(
@@ -27,14 +51,34 @@ public class MarkReachedUseCaseTest {
         )
 
     @Test
-    public fun `transitions EN_ROUTE to REACHED`(): Unit =
+    public fun `transitions EN_ROUTE to REACHED with integrity token`(): Unit =
         runTest {
-            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.REACHED) } returns
-                Result.success(aJob())
+            coEvery {
+                repository.transitionStatus("bk-1", ActiveJobStatus.REACHED, "integrity-token")
+            } returns Result.success(aJob())
 
             val result = useCase("bk-1")
 
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrThrow().status).isEqualTo(ActiveJobStatus.REACHED)
+            coVerify(exactly = 1) {
+                repository.transitionStatus("bk-1", ActiveJobStatus.REACHED, "integrity-token")
+            }
+        }
+
+    @Test
+    public fun `proceeds with null token when attestation fails (fail-open)`(): Unit =
+        runTest {
+            coEvery { integrityAttestor.attest(any()) } returns Result.failure(RuntimeException("attestation failed"))
+            coEvery {
+                repository.transitionStatus("bk-1", ActiveJobStatus.REACHED, null)
+            } returns Result.success(aJob())
+
+            val result = useCase("bk-1")
+
+            assertThat(result.isSuccess).isTrue()
+            coVerify(exactly = 1) {
+                repository.transitionStatus("bk-1", ActiveJobStatus.REACHED, null)
+            }
         }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/StartTripUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/StartTripUseCaseTest.kt
@@ -30,7 +30,7 @@ public class StartTripUseCaseTest {
     @Test
     public fun `success — returns Result success and emits Maps NavigationEvent`(): Unit =
         runTest {
-            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE) } returns
+            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE, null) } returns
                 Result.success(aJob(ActiveJobStatus.EN_ROUTE))
 
             val (result, navEvent) = useCase("bk-1")
@@ -42,7 +42,7 @@ public class StartTripUseCaseTest {
     @Test
     public fun `failure — returns Result failure and navEvent is null`(): Unit =
         runTest {
-            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE) } returns
+            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.EN_ROUTE, null) } returns
                 Result.failure(RuntimeException("offline"))
 
             val (result, navEvent) = useCase("bk-1")

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/StartWorkUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/activeJob/StartWorkUseCaseTest.kt
@@ -29,7 +29,7 @@ public class StartWorkUseCaseTest {
     @Test
     public fun `transitions REACHED to IN_PROGRESS`(): Unit =
         runTest {
-            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.IN_PROGRESS) } returns
+            coEvery { repository.transitionStatus("bk-1", ActiveJobStatus.IN_PROGRESS, null) } returns
                 Result.success(aJob())
 
             val result = useCase("bk-1")

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestorTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestorTest.kt
@@ -1,0 +1,78 @@
+package com.homeservices.technician.domain.integrity
+
+import android.content.Context
+import com.google.android.play.core.integrity.IntegrityManager
+import com.google.android.play.core.integrity.IntegrityTokenRequest
+import com.google.android.play.core.integrity.IntegrityTokenResponse
+import com.google.android.gms.tasks.Tasks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+public class PlayIntegrityAttestorTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val manager: IntegrityManager = mockk()
+
+    @BeforeEach
+    public fun setUp() {
+        mockkStatic("com.google.android.play.core.integrity.IntegrityManagerFactory")
+        every {
+            com.google.android.play.core.integrity.IntegrityManagerFactory.create(context)
+        } returns manager
+    }
+
+    @AfterEach
+    public fun tearDown() {
+        unmockkStatic("com.google.android.play.core.integrity.IntegrityManagerFactory")
+    }
+
+    @Test
+    public fun `attest — success path — returns Result success with token`(): Unit =
+        runTest {
+            val fakeToken = "fake-integrity-token"
+            val response: IntegrityTokenResponse = mockk {
+                every { token() } returns fakeToken
+            }
+            every {
+                manager.requestIntegrityToken(any<IntegrityTokenRequest>())
+            } returns Tasks.forResult(response)
+
+            val sut = PlayIntegrityAttestor(context)
+            val result = sut.attest("test-nonce")
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo(fakeToken)
+        }
+
+    @Test
+    public fun `attest — failure path — returns Result failure`(): Unit =
+        runTest {
+            val exception = RuntimeException("Play Integrity not available")
+            every {
+                manager.requestIntegrityToken(any<IntegrityTokenRequest>())
+            } returns Tasks.forException(exception)
+
+            val sut = PlayIntegrityAttestor(context)
+            val result = sut.attest("test-nonce")
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isEqualTo(exception)
+        }
+
+    @Test
+    public fun `attest — debug bypass — returns Result success with debug-bypass token`(): Unit =
+        runTest {
+            val sut = PlayIntegrityAttestor(context, debugBypass = true)
+            val result = sut.attest("any-nonce")
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo("debug-bypass")
+        }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestorTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/integrity/PlayIntegrityAttestorTest.kt
@@ -1,10 +1,10 @@
 package com.homeservices.technician.domain.integrity
 
 import android.content.Context
+import com.google.android.gms.tasks.Tasks
 import com.google.android.play.core.integrity.IntegrityManager
 import com.google.android.play.core.integrity.IntegrityTokenRequest
 import com.google.android.play.core.integrity.IntegrityTokenResponse
-import com.google.android.gms.tasks.Tasks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 public class PlayIntegrityAttestorTest {
-
     private val context: Context = mockk(relaxed = true)
     private val manager: IntegrityManager = mockk()
 
@@ -24,7 +23,8 @@ public class PlayIntegrityAttestorTest {
     public fun setUp() {
         mockkStatic("com.google.android.play.core.integrity.IntegrityManagerFactory")
         every {
-            com.google.android.play.core.integrity.IntegrityManagerFactory.create(context)
+            com.google.android.play.core.integrity.IntegrityManagerFactory
+                .create(context)
         } returns manager
     }
 
@@ -37,9 +37,10 @@ public class PlayIntegrityAttestorTest {
     public fun `attest — success path — returns Result success with token`(): Unit =
         runTest {
             val fakeToken = "fake-integrity-token"
-            val response: IntegrityTokenResponse = mockk {
-                every { token() } returns fakeToken
-            }
+            val response: IntegrityTokenResponse =
+                mockk {
+                    every { token() } returns fakeToken
+                }
             every {
                 manager.requestIntegrityToken(any<IntegrityTokenRequest>())
             } returns Tasks.forResult(response)

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/kyc/DigiLockerConsentUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/kyc/DigiLockerConsentUseCaseTest.kt
@@ -1,8 +1,16 @@
 package com.homeservices.technician.domain.kyc
 
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.GetTokenResult
+import com.homeservices.technician.data.integrity.IntegrityApiService
+import com.homeservices.technician.data.integrity.IntegrityNonceResponseDto
 import com.homeservices.technician.data.kyc.KycRepository
+import com.homeservices.technician.domain.integrity.IntegrityAttestor
 import com.homeservices.technician.domain.kyc.model.DigiLockerResult
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -14,19 +22,35 @@ import org.junit.jupiter.api.Test
 @ExperimentalCoroutinesApi
 public class DigiLockerConsentUseCaseTest {
     private lateinit var repo: KycRepository
+    private lateinit var integrityAttestor: IntegrityAttestor
+    private lateinit var integrityApiService: IntegrityApiService
+    private lateinit var firebaseAuth: FirebaseAuth
+    private lateinit var firebaseUser: FirebaseUser
+    private lateinit var tokenResult: GetTokenResult
     private lateinit var useCase: DigiLockerConsentUseCase
 
     @BeforeEach
     public fun setUp(): Unit {
         repo = mockk()
-        useCase = DigiLockerConsentUseCase(repo)
+        integrityAttestor = mockk()
+        integrityApiService = mockk()
+        firebaseAuth = mockk()
+        firebaseUser = mockk()
+        tokenResult = mockk()
+        every { firebaseAuth.currentUser } returns firebaseUser
+        every { firebaseUser.getIdToken(false) } returns Tasks.forResult(tokenResult)
+        every { tokenResult.token } returns "firebase-token"
+        coEvery { integrityApiService.getNonce(any()) } returns IntegrityNonceResponseDto("nonce-kyc")
+        coEvery { integrityAttestor.attest("nonce-kyc") } returns Result.success("integrity-token-kyc")
+        useCase = DigiLockerConsentUseCase(repo, integrityAttestor, integrityApiService, firebaseAuth)
     }
 
     @Test
     public fun `emits AadhaarVerified when API returns verified`(): Unit =
         runTest {
-            coEvery { repo.exchangeAadhaarCode("code123", "homeservices://digilocker") } returns
-                DigiLockerResult.AadhaarVerified("XXXX-XXXX-1234")
+            coEvery {
+                repo.exchangeAadhaarCode("code123", "homeservices://digilocker", "integrity-token-kyc")
+            } returns DigiLockerResult.AadhaarVerified("XXXX-XXXX-1234")
 
             val results = useCase("code123", "homeservices://digilocker").toList()
 
@@ -39,7 +63,7 @@ public class DigiLockerConsentUseCaseTest {
     @Test
     public fun `emits UserCancelled when repo returns UserCancelled`(): Unit =
         runTest {
-            coEvery { repo.exchangeAadhaarCode(any(), any()) } returns DigiLockerResult.UserCancelled
+            coEvery { repo.exchangeAadhaarCode(any(), any(), any()) } returns DigiLockerResult.UserCancelled
 
             val results = useCase("", "homeservices://digilocker").toList()
 
@@ -51,7 +75,7 @@ public class DigiLockerConsentUseCaseTest {
     public fun `emits NetworkError when repo returns NetworkError`(): Unit =
         runTest {
             val ex = RuntimeException("No internet")
-            coEvery { repo.exchangeAadhaarCode(any(), any()) } returns DigiLockerResult.NetworkError(ex)
+            coEvery { repo.exchangeAadhaarCode(any(), any(), any()) } returns DigiLockerResult.NetworkError(ex)
 
             val results = useCase("code", "homeservices://digilocker").toList()
 
@@ -63,12 +87,25 @@ public class DigiLockerConsentUseCaseTest {
     @Test
     public fun `emits ApiError when repo returns ApiError`(): Unit =
         runTest {
-            coEvery { repo.exchangeAadhaarCode(any(), any()) } returns
+            coEvery { repo.exchangeAadhaarCode(any(), any(), any()) } returns
                 DigiLockerResult.ApiError("Unexpected response: verified=false")
 
             val results = useCase("code", "homeservices://digilocker").toList()
 
             assertThat(results).hasSize(1)
             assertThat(results[0]).isInstanceOf(DigiLockerResult.ApiError::class.java)
+        }
+
+    @Test
+    public fun `proceeds with null token when attestation fails (fail-open)`(): Unit =
+        runTest {
+            coEvery { integrityAttestor.attest(any()) } returns Result.failure(RuntimeException("Play Integrity unavailable"))
+            coEvery { repo.exchangeAadhaarCode(any(), any(), null) } returns
+                DigiLockerResult.AadhaarVerified("XXXX-XXXX-5678")
+
+            val results = useCase("code", "homeservices://digilocker").toList()
+
+            assertThat(results).hasSize(1)
+            assertThat(results[0]).isInstanceOf(DigiLockerResult.AadhaarVerified::class.java)
         }
 }


### PR DESCRIPTION
## Summary

- **IntegrityAttestor interface + PlayIntegrityAttestor** added to both `customer-app` and `technician-app` under `domain/integrity/`. Debug-bypass mode short-circuits to `"debug-bypass"` token when `BuildConfig.DEBUG=true`, accepted by server when `PLAY_INTEGRITY_STRICT=false`.
- **High-value mutations wired**: `ConfirmBookingUseCase` (payment-confirm), `MarkReachedUseCase` (REACHED transition), `DigiLockerConsentUseCase` (KYC aadhaar submit) — all now fetch a nonce from `GET /v1/integrity/nonce`, attest with Play Integrity, and attach `X-Integrity-Token` header. All three are **fail-open**: attestation failure passes `null` token, server warns to Sentry but allows through.
- **API layer**: `nonce.ts` (`GET /v1/integrity/nonce`, rate-limited 20 req/min/ip via existing `withRateLimit`) + `requireIntegrity.ts` middleware (checks verdict, fail-open non-strict, strict=true enforces 403). Middleware wired into `transitionActiveJobStatus` and `confirmBooking` routes.
- `play-integrity = "1.4.0"` dependency added to both app `build.gradle.kts` (library already in `libs.versions.toml`).

## Test plan

- [x] API typecheck: `pnpm typecheck` — clean
- [x] API lint: `pnpm lint --max-warnings 0` — clean
- [x] API tests: `pnpm test` — **1004/1004 passed** (includes new `nonce.test.ts` + `requireIntegrity.test.ts`)
- [ ] Android unit tests (requires CI Linux with Android SDK): `PlayIntegrityAttestorTest`, updated `ConfirmBookingUseCaseTest`, `MarkReachedUseCaseTest`, `DigiLockerConsentUseCaseTest`, `KycRepositoryImplTest`, `KycRepositoryTest`, `StartTripUseCaseTest`, `CompleteJobUseCaseTest`, `StartWorkUseCaseTest`
- [ ] Kover coverage gates — CI will verify `≥50% line / 35% branch / 40% instruction` for technician-app and `≥80%/69%/80%` for customer-app

## Key design decisions

- **Fail-open enforcement**: absent tokens warn to Sentry but never block (non-strict default). Set `PLAY_INTEGRITY_STRICT=true` in production when coverage is sufficient.
- **No `@Inject` on PlayIntegrityAttestor constructor**: `debugBypass: Boolean` param made it non-injectable by Hilt directly; `IntegrityModule` uses `@Provides` to construct with `BuildConfig.DEBUG`.
- **`IntegrityApiService` per-app**: technician-app uses `Authorization` header on nonce endpoint (Firebase token); customer-app uses the shared auth OkHttpClient interceptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)