### PR TITLE
fix(admin-web): shrink SWA Next function bundle

### DIFF
--- a/admin-web/next.config.ts
+++ b/admin-web/next.config.ts
@@ -9,6 +9,7 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const config: NextConfig = {
   reactStrictMode: true,
+  output: 'standalone',
   // typedRoutes: disabled during E12-S03a — all dashboard routes now under [locale]/
   // but existing catalogue navigation still uses bare paths (/catalogue/...).
   // Re-enable in E12-S03b when all navigation calls are updated to locale-aware paths.


### PR DESCRIPTION
## Summary
- enable Next standalone output for Azure Static Web Apps hybrid deployment
- reduce the generated Next server bundle used by the managed Functions backend

## Verification
- pnpm lint --max-warnings 0
- pnpm typecheck
- npm run build
- measured .next/standalone at ~84 MB locally