### PR TITLE
fix(admin-web): keep SWA redirects on public host

### DIFF
--- a/admin-web/middleware.ts
+++ b/admin-web/middleware.ts
@@ -47,6 +47,28 @@ function getSetCookieHeaders(headers: Headers): string[] {
   return combined ? splitSetCookieHeader(combined) : [];
 }
 
+function firstForwardedValue(value: string | null): string | null {
+  return value?.split(',')[0]?.trim() || null;
+}
+
+function externalUrl(request: NextRequest, pathname: string): URL {
+  const protocol =
+    firstForwardedValue(request.headers.get('x-forwarded-proto')) ??
+    request.nextUrl.protocol.replace(/:$/, '');
+  const host =
+    firstForwardedValue(request.headers.get('x-forwarded-host')) ??
+    firstForwardedValue(request.headers.get('host')) ??
+    request.nextUrl.host;
+
+  const url = new URL(`${protocol}://${host}`);
+  if (url.protocol === 'https:' && url.port === '8080') {
+    url.port = '';
+  }
+  url.pathname = pathname;
+  url.search = '';
+  return url;
+}
+
 function isLocalhost(requestUrl: string): boolean {
   const hostname = new URL(requestUrl).hostname;
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
@@ -108,7 +130,7 @@ function clearAdminCookies(response: NextResponse): void {
 
 function redirectToLogin(request: NextRequest): NextResponse {
   const locale = getLocaleFromRequest(request, routing.defaultLocale, routing.locales);
-  const loginUrl = new URL(`/${locale}/login`, request.url);
+  const loginUrl = externalUrl(request, `/${locale}/login`);
   loginUrl.searchParams.set('next', request.nextUrl.pathname);
   const response = NextResponse.redirect(loginUrl);
   clearAdminCookies(response);
@@ -117,7 +139,7 @@ function redirectToLogin(request: NextRequest): NextResponse {
 
 function redirectToNotAuthorized(request: NextRequest, role: AdminRole): NextResponse {
   const locale = getLocaleFromRequest(request, routing.defaultLocale, routing.locales);
-  const url = new URL(`/${locale}/not-authorized`, request.url);
+  const url = externalUrl(request, `/${locale}/not-authorized`);
   url.searchParams.set('from', request.nextUrl.pathname);
   const rawDefault = defaultPathForRole(role);
   url.searchParams.set('next', `/${locale}${rawDefault}`);
@@ -192,6 +214,25 @@ export async function middleware(request: NextRequest) {
 
   // 2. Strip locale prefix to get the underlying path for capability checks
   const rawPath = stripLocalePrefix(pathname, routing.locales);
+  const hasLocalePrefix = routing.locales.some(
+    (locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
+  );
+
+  if (rawPath === '/') {
+    const locale = getLocaleFromRequest(request, routing.defaultLocale, routing.locales);
+    return NextResponse.redirect(externalUrl(request, `/${locale}/login`));
+  }
+
+  if (
+    !hasLocalePrefix &&
+    (rawPath === '/login' ||
+      rawPath.startsWith('/login/') ||
+      rawPath === '/setup' ||
+      rawPath.startsWith('/setup/'))
+  ) {
+    const locale = getLocaleFromRequest(request, routing.defaultLocale, routing.locales);
+    return NextResponse.redirect(externalUrl(request, `/${locale}${rawPath}`));
+  }
 
   // 3. Public paths — locale routing only, no JWT required
   const PUBLIC_PATHS = ['/', '/login', '/setup'];

--- a/admin-web/tests/middleware.test.ts
+++ b/admin-web/tests/middleware.test.ts
@@ -15,10 +15,15 @@ import { middleware } from '../middleware';
 
 const JWT_SECRET = 'test-secret-that-is-long-enough-for-hs256-minimum-32-chars!!';
 
-function makeRequest(pathname: string, cookie?: string): NextRequest {
-  const url = `http://localhost:3000${pathname}`;
-  if (!cookie) return new NextRequest(url);
-  return new NextRequest(url, { headers: { cookie } });
+function makeRequest(
+  pathname: string,
+  cookie?: string,
+  headers?: HeadersInit,
+  origin = 'http://localhost:3000',
+): NextRequest {
+  const requestHeaders = new Headers(headers);
+  if (cookie) requestHeaders.set('cookie', cookie);
+  return new NextRequest(`${origin}${pathname}`, { headers: requestHeaders });
 }
 
 async function signAccessToken(role: AdminRole): Promise<string> {
@@ -99,6 +104,62 @@ describe('admin middleware session refresh', () => {
     expect(setCookie).toContain('hs_access=');
     expect(setCookie).toContain('hs_refresh=');
     expect(setCookie).toContain('Path=/admin-api/v1/admin/auth/refresh');
+  });
+
+  it('keeps SWA backend port out of unauthenticated redirects', async () => {
+    vi.stubEnv('JWT_SECRET', JWT_SECRET);
+
+    const response = await middleware(
+      makeRequest(
+        '/orders',
+        undefined,
+        {
+          'x-forwarded-host': 'black-river-0af326a00.7.azurestaticapps.net',
+          'x-forwarded-proto': 'https',
+        },
+        'https://black-river-0af326a00.7.azurestaticapps.net:8080',
+      ),
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://black-river-0af326a00.7.azurestaticapps.net/hi/login?next=%2Forders',
+    );
+  });
+
+  it('redirects locale roots directly to login without the SWA backend port', async () => {
+    const response = await middleware(
+      makeRequest(
+        '/',
+        undefined,
+        {
+          'x-forwarded-host': 'black-river-0af326a00.7.azurestaticapps.net',
+          'x-forwarded-proto': 'https',
+        },
+        'https://black-river-0af326a00.7.azurestaticapps.net:8080',
+      ),
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://black-river-0af326a00.7.azurestaticapps.net/hi/login',
+    );
+  });
+
+  it('redirects unprefixed public routes to their locale-prefixed URL without the SWA backend port', async () => {
+    const response = await middleware(
+      makeRequest(
+        '/login',
+        undefined,
+        {
+          'x-forwarded-host': 'black-river-0af326a00.7.azurestaticapps.net',
+          'x-forwarded-proto': 'https',
+        },
+        'https://black-river-0af326a00.7.azurestaticapps.net:8080',
+      ),
+    );
+
+    expect(response.headers.get('location')).toBe(
+      'https://black-river-0af326a00.7.azurestaticapps.net/hi/login',
+    );
   });
 
   it('keeps RBAC redirects after a successful refresh', async () => {


### PR DESCRIPTION
## Summary
- build middleware redirects from forwarded public host/proto instead of SWA backend :8080 origin
- redirect root and unprefixed public admin routes directly to locale-prefixed login/setup paths
- add regression coverage for SWA forwarded-host redirects

## Verification
- pnpm test -- tests/middleware.test.ts
- pnpm lint --max-warnings 0
- pnpm typecheck
- npm run build