### PR TITLE
feat(W0-C): align earnings endpoint to plan spec contract

### DIFF
--- a/api/src/functions/earnings.ts
+++ b/api/src/functions/earnings.ts
@@ -6,9 +6,11 @@ import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
 import { walletLedgerRepo } from '../cosmos/wallet-ledger-repository.js';
 import type { EarningsResponse, EarningsPeriod, DailyEarnings, WalletLedgerEntry } from '../schemas/wallet-ledger.js';
 
+const MONTH_GOAL_PAISE = 3_500_000;
+
 function aggregate(entries: WalletLedgerEntry[], predicate: (e: WalletLedgerEntry) => boolean): EarningsPeriod {
   const subset = entries.filter(predicate);
-  return { techAmount: subset.reduce((s, e) => s + e.techAmount, 0), count: subset.length };
+  return { amountPaise: subset.reduce((s, e) => s + e.techAmount, 0), jobs: subset.length };
 }
 
 export const getEarningsHandler: HttpHandler = async (req: HttpRequest, ctx: InvocationContext) => {
@@ -47,23 +49,26 @@ export const getEarningsHandler: HttpHandler = async (req: HttpRequest, ctx: Inv
     const toIstDateStr = (utcIso: string): string =>
       new Date(new Date(utcIso).getTime() + IST_OFFSET_MS).toISOString().slice(0, 10);
 
-    const lastSevenDays: DailyEarnings[] = [];
+    const dailyLast7: DailyEarnings[] = [];
     for (let i = 6; i >= 0; i--) {
       const d = new Date(istNow);
       d.setUTCDate(istNow.getUTCDate() - i);
       const dateStr = d.toISOString().slice(0, 10);
-      const dayTotal = settled
-        .filter(e => toIstDateStr(e.createdAt) === dateStr)
-        .reduce((s, e) => s + e.techAmount, 0);
-      lastSevenDays.push({ date: dateStr, techAmount: dayTotal });
+      const dayEntries = settled.filter(e => toIstDateStr(e.createdAt) === dateStr);
+      dailyLast7.push({
+        date: dateStr,
+        amountPaise: dayEntries.reduce((s, e) => s + e.techAmount, 0),
+        jobs: dayEntries.length,
+      });
     }
 
+    const monthPeriod = aggregate(settled, e => toIstDateStr(e.createdAt).slice(0, 7) === monthStr);
     const response: EarningsResponse = {
       today: aggregate(settled, e => toIstDateStr(e.createdAt) === todayStr),
       week:  aggregate(settled, e => new Date(e.createdAt) >= weekStartUtc),
-      month: aggregate(settled, e => toIstDateStr(e.createdAt).slice(0, 7) === monthStr),
+      month: { ...monthPeriod, goalPaise: MONTH_GOAL_PAISE },
       lifetime: aggregate(settled, _ => true),
-      lastSevenDays,
+      dailyLast7,
       pendingHeld,
     };
 

--- a/api/src/schemas/wallet-ledger.ts
+++ b/api/src/schemas/wallet-ledger.ts
@@ -42,23 +42,29 @@ export type WalletLedgerCreateInput = {
 };
 
 export const EarningsPeriodSchema = z.object({
-  techAmount: z.number().int().nonnegative(),
-  count: z.number().int().nonnegative(),
+  amountPaise: z.number().int().nonnegative(),
+  jobs: z.number().int().nonnegative(),
 });
 export type EarningsPeriod = z.infer<typeof EarningsPeriodSchema>;
 
+export const MonthEarningsPeriodSchema = EarningsPeriodSchema.extend({
+  goalPaise: z.number().int().positive(),
+});
+export type MonthEarningsPeriod = z.infer<typeof MonthEarningsPeriodSchema>;
+
 export const DailyEarningsSchema = z.object({
   date: z.string(),
-  techAmount: z.number().int().nonnegative(),
+  amountPaise: z.number().int().nonnegative(),
+  jobs: z.number().int().nonnegative(),
 });
 export type DailyEarnings = z.infer<typeof DailyEarningsSchema>;
 
 export const EarningsResponseSchema = z.object({
   today: EarningsPeriodSchema,
   week: EarningsPeriodSchema,
-  month: EarningsPeriodSchema,
+  month: MonthEarningsPeriodSchema,
   lifetime: EarningsPeriodSchema,
-  lastSevenDays: z.array(DailyEarningsSchema),
+  dailyLast7: z.array(DailyEarningsSchema),
   pendingHeld: z.number().int().nonnegative(),
 });
 export type EarningsResponse = z.infer<typeof EarningsResponseSchema>;

--- a/api/tests/unit/earnings.test.ts
+++ b/api/tests/unit/earnings.test.ts
@@ -33,6 +33,7 @@ function makeEntry(createdAt: string, techAmount: number, payoutStatus: 'PENDING
 
 const fixedNow = new Date('2026-04-15T12:00:00.000Z');
 const today = fixedNow.toISOString().slice(0, 10);
+const MONTH_GOAL_PAISE = 3_500_000;
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -58,10 +59,16 @@ describe('GET /v1/technicians/me/earnings', () => {
     const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
     expect(res.status).toBe(200);
     const body = res.jsonBody as any;
-    expect(body.today.techAmount).toBe(0);
-    expect(body.today.count).toBe(0);
-    expect(body.lastSevenDays).toHaveLength(7);
-    expect(body.lastSevenDays.every((d: any) => d.techAmount === 0)).toBe(true);
+    expect(body.today.amountPaise).toBe(0);
+    expect(body.today.jobs).toBe(0);
+    expect(body.dailyLast7).toHaveLength(7);
+    expect(body.dailyLast7.every((d: any) => d.amountPaise === 0 && d.jobs === 0)).toBe(true);
+  });
+
+  it('includes month.goalPaise on the month period', async () => {
+    const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
+    const body = res.jsonBody as any;
+    expect(body.month.goalPaise).toBe(MONTH_GOAL_PAISE);
   });
 
   it('aggregates today entry correctly', async () => {
@@ -70,10 +77,10 @@ describe('GET /v1/technicians/me/earnings', () => {
     ]);
     const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
     const body = res.jsonBody as any;
-    expect(body.today.techAmount).toBe(120000);
-    expect(body.today.count).toBe(1);
-    expect(body.lifetime.techAmount).toBe(120000);
-    expect(body.lifetime.count).toBe(1);
+    expect(body.today.amountPaise).toBe(120000);
+    expect(body.today.jobs).toBe(1);
+    expect(body.lifetime.amountPaise).toBe(120000);
+    expect(body.lifetime.jobs).toBe(1);
   });
 
   it('aggregates week entry (3 days ago) correctly', async () => {
@@ -85,10 +92,10 @@ describe('GET /v1/technicians/me/earnings', () => {
     ]);
     const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
     const body = res.jsonBody as any;
-    expect(body.today.techAmount).toBe(0);
-    expect(body.week.techAmount).toBe(90000);
-    expect(body.week.count).toBe(1);
-    expect(body.lifetime.techAmount).toBe(90000);
+    expect(body.today.amountPaise).toBe(0);
+    expect(body.week.amountPaise).toBe(90000);
+    expect(body.week.jobs).toBe(1);
+    expect(body.lifetime.amountPaise).toBe(90000);
   });
 
   it('aggregates month entry (same month, older) correctly', async () => {
@@ -100,10 +107,11 @@ describe('GET /v1/technicians/me/earnings', () => {
     ]);
     const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
     const body = res.jsonBody as any;
-    expect(body.today.techAmount).toBe(0);
-    expect(body.month.techAmount).toBe(75000);
-    expect(body.month.count).toBe(1);
-    expect(body.lifetime.techAmount).toBe(75000);
+    expect(body.today.amountPaise).toBe(0);
+    expect(body.month.amountPaise).toBe(75000);
+    expect(body.month.jobs).toBe(1);
+    expect(body.month.goalPaise).toBe(MONTH_GOAL_PAISE);
+    expect(body.lifetime.amountPaise).toBe(75000);
   });
 
   it('excludes FAILED entries from all totals', async () => {
@@ -112,22 +120,26 @@ describe('GET /v1/technicians/me/earnings', () => {
     ]);
     const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
     const body = res.jsonBody as any;
-    expect(body.today.techAmount).toBe(0);
-    expect(body.today.count).toBe(0);
-    expect(body.lifetime.techAmount).toBe(0);
-    expect(body.lastSevenDays[6].techAmount).toBe(0);
+    expect(body.today.amountPaise).toBe(0);
+    expect(body.today.jobs).toBe(0);
+    expect(body.lifetime.amountPaise).toBe(0);
+    expect(body.dailyLast7[6].amountPaise).toBe(0);
+    expect(body.dailyLast7[6].jobs).toBe(0);
   });
 
-  it('lastSevenDays is always exactly 7 entries ordered oldest-to-newest', async () => {
+  it('dailyLast7 is always exactly 7 entries ordered oldest-to-newest with per-day jobs count', async () => {
     vi.mocked(walletLedgerRepo.getAllByTechnicianId).mockResolvedValue([
       makeEntry(`${today}T08:00:00.000Z`, 50000),
+      makeEntry(`${today}T14:00:00.000Z`, 30000),
     ]);
     const res = await getEarningsHandler(makeReq('Bearer tok'), ctx) as HttpResponseInit;
     const body = res.jsonBody as any;
-    expect(body.lastSevenDays).toHaveLength(7);
-    expect(body.lastSevenDays[6].date).toBe(today);
-    expect(body.lastSevenDays[6].techAmount).toBe(50000);
-    expect(body.lastSevenDays[0].techAmount).toBe(0);
+    expect(body.dailyLast7).toHaveLength(7);
+    expect(body.dailyLast7[6].date).toBe(today);
+    expect(body.dailyLast7[6].amountPaise).toBe(80000);
+    expect(body.dailyLast7[6].jobs).toBe(2);
+    expect(body.dailyLast7[0].amountPaise).toBe(0);
+    expect(body.dailyLast7[0].jobs).toBe(0);
   });
 
   it('calls getAllByTechnicianId with the authenticated uid', async () => {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/EarningsRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/EarningsRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.homeservices.technician.domain.earnings.EarningsRepository
 import com.homeservices.technician.domain.earnings.model.DailyEarnings
 import com.homeservices.technician.domain.earnings.model.EarningsPeriod
 import com.homeservices.technician.domain.earnings.model.EarningsSummary
+import com.homeservices.technician.domain.earnings.model.MonthEarningsPeriod
 import javax.inject.Inject
 
 public class EarningsRepositoryImpl
@@ -16,11 +17,11 @@ public class EarningsRepositoryImpl
             runCatching {
                 val dto = apiService.getEarnings()
                 EarningsSummary(
-                    today = EarningsPeriod(dto.today.techAmount, dto.today.count),
-                    week = EarningsPeriod(dto.week.techAmount, dto.week.count),
-                    month = EarningsPeriod(dto.month.techAmount, dto.month.count),
-                    lifetime = EarningsPeriod(dto.lifetime.techAmount, dto.lifetime.count),
-                    lastSevenDays = dto.lastSevenDays.map { DailyEarnings(it.date, it.techAmount) },
+                    today = EarningsPeriod(dto.today.amountPaise, dto.today.jobs),
+                    week = EarningsPeriod(dto.week.amountPaise, dto.week.jobs),
+                    month = MonthEarningsPeriod(dto.month.amountPaise, dto.month.jobs, dto.month.goalPaise),
+                    lifetime = EarningsPeriod(dto.lifetime.amountPaise, dto.lifetime.jobs),
+                    lastSevenDays = dto.dailyLast7.map { DailyEarnings(it.date, it.amountPaise, it.jobs) },
                     pendingHeldPaise = dto.pendingHeld,
                 )
             }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/remote/dto/EarningsDtos.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/remote/dto/EarningsDtos.kt
@@ -4,22 +4,30 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 public data class EarningsPeriodDto(
-    val techAmount: Long,
-    val count: Int,
+    val amountPaise: Long,
+    val jobs: Int,
+)
+
+@JsonClass(generateAdapter = true)
+public data class MonthEarningsPeriodDto(
+    val amountPaise: Long,
+    val jobs: Int,
+    val goalPaise: Long,
 )
 
 @JsonClass(generateAdapter = true)
 public data class DailyEarningsDto(
     val date: String,
-    val techAmount: Long,
+    val amountPaise: Long,
+    val jobs: Int,
 )
 
 @JsonClass(generateAdapter = true)
 public data class EarningsResponseDto(
     val today: EarningsPeriodDto,
     val week: EarningsPeriodDto,
-    val month: EarningsPeriodDto,
+    val month: MonthEarningsPeriodDto,
     val lifetime: EarningsPeriodDto,
-    val lastSevenDays: List<DailyEarningsDto>,
+    val dailyLast7: List<DailyEarningsDto>,
     val pendingHeld: Long = 0L,
 )

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/earnings/model/EarningsSummary.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/earnings/model/EarningsSummary.kt
@@ -1,21 +1,32 @@
 package com.homeservices.technician.domain.earnings.model
 
-public data class EarningsPeriod(
-    val techAmountPaise: Long,
-    val count: Int,
-) {
+public sealed interface BaseEarningsPeriod {
+    public val techAmountPaise: Long
+    public val count: Int
     public val rupees: Double get() = techAmountPaise / 100.0
 }
+
+public data class EarningsPeriod(
+    override val techAmountPaise: Long,
+    override val count: Int,
+) : BaseEarningsPeriod
+
+public data class MonthEarningsPeriod(
+    override val techAmountPaise: Long,
+    override val count: Int,
+    val goalPaise: Long,
+) : BaseEarningsPeriod
 
 public data class DailyEarnings(
     val date: String,
     val techAmountPaise: Long,
+    val jobs: Int,
 )
 
 public data class EarningsSummary(
     val today: EarningsPeriod,
     val week: EarningsPeriod,
-    val month: EarningsPeriod,
+    val month: MonthEarningsPeriod,
     val lifetime: EarningsPeriod,
     val lastSevenDays: List<DailyEarnings>,
     val pendingHeldPaise: Long = 0L,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/earnings/EarningsScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/earnings/EarningsScreen.kt
@@ -52,9 +52,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.homeservices.designsystem.components.HsSectionCard
 import com.homeservices.technician.R
+import com.homeservices.technician.domain.earnings.model.BaseEarningsPeriod
 import com.homeservices.technician.domain.earnings.model.DailyEarnings
-import com.homeservices.technician.domain.earnings.model.EarningsPeriod
 import com.homeservices.technician.domain.earnings.model.EarningsSummary
+import com.homeservices.technician.domain.earnings.model.MonthEarningsPeriod
 import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Locale
@@ -249,7 +250,7 @@ private fun EarningsSuccess(
                 PeriodCard(stringResource(R.string.earnings_period_lifetime), summary.lifetime, modifier = Modifier.weight(1f))
             }
         }
-        item { GoalProgressCard(summary.month.techAmountPaise) }
+        item { GoalProgressCard(summary.month) }
         item { SparklineCard(summary.lastSevenDays) }
         item {
             OutlinedButton(onClick = onViewRatings, modifier = Modifier.fillMaxWidth()) {
@@ -267,7 +268,7 @@ private fun EarningsSuccess(
 @Composable
 private fun PeriodCard(
     label: String,
-    period: EarningsPeriod,
+    period: BaseEarningsPeriod,
     modifier: Modifier = Modifier,
 ) {
     HsSectionCard(modifier = modifier) {
@@ -293,19 +294,17 @@ private fun PeriodCard(
     }
 }
 
-private val MONTHLY_GOAL_PAISE = 3_500_000L
-
 @Composable
-private fun GoalProgressCard(monthAmountPaise: Long) {
+private fun GoalProgressCard(month: MonthEarningsPeriod) {
     HsSectionCard(title = stringResource(R.string.earnings_monthly_goal)) {
         LinearProgressIndicator(
-            progress = { (monthAmountPaise.toFloat() / MONTHLY_GOAL_PAISE).coerceIn(0f, 1f) },
+            progress = { (month.techAmountPaise.toFloat() / month.goalPaise).coerceIn(0f, 1f) },
             modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(4.dp)),
             color = BrandGreen,
         )
         Spacer(Modifier.height(4.dp))
         Text(
-            "${formatRupees(monthAmountPaise)} / ${formatRupees(MONTHLY_GOAL_PAISE)}",
+            "${formatRupees(month.techAmountPaise)} / ${formatRupees(month.goalPaise)}",
             style = MaterialTheme.typography.bodySmall,
             color = TextSecondary,
         )

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/earnings/EarningsRepositoryImplTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/earnings/EarningsRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import com.homeservices.technician.data.earnings.remote.EarningsApiService
 import com.homeservices.technician.data.earnings.remote.dto.DailyEarningsDto
 import com.homeservices.technician.data.earnings.remote.dto.EarningsPeriodDto
 import com.homeservices.technician.data.earnings.remote.dto.EarningsResponseDto
+import com.homeservices.technician.data.earnings.remote.dto.MonthEarningsPeriodDto
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -19,9 +20,9 @@ public class EarningsRepositoryImplTest {
         EarningsResponseDto(
             today = EarningsPeriodDto(120000L, 1),
             week = EarningsPeriodDto(360000L, 3),
-            month = EarningsPeriodDto(360000L, 3),
+            month = MonthEarningsPeriodDto(360000L, 3, 3_500_000L),
             lifetime = EarningsPeriodDto(960000L, 8),
-            lastSevenDays = listOf(DailyEarningsDto("2026-04-26", 120000L)),
+            dailyLast7 = listOf(DailyEarningsDto("2026-04-26", 120000L, 1)),
             pendingHeld = 50000L,
         )
 
@@ -35,9 +36,11 @@ public class EarningsRepositoryImplTest {
             assertEquals(120000L, s.today.techAmountPaise)
             assertEquals(1, s.today.count)
             assertEquals(8, s.lifetime.count)
+            assertEquals(3_500_000L, s.month.goalPaise)
             assertEquals(1, s.lastSevenDays.size)
             assertEquals("2026-04-26", s.lastSevenDays[0].date)
             assertEquals(120000L, s.lastSevenDays[0].techAmountPaise)
+            assertEquals(1, s.lastSevenDays[0].jobs)
         }
 
     @Test
@@ -57,21 +60,24 @@ public class EarningsRepositoryImplTest {
         }
 
     @Test
-    public fun `getEarnings maps multiple lastSevenDays entries`(): Unit =
+    public fun `getEarnings maps multiple dailyLast7 entries`(): Unit =
         runTest {
             val entries =
                 listOf(
-                    DailyEarningsDto("2026-04-23", 0L),
-                    DailyEarningsDto("2026-04-24", 60000L),
-                    DailyEarningsDto("2026-04-25", 80000L),
+                    DailyEarningsDto("2026-04-23", 0L, 0),
+                    DailyEarningsDto("2026-04-24", 60000L, 1),
+                    DailyEarningsDto("2026-04-25", 80000L, 2),
                 )
-            coEvery { apiService.getEarnings() } returns dto.copy(lastSevenDays = entries)
+            coEvery { apiService.getEarnings() } returns dto.copy(dailyLast7 = entries)
             val result = repository.getEarnings()
             val days = result.getOrThrow().lastSevenDays
             assertEquals(3, days.size)
             assertEquals(0L, days[0].techAmountPaise)
+            assertEquals(0, days[0].jobs)
             assertEquals(60000L, days[1].techAmountPaise)
+            assertEquals(1, days[1].jobs)
             assertEquals(80000L, days[2].techAmountPaise)
+            assertEquals(2, days[2].jobs)
         }
 
     @Test

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/earnings/GetEarningsUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/earnings/GetEarningsUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.homeservices.technician.domain.earnings
 
 import com.homeservices.technician.domain.earnings.model.EarningsPeriod
 import com.homeservices.technician.domain.earnings.model.EarningsSummary
+import com.homeservices.technician.domain.earnings.model.MonthEarningsPeriod
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -17,7 +18,7 @@ public class GetEarningsUseCaseTest {
         EarningsSummary(
             today = EarningsPeriod(0L, 0),
             week = EarningsPeriod(0L, 0),
-            month = EarningsPeriod(0L, 0),
+            month = MonthEarningsPeriod(0L, 0, 3_500_000L),
             lifetime = EarningsPeriod(0L, 0),
             lastSevenDays = emptyList(),
         )

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/earnings/EarningsScreenTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/earnings/EarningsScreenTest.kt
@@ -6,6 +6,7 @@ import com.homeservices.designsystem.theme.HomeservicesTheme
 import com.homeservices.technician.domain.earnings.model.DailyEarnings
 import com.homeservices.technician.domain.earnings.model.EarningsPeriod
 import com.homeservices.technician.domain.earnings.model.EarningsSummary
+import com.homeservices.technician.domain.earnings.model.MonthEarningsPeriod
 import org.junit.Rule
 import org.junit.Test
 
@@ -31,17 +32,17 @@ public class EarningsScreenTest {
         EarningsSummary(
             today = EarningsPeriod(125000, 3),
             week = EarningsPeriod(865000, 14),
-            month = EarningsPeriod(2140000, 41),
+            month = MonthEarningsPeriod(2140000, 41, 3_500_000L),
             lifetime = EarningsPeriod(18450000, 326),
             lastSevenDays =
                 listOf(
-                    DailyEarnings("2026-04-23", 90000),
-                    DailyEarnings("2026-04-24", 110000),
-                    DailyEarnings("2026-04-25", 80000),
-                    DailyEarnings("2026-04-26", 160000),
-                    DailyEarnings("2026-04-27", 150000),
-                    DailyEarnings("2026-04-28", 170000),
-                    DailyEarnings("2026-04-29", 125000),
+                    DailyEarnings("2026-04-23", 90000, 2),
+                    DailyEarnings("2026-04-24", 110000, 3),
+                    DailyEarnings("2026-04-25", 80000, 2),
+                    DailyEarnings("2026-04-26", 160000, 4),
+                    DailyEarnings("2026-04-27", 150000, 3),
+                    DailyEarnings("2026-04-28", 170000, 4),
+                    DailyEarnings("2026-04-29", 125000, 3),
                 ),
         )
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/earnings/EarningsViewModelTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/earnings/EarningsViewModelTest.kt
@@ -5,6 +5,7 @@ import com.homeservices.technician.domain.earnings.GetEarningsUseCase
 import com.homeservices.technician.domain.earnings.model.DailyEarnings
 import com.homeservices.technician.domain.earnings.model.EarningsPeriod
 import com.homeservices.technician.domain.earnings.model.EarningsSummary
+import com.homeservices.technician.domain.earnings.model.MonthEarningsPeriod
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -30,9 +31,9 @@ public class EarningsViewModelTest {
         EarningsSummary(
             today = EarningsPeriod(120000L, 1),
             week = EarningsPeriod(240000L, 2),
-            month = EarningsPeriod(360000L, 3),
+            month = MonthEarningsPeriod(360000L, 3, 3_500_000L),
             lifetime = EarningsPeriod(960000L, 8),
-            lastSevenDays = List(7) { DailyEarnings("2026-04-${20 + it}", 0L) },
+            lastSevenDays = List(7) { DailyEarnings("2026-04-${20 + it}", 0L, 0) },
         )
 
     @BeforeEach


### PR DESCRIPTION
## Summary

Aligns `GET /v1/technicians/me/earnings` wire contract to plan §4 W0-C spec:

- **Period fields**: `techAmount` → `amountPaise`, `count` → `jobs`
- **Daily list**: `lastSevenDays` → `dailyLast7`, items gain `jobs` (per-day count)
- **Month period**: gains required `goalPaise = 3,500,000` (₹35k), modeled as `MonthEarningsPeriodSchema`
- **Additive**: `pendingHeld` retained (used by payout-cadence UI)

Tech-app mirrors the wire contract end-to-end (DTO → repository mapping → domain → UI). New `BaseEarningsPeriod` sealed interface lets the shared `PeriodCard` accept both `EarningsPeriod` and `MonthEarningsPeriod` without duplication. The hardcoded `MONTHLY_GOAL_PAISE = 3_500_000L` in `EarningsScreen.kt` is removed — the goal now comes from the server so ops can tune per-cohort.

## Test plan

- [x] API: 10 vitest integration tests (401/empty/today/week/month with `goalPaise`/FAILED-exclusion/dailyLast7 with per-day `jobs`/500) — all green
- [x] API smoke gate: 141 test files, 1060 tests all green
- [x] Tech-app: detekt + ktlint + testDebugUnitTest all green locally
- [x] CI: `quality-gate` green for technician-ship, api-ship, admin-ship; e2e-and-a11y green
- [x] Codex review --base main
- [ ] After merge: `api-ship.yml` auto-deploys to `func-homeservices-prod`; health endpoint reports new commit SHA

## Codex review notes

Codex flagged one P1 (backwards compat — old tech-app builds would fail Moshi parsing of new field names). **Dismissed with rationale:**

- This is a pre-launch pilot project (≤5k bookings/mo target). No Play Store release yet; tech-app distribution is owner-controlled.
- This PR ships tech-app and API together in lockstep — no scenario where an old-DTO tech-app build hits the new API in production.
- Adding alias fields (`techAmount` + `amountPaise` both) would carry deprecation cruft for callers that don't exist.

If/when the tech-app gets a public Play Store release, a future API contract change would warrant a versioned route or alias-during-deprecation. Not applicable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)