### PR TITLE
fix(api): remove ORDER BY from cross-partition bookings query

### DIFF
--- a/api/src/cosmos/booking-repository.ts
+++ b/api/src/cosmos/booking-repository.ts
@@ -129,12 +129,16 @@ export const bookingRepo = {
                   AND c.status IN (
                     'ASSIGNED', 'EN_ROUTE', 'REACHED', 'IN_PROGRESS',
                     'AWAITING_PRICE_APPROVAL', 'COMPLETED', 'PAID', 'CLOSED'
-                  )
-                ORDER BY c.slotDate ASC, c.slotWindow ASC`,
+                  )`,
         parameters: [{ name: '@technicianId', value: technicianId }],
       })
       .fetchAll();
-    return resources;
+    // Sort in memory — ORDER BY on a cross-partition (non-PK) query requires
+    // a composite index that isn't provisioned on the bookings container.
+    return resources.sort(
+      (a, b) =>
+        a.slotDate.localeCompare(b.slotDate) || a.slotWindow.localeCompare(b.slotWindow),
+    );
   },
 
   async getByCustomerId(customerId: string): Promise<BookingDoc[]> {


### PR DESCRIPTION
## Summary
- `getByTechnicianId` ran a cross-partition scan (partition key is `customerId`, not `technicianId`) with `ORDER BY slotDate, slotWindow`
- Cosmos DB rejects cross-partition `ORDER BY` without a composite index → 500 `INTERNAL_ERROR`
- Surfaced as **"Could not refresh jobs"** in the technician app Jobs screen
- Fix: drop `ORDER BY` from the query, sort result in memory (identical output, no index required)

## Test plan
- [x] Verified root cause via OkHttp logcat — endpoint was returning `{"code":"INTERNAL_ERROR"}`
- [ ] CI quality-gate passes
- [ ] Deploy to prod via `api-ship.yml` after merge
- [ ] Verify Jobs screen loads after deploy

🤖 Generated with [Claude Code](https://claude.ai/claude-code)