### PR TITLE
fix(api): keep technician jobs response safe

### DIFF
--- a/api/src/functions/technician-bookings.ts
+++ b/api/src/functions/technician-bookings.ts
@@ -7,6 +7,78 @@ import { bookingRepo } from '../cosmos/booking-repository.js';
 import type { BookingDoc } from '../schemas/booking.js';
 import { catalogueRepo } from '../cosmos/catalogue-repository.js';
 
+type BookingRecord = Partial<BookingDoc> & Record<string, unknown>;
+
+function safeWarn(ctx: InvocationContext, message: string): void {
+  try {
+    ctx.warn(message);
+  } catch {
+    // Logging must not decide the API response path.
+  }
+}
+
+function safeError(ctx: InvocationContext, message: string, detail: string): void {
+  try {
+    ctx.error(message, detail);
+  } catch {
+    // Logging must not decide the API response path.
+  }
+}
+
+function asBookingRecord(value: unknown): BookingRecord | null {
+  if (typeof value === 'object' && value !== null) {
+    return value as BookingRecord;
+  }
+  return null;
+}
+
+function safeString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+function safeAmount(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function safeLatLng(value: unknown): { lat: number; lng: number } {
+  if (typeof value === 'object' && value !== null) {
+    const { lat, lng } = value as { lat?: unknown; lng?: unknown };
+    if (
+      typeof lat === 'number' &&
+      Number.isFinite(lat) &&
+      typeof lng === 'number' &&
+      Number.isFinite(lng)
+    ) {
+      return { lat, lng };
+    }
+  }
+  return { lat: 0, lng: 0 };
+}
+
+function toTechnicianBookingDto(
+  booking: BookingRecord,
+  serviceNames: Map<string, string>,
+) {
+  const bookingId = safeString(booking.id, '');
+  if (!bookingId) return null;
+
+  const serviceId = safeString(booking.serviceId, 'unknown-service');
+  const amount = safeAmount(booking.finalAmount, safeAmount(booking.amount, 0));
+
+  return {
+    bookingId,
+    customerId: safeString(booking.customerId, ''),
+    serviceId,
+    serviceName: serviceNames.get(serviceId) ?? safeString(booking.serviceName, serviceId),
+    addressText: safeString(booking.addressText, ''),
+    addressLatLng: safeLatLng(booking.addressLatLng),
+    status: safeString(booking.status, 'UNKNOWN'),
+    slotDate: safeString(booking.slotDate, ''),
+    slotWindow: safeString(booking.slotWindow, ''),
+    amount,
+  };
+}
+
 export const getMyTechnicianBookingsHandler: HttpHandler = async (
   req: HttpRequest,
   ctx: InvocationContext,
@@ -27,13 +99,35 @@ export const getMyTechnicianBookingsHandler: HttpHandler = async (
       // Cosmos Serverless free tier. Return empty list for F&F pilot — new
       // technicians have no jobs anyway. Sentry captures for visibility.
       Sentry.captureException(queryErr);
-      ctx.warn('getByTechnicianId failed (cross-partition scan); returning empty list for pilot');
+      safeWarn(ctx, 'getByTechnicianId failed (cross-partition scan); returning empty list for pilot');
       return { status: 200, jsonBody: { bookings: [] } };
     }
 
+    if (!Array.isArray(bookings)) {
+      Sentry.captureException(new Error('getByTechnicianId returned a non-array result'));
+      safeWarn(ctx, 'getByTechnicianId returned a non-array result; returning empty list');
+      return { status: 200, jsonBody: { bookings: [] } };
+    }
+
+    const bookingRecords = bookings.flatMap((booking) => {
+      const record = asBookingRecord(booking);
+      if (!record) {
+        Sentry.captureException(new Error('getByTechnicianId returned a malformed booking row'));
+        safeWarn(ctx, 'getByTechnicianId returned a malformed booking row; skipping it');
+        return [];
+      }
+      return [record];
+    });
+
     const serviceNames = new Map<string, string>();
     await Promise.all(
-      [...new Set(bookings.map((booking) => booking.serviceId))].map(async (serviceId) => {
+      [
+        ...new Set(
+          bookingRecords
+            .map((booking) => safeString(booking.serviceId, ''))
+            .filter((serviceId) => serviceId.length > 0),
+        ),
+      ].map(async (serviceId) => {
         try {
           const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
           if (service?.name) {
@@ -41,7 +135,7 @@ export const getMyTechnicianBookingsHandler: HttpHandler = async (
           }
         } catch (catalogueErr: unknown) {
           Sentry.captureException(catalogueErr);
-          ctx.warn(`getServiceByIdCrossPartition failed for ${serviceId}; using booking fallback`);
+          safeWarn(ctx, `getServiceByIdCrossPartition failed for ${serviceId}; using booking fallback`);
         }
       }),
     );
@@ -49,24 +143,21 @@ export const getMyTechnicianBookingsHandler: HttpHandler = async (
     return {
       status: 200,
       jsonBody: {
-        bookings: bookings.map((booking) => ({
-          bookingId: booking.id,
-          customerId: booking.customerId,
-          serviceId: booking.serviceId,
-          serviceName: serviceNames.get(booking.serviceId) ?? booking.serviceName ?? booking.serviceId,
-          addressText: booking.addressText,
-          addressLatLng: booking.addressLatLng,
-          status: booking.status,
-          slotDate: booking.slotDate,
-          slotWindow: booking.slotWindow,
-          amount: booking.finalAmount ?? booking.amount,
-        })),
+        bookings: bookingRecords.flatMap((booking) => {
+          const dto = toTechnicianBookingDto(booking, serviceNames);
+          if (!dto) {
+            Sentry.captureException(new Error('Skipping technician booking row without id'));
+            safeWarn(ctx, 'Skipping technician booking row without id');
+            return [];
+          }
+          return [dto];
+        }),
       },
     };
   } catch (err: unknown) {
     Sentry.captureException(err);
-    ctx.error('getMyTechnicianBookings failed', err instanceof Error ? err.message : String(err));
-    return { status: 500, jsonBody: { code: 'INTERNAL_ERROR' } };
+    safeError(ctx, 'getMyTechnicianBookings failed; returning empty list', err instanceof Error ? err.message : String(err));
+    return { status: 200, jsonBody: { bookings: [] } };
   }
 };
 

--- a/api/tests/functions/technician-bookings.test.ts
+++ b/api/tests/functions/technician-bookings.test.ts
@@ -98,6 +98,53 @@ describe('GET /v1/technicians/me/bookings', () => {
     expect(res.jsonBody).toEqual({ bookings: [] });
   });
 
+  it('returns empty bookings when the repository returns an invalid result shape', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (bookingRepo.getByTechnicianId as MockFn).mockResolvedValue(null);
+
+    const res = (await handler(makeReq(), ctx)) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect(res.jsonBody).toEqual({ bookings: [] });
+  });
+
+  it('skips malformed booking rows and defaults missing optional response fields', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    const { catalogueRepo } = await import('../../src/cosmos/catalogue-repository.js');
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (bookingRepo.getByTechnicianId as MockFn).mockResolvedValue([
+      null,
+      {
+        id: 'bk-1',
+        serviceId: 'ac-deep-clean',
+      },
+    ]);
+    (catalogueRepo.getServiceByIdCrossPartition as MockFn).mockResolvedValue({ name: 'AC deep clean' });
+
+    const res = (await handler(makeReq(), ctx)) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect(res.jsonBody).toEqual({
+      bookings: [
+        {
+          bookingId: 'bk-1',
+          customerId: '',
+          serviceId: 'ac-deep-clean',
+          serviceName: 'AC deep clean',
+          addressText: '',
+          addressLatLng: { lat: 0, lng: 0 },
+          status: 'UNKNOWN',
+          slotDate: '',
+          slotWindow: '',
+          amount: 0,
+        },
+      ],
+    });
+  });
+
   it('uses booking serviceName fallback when catalogue lookup fails', async () => {
     const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
     const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');


### PR DESCRIPTION
## Summary
- harden technician jobs response shaping against malformed production rows
- keep catalogue and logging failures non-fatal
- return an empty bookings list instead of a 500 as the last-resort fallback

## Tests
- pnpm build
- pnpm test -- tests/functions/technician-bookings.test.ts
- pnpm lint