### PR TITLE
fix(api): dashboard metrics and dispatch offer timer

### DIFF
--- a/api/src/cosmos/finance-repository.ts
+++ b/api/src/cosmos/finance-repository.ts
@@ -11,6 +11,8 @@ interface CompletedBooking {
   completedAt: string;
 }
 
+const DEFAULT_COMMISSION_BPS = 2200;
+
 interface LedgerTransferDoc {
   id: string;
   type: 'TRANSFER';
@@ -57,7 +59,7 @@ export async function getDailyPnL(from: string, to: string): Promise<FinanceSumm
 
   for (const b of bookings) {
     const date = b.completedAt.slice(0, 10);
-    const bps = b.commissionBps ?? 0;
+    const bps = b.commissionBps ?? DEFAULT_COMMISSION_BPS;
     const commission = Math.round(b.amount * bps / 10000);
     const existing = byDate.get(date) ?? { gross: 0, commission: 0 };
     byDate.set(date, { gross: existing.gross + b.amount, commission: existing.commission + commission });
@@ -81,7 +83,7 @@ export async function getPayoutQueue(weekStart: string, weekEnd: string): Promis
   const byTech = new Map<string, { name: string; jobs: number; gross: number; commission: number }>();
 
   for (const b of bookings) {
-    const bps = b.commissionBps ?? 0;
+    const bps = b.commissionBps ?? DEFAULT_COMMISSION_BPS;
     const commission = Math.round(b.amount * bps / 10000);
     const existing = byTech.get(b.technicianId) ?? { name: b.technicianName, jobs: 0, gross: 0, commission: 0 };
     byTech.set(b.technicianId, {

--- a/api/src/functions/admin/customers/list.ts
+++ b/api/src/functions/admin/customers/list.ts
@@ -4,6 +4,7 @@ import { requireAdmin } from '../../../middleware/requireAdmin.js';
 import type { AdminContext } from '../../../types/admin.js';
 import { getCustomerSummaries } from '../../../cosmos/booking-repository.js';
 import { getCustomerMetadata } from '../../../cosmos/customer-metadata-repository.js';
+import { getFirebaseAdmin } from '../../../services/firebaseAdmin.js';
 import type { AdminCustomer } from '../../../schemas/admin-customer.js';
 
 function maskPhone(phone: string): string {
@@ -21,19 +22,21 @@ export async function adminListCustomersHandler(
 
   const customerIds = summaries.map((s) => s.customerId);
 
-  // Batch fetch Firebase Auth users (100 at a time)
-  const firebaseAdmin = await import('firebase-admin');
-  const firebaseApp = firebaseAdmin.app();
   const authMap = new Map<string, { displayName?: string; phoneNumber?: string }>();
-  for (let i = 0; i < customerIds.length; i += 100) {
-    const chunk = customerIds.slice(i, i + 100);
-    const { users } = await firebaseApp.auth().getUsers(chunk.map((uid) => ({ uid })));
-    for (const u of users) {
-      const entry: { displayName?: string; phoneNumber?: string } = {};
-      if (u.displayName) entry.displayName = u.displayName;
-      if (u.phoneNumber) entry.phoneNumber = u.phoneNumber;
-      authMap.set(u.uid, entry);
+  try {
+    const auth = getFirebaseAdmin().auth();
+    for (let i = 0; i < customerIds.length; i += 100) {
+      const chunk = customerIds.slice(i, i + 100);
+      const { users } = await auth.getUsers(chunk.map((uid) => ({ uid })));
+      for (const u of users) {
+        const entry: { displayName?: string; phoneNumber?: string } = {};
+        if (u.displayName) entry.displayName = u.displayName;
+        if (u.phoneNumber) entry.phoneNumber = u.phoneNumber;
+        authMap.set(u.uid, entry);
+      }
     }
+  } catch {
+    // Firebase Auth metadata is best-effort; booking summaries still render without it.
   }
 
   const metadataMap = await getCustomerMetadata(customerIds);

--- a/api/src/functions/admin/dashboard/summary.ts
+++ b/api/src/functions/admin/dashboard/summary.ts
@@ -3,16 +3,33 @@ import { app, type HttpRequest, type HttpResponseInit, type InvocationContext } 
 import { requireAdmin } from '../../../middleware/requireAdmin.js';
 import type { AdminContext } from '../../../types/admin.js';
 import { getCosmosClient, DB_NAME } from '../../../cosmos/client.js';
+import { getPayoutQueue, getWeekSnapshot } from '../../../cosmos/finance-repository.js';
 import { DashboardSummaryResponseSchema } from '../../../schemas/dashboard.js';
 
 const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
 
-function getIndiaBusinessDayStartIso(now = new Date()): string {
+function getIndiaBusinessDay(now = new Date()): { date: string; startIso: string } {
   const shifted = new Date(now.getTime() + IST_OFFSET_MS);
   const year = shifted.getUTCFullYear();
   const month = shifted.getUTCMonth();
   const date = shifted.getUTCDate();
-  return new Date(Date.UTC(year, month, date) - IST_OFFSET_MS).toISOString();
+  const start = new Date(Date.UTC(year, month, date) - IST_OFFSET_MS);
+  return {
+    date: shifted.toISOString().slice(0, 10),
+    startIso: start.toISOString(),
+  };
+}
+
+function priorWeekBounds(now = new Date()): { weekStart: string; weekEnd: string } {
+  const weekEnd = new Date(now);
+  weekEnd.setUTCHours(0, 0, 0, 0);
+  weekEnd.setUTCDate(weekEnd.getUTCDate() - 1);
+  const weekStart = new Date(weekEnd);
+  weekStart.setUTCDate(weekStart.getUTCDate() - 6);
+  return {
+    weekStart: weekStart.toISOString().slice(0, 10),
+    weekEnd: weekEnd.toISOString().slice(0, 10),
+  };
 }
 
 export async function summaryHandler(
@@ -22,27 +39,35 @@ export async function summaryHandler(
 ): Promise<HttpResponseInit> {
   try {
     const db = getCosmosClient().database(DB_NAME);
-    const todayIso = getIndiaBusinessDayStartIso();
+    const today = getIndiaBusinessDay();
+    const { weekStart, weekEnd } = priorWeekBounds();
 
     const [bookingsResult, gmvResult, techsResult] = await Promise.all([
       db
         .container('bookings')
         .items.query({
-          query: 'SELECT VALUE COUNT(1) FROM c WHERE c.createdAt >= @today',
-          parameters: [{ name: '@today', value: todayIso }],
+          query: 'SELECT VALUE COUNT(1) FROM c WHERE c.slotDate = @todayDate OR c.createdAt >= @todayStart',
+          parameters: [
+            { name: '@todayDate', value: today.date },
+            { name: '@todayStart', value: today.startIso },
+          ],
         })
         .fetchAll(),
       db
         .container('bookings')
         .items.query({
-          query: 'SELECT VALUE SUM(IIF(IS_DEFINED(c.finalAmount), c.finalAmount, c.amount)) FROM c WHERE c.createdAt >= @today',
-          parameters: [{ name: '@today', value: todayIso }],
+          query:
+            'SELECT VALUE SUM(IIF(IS_DEFINED(c.finalAmount), c.finalAmount, c.amount)) FROM c WHERE c.slotDate = @todayDate OR c.createdAt >= @todayStart',
+          parameters: [
+            { name: '@todayDate', value: today.date },
+            { name: '@todayStart', value: today.startIso },
+          ],
         })
         .fetchAll(),
       db
         .container('technicians')
         .items.query({
-          query: 'SELECT VALUE COUNT(1) FROM c WHERE c.isOnDuty = true',
+          query: 'SELECT VALUE COUNT(1) FROM c WHERE c.isOnline = true AND (NOT IS_DEFINED(c.suspended) OR c.suspended = false)',
           parameters: [],
         })
         .fetchAll(),
@@ -62,13 +87,15 @@ export async function summaryHandler(
         throw err;
       });
 
+    const payoutQueue =
+      (await getWeekSnapshot(weekStart).catch(() => null)) ?? (await getPayoutQueue(weekStart, weekEnd));
     const commissionRate = parseFloat(process.env['COMMISSION_RATE'] ?? '0.225');
     const gmvToday: number = (gmvResult.resources[0] as number | undefined) ?? 0;
     const summary = {
       bookingsToday: (bookingsResult.resources[0] as number | undefined) ?? 0,
       gmvToday,
       commissionToday: Math.round(gmvToday * commissionRate),
-      payoutsPending: 0,
+      payoutsPending: Math.round(payoutQueue.totalNetPayable),
       complaintsOpen,
       techsOnDuty: (techsResult.resources[0] as number | undefined) ?? 0,
     };

--- a/api/src/functions/admin/dashboard/tech-locations.ts
+++ b/api/src/functions/admin/dashboard/tech-locations.ts
@@ -5,6 +5,37 @@ import type { AdminContext } from '../../../types/admin.js';
 import { getCosmosClient, DB_NAME } from '../../../cosmos/client.js';
 import { TechLocationsResponseSchema } from '../../../schemas/dashboard.js';
 
+interface TechnicianLocationDoc {
+  id?: string;
+  technicianId?: string;
+  displayName?: string;
+  name?: string;
+  serviceType?: string;
+  skills?: string[];
+  lat?: number;
+  lng?: number;
+  location?: { coordinates?: [number, number] };
+  state?: 'active' | 'enroute' | 'idle' | 'alert';
+  isAvailable?: boolean;
+  updatedAt?: string;
+}
+
+function toTechLocation(doc: TechnicianLocationDoc) {
+  const lng = typeof doc.lng === 'number' ? doc.lng : doc.location?.coordinates?.[0];
+  const lat = typeof doc.lat === 'number' ? doc.lat : doc.location?.coordinates?.[1];
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+
+  return {
+    technicianId: doc.technicianId ?? doc.id ?? 'unknown',
+    ...(doc.displayName ?? doc.name ? { name: doc.displayName ?? doc.name } : {}),
+    ...(doc.serviceType ?? doc.skills?.[0] ? { serviceType: doc.serviceType ?? doc.skills?.[0] } : {}),
+    lat,
+    lng,
+    state: doc.state ?? (doc.isAvailable === false ? 'enroute' : 'active'),
+    updatedAt: doc.updatedAt ?? new Date().toISOString(),
+  };
+}
+
 export async function techLocationsHandler(
   _req: HttpRequest,
   ctx: InvocationContext,
@@ -17,12 +48,14 @@ export async function techLocationsHandler(
       .container('technicians')
       .items.query({
         query:
-          'SELECT c.technicianId, c.name, c.serviceType, c.lat, c.lng, c.state, c.updatedAt FROM c WHERE c.isOnDuty = true',
+          'SELECT c.id, c.technicianId, c.displayName, c.name, c.serviceType, c.skills, c.lat, c.lng, c.location, c.state, c.isAvailable, c.updatedAt FROM c WHERE c.isOnline = true AND (NOT IS_DEFINED(c.suspended) OR c.suspended = false)',
         parameters: [],
       })
       .fetchAll();
 
-    const techs = result.resources;
+    const techs = (result.resources as TechnicianLocationDoc[])
+      .map(toTechLocation)
+      .filter((tech): tech is NonNullable<ReturnType<typeof toTechLocation>> => tech !== null);
 
     return {
       status: 200,

--- a/api/src/functions/admin/technicians/list.ts
+++ b/api/src/functions/admin/technicians/list.ts
@@ -4,6 +4,7 @@ import { requireAdmin } from '../../../middleware/requireAdmin.js';
 import type { AdminContext } from '../../../types/admin.js';
 import { listAllTechniciansForAdmin } from '../../../cosmos/technician-repository.js';
 import { getActiveBookingCountForTechnician } from '../../../cosmos/booking-repository.js';
+import { getFirebaseAdmin } from '../../../services/firebaseAdmin.js';
 import type { AdminTechnician } from '../../../schemas/admin-technician.js';
 
 function maskPhone(phone: string): string {
@@ -31,12 +32,14 @@ export async function adminListTechniciansHandler(
   const docs = await listAllTechniciansForAdmin();
   if (docs.length === 0) return { status: 200, jsonBody: { technicians: [] } };
 
-  // Import firebase-admin lazily to avoid cold-start cost when list is empty
-  const firebaseAdmin = await import('firebase-admin');
-  const firebaseApp = firebaseAdmin.app();
-  const { users } = await firebaseApp.auth().getUsers(
-    docs.map((d) => ({ uid: d.id })),
-  );
+  let users: Array<{ uid: string; displayName?: string; phoneNumber?: string }> = [];
+  try {
+    ({ users } = await getFirebaseAdmin().auth().getUsers(
+      docs.map((d) => ({ uid: d.id })),
+    ));
+  } catch {
+    // Firebase Auth metadata is best-effort for the roster; Cosmos remains authoritative.
+  }
   const authMap = new Map(users.map((u) => [u.uid, u]));
 
   const counts = await Promise.all(

--- a/api/src/services/dispatcher.service.ts
+++ b/api/src/services/dispatcher.service.ts
@@ -13,7 +13,7 @@ import type { BookingDoc } from '../schemas/booking.js';
 import { normalizeAddressText } from '../shared/address-text.js';
 
 const DISPATCH_RADIUS_KM = 10;
-const OFFER_WINDOW_MS = 30_000;
+const OFFER_WINDOW_MS = 90_000;
 const SLOT_GRACE_WINDOW_MS = 30 * 60 * 1_000;
 
 function slotStartUtcMs(slotDate: string, slotWindow: string): number {

--- a/api/tests/cosmos/finance-repository.test.ts
+++ b/api/tests/cosmos/finance-repository.test.ts
@@ -68,7 +68,7 @@ describe('getDailyPnL', () => {
     expect(day.netToOwner).toBe(59900 - expectedCommission);
   });
 
-  it('uses commissionBps=0 when field is missing on booking', async () => {
+  it('uses default commissionBps when field is missing on booking', async () => {
     const booking = {
       id: 'b2',
       amount: 10000,
@@ -79,8 +79,8 @@ describe('getDailyPnL', () => {
     };
     vi.mocked(getCosmosClient).mockReturnValue(makeClient({ bookings: makeContainer([booking]) }) as any);
     const result = await getDailyPnL('2026-04-14', '2026-04-14');
-    expect(result.dailyPnL[0]!.commission).toBe(0);
-    expect(result.dailyPnL[0]!.netToOwner).toBe(10000);
+    expect(result.dailyPnL[0]!.commission).toBe(2200);
+    expect(result.dailyPnL[0]!.netToOwner).toBe(7800);
   });
 
   it('aggregates two bookings on the same date', async () => {

--- a/api/tests/functions/admin/dashboard/summary.test.ts
+++ b/api/tests/functions/admin/dashboard/summary.test.ts
@@ -13,8 +13,14 @@ vi.mock('../../../../src/services/adminSession.service.js', () => ({
   touchAndGetSession: vi.fn(),
 }));
 
+vi.mock('../../../../src/cosmos/finance-repository.js', () => ({
+  getWeekSnapshot: vi.fn(),
+  getPayoutQueue: vi.fn(),
+}));
+
 import { summaryHandler } from '../../../../src/functions/admin/dashboard/summary.js';
 import { getCosmosClient } from '../../../../src/cosmos/client.js';
+import { getPayoutQueue, getWeekSnapshot } from '../../../../src/cosmos/finance-repository.js';
 import { touchAndGetSession } from '../../../../src/services/adminSession.service.js';
 import { requireAdmin } from '../../../../src/middleware/requireAdmin.js';
 import { signAccessToken } from '../../../../src/services/jwt.service.js';
@@ -43,6 +49,13 @@ const makeContainer = (queryValue: number) => ({
 describe('GET /v1/admin/dashboard/summary', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getWeekSnapshot).mockResolvedValue(null);
+    vi.mocked(getPayoutQueue).mockResolvedValue({
+      weekStart: '2026-05-02',
+      weekEnd: '2026-05-08',
+      entries: [],
+      totalNetPayable: 59_900,
+    });
   });
 
   it('returns 401 when unauthenticated', async () => {

--- a/api/tests/unit/dispatcher.service.test.ts
+++ b/api/tests/unit/dispatcher.service.test.ts
@@ -217,7 +217,7 @@ describe('dispatcherService.triggerDispatch', () => {
     expect(vi.mocked(messaging.send).mock.calls[0]![0].token).toBe('fcm-token-t1');
   });
 
-  it('sets expiresAt to sentAt + 30 seconds', async () => {
+  it('sets expiresAt to sentAt + 90 seconds', async () => {
     vi.mocked(bookingRepo.getById).mockResolvedValue(BASE_BOOKING);
     vi.mocked(getTechniciansWithinRadius).mockResolvedValue([makeTech('t1', 0.05)]);
 
@@ -231,7 +231,7 @@ describe('dispatcherService.triggerDispatch', () => {
 
     expect(sentAt).toBeGreaterThanOrEqual(before);
     expect(sentAt).toBeLessThanOrEqual(after);
-    expect(expiresAt - sentAt).toBe(30_000);
+    expect(expiresAt - sentAt).toBe(90_000);
 
     // expiresAt also propagated to FCM payload
     const msg = vi.mocked(messaging.send).mock.calls[0]![0] as any;


### PR DESCRIPTION
## Summary
- extend technician dispatch offer expiry from 30s to 90s
- keep deployed dashboard metric fixes for techs on duty, payouts, commission, and today's bookings
- preserve Firebase metadata fallback behavior for admin customer/technician lists

## Verification
- pnpm build
- pnpm typecheck
- pnpm lint --max-warnings 0
- pnpm test -- tests/unit/dispatcher.service.test.ts tests/functions/job-offers-expire-stale.test.ts tests/cosmos/dispatch-attempt-repository.test.ts
- pnpm test:coverage
- pnpm run openapi:lint