### PR TITLE
feat(E11-S07): enable R8/minify + ProGuard keep rules for Razorpay/Maps/Truecaller/Moshi/Coil

### DIFF
--- a/.github/workflows/customer-ship.yml
+++ b/.github/workflows/customer-ship.yml
@@ -73,6 +73,9 @@ jobs:
       - name: unit tests + coverage gate
         run: ./gradlew testDebugUnitTest koverVerify
 
+      - name: assemble release (verify R8 + ProGuard)
+        run: ./gradlew assembleRelease
+
       - name: ktlint + detekt + android lint
         run: ./gradlew ktlintCheck detekt lintDebug
 

--- a/.github/workflows/technician-ship.yml
+++ b/.github/workflows/technician-ship.yml
@@ -72,6 +72,9 @@ jobs:
       - name: unit tests + coverage gate
         run: ./gradlew testDebugUnitTest koverVerify
 
+      - name: assemble release (verify R8 + ProGuard)
+        run: ./gradlew assembleRelease
+
       - name: ktlint + detekt + android lint
         run: ./gradlew ktlintCheck detekt lintDebug
 

--- a/customer-app/app/build.gradle.kts
+++ b/customer-app/app/build.gradle.kts
@@ -108,12 +108,13 @@ android {
             isMinifyEnabled = false
         }
         release {
-            // TODO(deploy-story): enable minification before Play Store submission — skeleton intentionally disabled
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            // NOTE: signing config will be added in E13-S09 (Android release pipeline)
         }
     }
 

--- a/customer-app/app/proguard-rules.pro
+++ b/customer-app/app/proguard-rules.pro
@@ -1,5 +1,3 @@
-# Release minification rules land in the deploy story (E0x-Sxx). Skeleton keeps minify off.
-
 # Truecaller SDK — SDK classes use reflection; must not be renamed or removed
 -keep class com.truecaller.android.sdk.** { *; }
 -dontwarn com.truecaller.android.sdk.**
@@ -14,3 +12,38 @@
 # Firebase Google auth provider
 -keep class com.google.firebase.auth.GoogleAuthProvider { *; }
 -keep class com.google.firebase.auth.FirebaseAuthUserCollisionException { *; }
+
+# Razorpay SDK (customer-app payment flow)
+-keep class com.razorpay.** { *; }
+-keep class proguard.annotation.** { *; }
+-keepattributes JavascriptInterface
+-keepclassmembers class * { @android.webkit.JavascriptInterface <methods>; }
+-dontwarn com.razorpay.**
+
+# Google Maps + Places SDK
+-keep class com.google.android.gms.maps.** { *; }
+-keep class com.google.android.libraries.places.** { *; }
+-dontwarn com.google.android.gms.**
+-dontwarn com.google.android.libraries.places.**
+
+# Google Maps Compose
+-keep class com.google.maps.android.** { *; }
+
+# Moshi + Kotlin codegen
+-keep @com.squareup.moshi.JsonClass class * { *; }
+-keep class * extends com.squareup.moshi.JsonAdapter { *; }
+-keepclassmembers class * { @com.squareup.moshi.Json <fields>; }
+
+# Coil image loading
+-dontwarn coil.**
+
+# Play Integrity (already has reflection via SDK)
+-keep class com.google.android.play.core.integrity.** { *; }
+-dontwarn com.google.android.play.core.integrity.**
+
+# OkHttp / Retrofit
+-dontwarn okhttp3.**
+-dontwarn retrofit2.**
+
+# Sentry
+-dontwarn io.sentry.**

--- a/technician-app/app/build.gradle.kts
+++ b/technician-app/app/build.gradle.kts
@@ -103,11 +103,13 @@ android {
             isMinifyEnabled = false
         }
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            // NOTE: signing config will be added in E13-S09 (Android release pipeline)
         }
     }
 

--- a/technician-app/app/proguard-rules.pro
+++ b/technician-app/app/proguard-rules.pro
@@ -1,5 +1,3 @@
-# Release minification rules land in the deploy story (E0x-Sxx). Skeleton keeps minify off.
-
 # Truecaller SDK
 -keep class com.truecaller.android.sdk.** { *; }
 -dontwarn com.truecaller.android.sdk.**
@@ -16,3 +14,42 @@
 -keep class com.google.android.libraries.identity.googleid.** { *; }
 -keep class com.google.firebase.auth.GoogleAuthProvider { *; }
 -keep class com.google.firebase.auth.FirebaseAuthUserCollisionException { *; }
+
+# Razorpay SDK (mirrored for safety — technician-app does not process payments)
+-keep class com.razorpay.** { *; }
+-keep class proguard.annotation.** { *; }
+-keepattributes JavascriptInterface
+-keepclassmembers class * { @android.webkit.JavascriptInterface <methods>; }
+-dontwarn com.razorpay.**
+
+# Google Maps + Places SDK
+-keep class com.google.android.gms.maps.** { *; }
+-keep class com.google.android.libraries.places.** { *; }
+-dontwarn com.google.android.gms.**
+-dontwarn com.google.android.libraries.places.**
+
+# Google Maps Compose
+-keep class com.google.maps.android.** { *; }
+
+# Moshi + Kotlin codegen
+-keep @com.squareup.moshi.JsonClass class * { *; }
+-keep class * extends com.squareup.moshi.JsonAdapter { *; }
+-keepclassmembers class * { @com.squareup.moshi.Json <fields>; }
+
+# Coil image loading
+-dontwarn coil.**
+
+# Play Integrity (already has reflection via SDK)
+-keep class com.google.android.play.core.integrity.** { *; }
+-dontwarn com.google.android.play.core.integrity.**
+
+# OkHttp / Retrofit
+-dontwarn okhttp3.**
+-dontwarn retrofit2.**
+
+# Sentry
+-dontwarn io.sentry.**
+
+# Keepattributes for reflection
+-keepattributes Signature
+-keepattributes *Annotation*


### PR DESCRIPTION
## Summary

- Enable `isMinifyEnabled = true` + `isShrinkResources = true` in the `release` buildType for both `customer-app` and `technician-app` (signing config deferred to E13-S09)
- Add comprehensive ProGuard keep rules to both apps: Razorpay SDK, Google Maps + Places, Maps Compose, Truecaller, Moshi codegen, Coil, Play Integrity, OkHttp/Retrofit, Sentry
- Add `assembleRelease` step to both `customer-ship.yml` and `technician-ship.yml` CI workflows so every PR gates on a passing R8 compilation

## Verification

- `./gradlew assembleRelease` — BUILD SUCCESSFUL for both apps (locally verified)
- Pre-codex smoke gate PASSED for both apps
- Only 6 non-Kotlin files changed: 2× `build.gradle.kts`, 2× `proguard-rules.pro`, 2× workflow YAMLs

## Deferred

- [ ] Razorpay-live-gate: in-app payment smoke with R8 enabled (deferred — awaiting Razorpay account provisioning)

## Test plan

- [ ] CI `customer-ship` workflow passes including new `assemble release (verify R8 + ProGuard)` step
- [ ] CI `technician-ship` workflow passes including new `assemble release (verify R8 + ProGuard)` step
- [ ] No R8 shrinkage warnings beyond the known GMS `play-services-location` companion object note

🤖 Generated with [Claude Code](https://claude.com/claude-code)