### PR TITLE
docs: mark admin SWA as canonical

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@
 
 Each sub-project has its own `CLAUDE.md` with stack-specific rules. **This root file governs cross-cutting concerns only.**
 
+## Production deployment ownership
+
+- **Admin web canonical production frontend:** Azure Static Web Apps resource `swa-homeservices-admin-prod`, public URL `https://black-river-0af326a00.7.azurestaticapps.net`, deployed by `.github/workflows/admin-ship.yml` from `main`.
+- **Do not use the old admin Azure Container App URL** (`aca-admin-homeservices-prod...azurecontainerapps.io`) for validation, screenshots, or customer/admin access. It is a legacy/stale endpoint from the pre-SWA migration path and is not kept in sync with `main`.
+- Do not add a new ACA admin deploy path, redirect users to ACA, or treat ACA as canonical unless the user explicitly approves a migration ADR and a single-source-of-truth cutover plan.
+
 ## Phase gate (enforced across all sub-projects)
 
 **No `src/` or `app/src/` edits in any sub-project** until ALL of the following exist and are committed:

--- a/admin-web/CLAUDE.md
+++ b/admin-web/CLAUDE.md
@@ -32,6 +32,14 @@ Hooks in `.claude/settings.json` enforce this.
 - Vitest + Playwright
 - CI: type, lint, test (≥80% coverage), Semgrep, axe-core, Lighthouse CI, Codex review
 
+## Production deployment
+
+- Canonical production admin frontend is Azure Static Web Apps resource `swa-homeservices-admin-prod`.
+- Public SWA URL: `https://black-river-0af326a00.7.azurestaticapps.net`.
+- Deploy workflow: `.github/workflows/admin-ship.yml` on `main`.
+- The old Azure Container App `aca-admin-homeservices-prod` is a legacy/stale admin endpoint and must not be used for validation or access unless a user-approved migration ADR makes ACA canonical again.
+- Firebase client auth config is baked into the SWA build from GitHub Actions secrets `NEXT_PUBLIC_FIREBASE_API_KEY`, `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`, and `NEXT_PUBLIC_FIREBASE_PROJECT_ID`. If login shows `auth/api-key-not-valid`, check those repo secrets before changing code.
+
 ## Override
 
 Set `CLAUDE_OVERRIDE_REASON="<reason>"` to bypass a hook. Logged to `~/.claude/override-log.jsonl`.


### PR DESCRIPTION
## Summary
- Document Static Web Apps as the canonical admin production frontend
- Mark the old admin Azure Container App as a legacy stale endpoint
- Add Firebase build-secret note for auth/api-key-not-valid troubleshooting

## Verification
- git diff --check