### PR TITLE
feat(E18-S06): Sentry user-context + breadcrumbs (ADR-0022 defers PostHog)

### DIFF
--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/AppNavigation.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/AppNavigation.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -17,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -25,6 +27,7 @@ import com.homeservices.customer.data.booking.PriceApprovalEventBus
 import com.homeservices.customer.data.rating.RatingPromptEventBus
 import com.homeservices.customer.domain.auth.model.AuthState
 import com.homeservices.customer.domain.locale.IsFirstLaunchUseCase
+import com.homeservices.customer.observability.SentryContextBinder
 import com.homeservices.customer.ui.locale.FirstLaunchLanguageScreen
 import com.homeservices.customer.ui.rating.RatingRoutes
 
@@ -111,6 +114,31 @@ internal fun AppNavigation(
                 ratingPromptEventBus.events.collect { bookingId ->
                     navController.navigate(RatingRoutes.route(bookingId)) { launchSingleTop = true }
                 }
+            }
+
+            // E18-S06: Sentry user-context — bind hashed uid on auth-state changes.
+            // Runs as a separate effect so it does NOT interfere with navigation logic above.
+            // Stream 2.1 (E11-S01b-1) also touches AppNavigation; this block is purely additive
+            // and does not change the composable signature.
+            LaunchedEffect(sessionManager) {
+                SentryContextBinder.bindAuthState(sessionManager.authState)
+            }
+
+            // E18-S06: Sentry navigation breadcrumbs — record every route transition.
+            // DisposableEffect ensures the listener is removed when the composable leaves
+            // composition, preventing a leaked reference to NavController.
+            DisposableEffect(navController) {
+                var previousRoute: String? = null
+                val listener =
+                    NavController.OnDestinationChangedListener { _, destination, _ ->
+                        SentryContextBinder.recordNavigationBreadcrumb(
+                            from = previousRoute,
+                            to = destination.route,
+                        )
+                        previousRoute = destination.route
+                    }
+                navController.addOnDestinationChangedListener(listener)
+                onDispose { navController.removeOnDestinationChangedListener(listener) }
             }
 
             NavHost(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/observability/SentryContextBinder.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/observability/SentryContextBinder.kt
@@ -1,0 +1,76 @@
+package com.homeservices.customer.observability
+
+import com.homeservices.customer.domain.auth.model.AuthState
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+import io.sentry.protocol.User
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Thin, testable façade for all Sentry context mutations (E18-S06).
+ *
+ * Responsibilities:
+ * - Bind user-context in Sentry when [AuthState] changes (never raw UID).
+ * - Record route-transition breadcrumbs on every NavController destination change.
+ *
+ * Stateless object — all functions are pure side-effect dispatchers so they can
+ * be unit-tested by MockK-patching Sentry's static API.
+ *
+ * Coordination note (Stream 2.1 / E11-S01b-1):
+ * [bindAuthState] is driven from a [LaunchedEffect] in [AppNavigation] and does
+ * NOT change the composable's signature. The breadcrumb listener is also added
+ * inside a [LaunchedEffect] block. Both additions are purely additive.
+ */
+public object SentryContextBinder {
+    /**
+     * Collects [authStateFlow] and updates Sentry user-context on each emission.
+     *
+     * - [AuthState.Authenticated]: calls [Sentry.setUser] with a 16-char hashed uid.
+     * - [AuthState.Unauthenticated]: calls [Sentry.setUser] with null (clears context).
+     *
+     * Intended to be called from a [kotlinx.coroutines.CoroutineScope] that is
+     * tied to the lifecycle of [AppNavigation] via [LaunchedEffect].
+     *
+     * @param authStateFlow A cold or hot [Flow] of [AuthState] values.
+     */
+    public suspend fun bindAuthState(authStateFlow: Flow<AuthState>) {
+        authStateFlow.collect { state ->
+            when (state) {
+                is AuthState.Authenticated -> {
+                    val user =
+                        User().apply {
+                            id = SentryIdentity.sentryUserId(state.uid)
+                        }
+                    Sentry.setUser(user)
+                }
+                is AuthState.Unauthenticated -> Sentry.setUser(null)
+            }
+        }
+    }
+
+    /**
+     * Adds a Sentry navigation breadcrumb for a single route transition.
+     *
+     * Safe to call from a [androidx.navigation.NavController.OnDestinationChangedListener].
+     * Falls back to "(initial)" when [from] is null (first destination), and
+     * "(unknown)" when [to] is null (defensive, should not happen with typed routes).
+     *
+     * @param from Previous route string, or null if this is the first destination.
+     * @param to New route string.
+     */
+    public fun recordNavigationBreadcrumb(
+        from: String?,
+        to: String?,
+    ) {
+        val crumb =
+            Breadcrumb
+                .navigation(
+                    from ?: "(initial)",
+                    to ?: "(unknown)",
+                ).apply {
+                    level = SentryLevel.INFO
+                }
+        Sentry.addBreadcrumb(crumb)
+    }
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/observability/SentryIdentity.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/observability/SentryIdentity.kt
@@ -17,6 +17,11 @@ import java.security.MessageDigest
  * shorter than the full digest to further reduce re-identification surface.
  */
 public object SentryIdentity {
+    /** Length of the truncated SHA-256 hex prefix sent to Sentry as user identifier.
+     *  64 bits (16 hex chars) is sufficient for Sentry correlation while reducing
+     *  re-identification surface vs the full 256-bit digest. */
+    private const val SENTRY_USER_ID_HEX_LENGTH = 16
+
     /**
      * Returns the first 16 hex characters of SHA-256(uid).
      *
@@ -28,6 +33,6 @@ public object SentryIdentity {
     public fun sentryUserId(uid: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val hashBytes = digest.digest(uid.toByteArray(Charsets.UTF_8))
-        return hashBytes.joinToString("") { "%02x".format(it) }.take(16)
+        return hashBytes.joinToString("") { "%02x".format(it) }.take(SENTRY_USER_ID_HEX_LENGTH)
     }
 }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/observability/SentryIdentity.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/observability/SentryIdentity.kt
@@ -1,0 +1,33 @@
+package com.homeservices.customer.observability
+
+import java.security.MessageDigest
+
+/**
+ * Sentry identity helpers (E18-S06).
+ *
+ * Provides a one-way, deterministic identifier for use in Sentry user-context.
+ * The raw Firebase UID is NEVER sent to Sentry; only the first 16 hex characters
+ * of its SHA-256 digest are used. This satisfies the PII constraint from ADR-0018:
+ * enough entropy to correlate Sentry issues to a specific account (via internal
+ * lookup by the engineering team) without exposing the raw identifier to Sentry.
+ *
+ * Security note: SHA-256 is used here for determinism and collision resistance,
+ * NOT as a cryptographic key derivation function. The output is intentionally
+ * truncated to 16 hex chars (64 bits) — sufficient for Sentry correlation and
+ * shorter than the full digest to further reduce re-identification surface.
+ */
+public object SentryIdentity {
+    /**
+     * Returns the first 16 hex characters of SHA-256(uid).
+     *
+     * Never returns the raw [uid]. Safe to send to Sentry.
+     *
+     * @param uid Firebase UID or any stable user identifier.
+     * @return 16-character lowercase hex string.
+     */
+    public fun sentryUserId(uid: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(uid.toByteArray(Charsets.UTF_8))
+        return hashBytes.joinToString("") { "%02x".format(it) }.take(16)
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryContextBinderTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryContextBinderTest.kt
@@ -25,6 +25,11 @@ import org.junit.jupiter.api.Test
  * 3. recordNavigationBreadcrumb → Breadcrumb with correct from/to.
  */
 public class SentryContextBinderTest {
+    // mirrors SentryIdentity.SENTRY_USER_ID_HEX_LENGTH
+    private companion object {
+        const val EXPECTED_HASH_LENGTH = 16
+    }
+
     @BeforeEach
     public fun setUp() {
         mockkStatic(Sentry::class)
@@ -52,9 +57,9 @@ public class SentryContextBinderTest {
 
             verify(exactly = 1) { Sentry.setUser(any<User>()) }
             val sentryUser = userSlot.captured
-            // Must be 16 hex chars (hashed)
-            assertThat(sentryUser.id).hasSize(16)
-            assertThat(sentryUser.id).matches("[0-9a-f]{16}")
+            // Must be EXPECTED_HASH_LENGTH hex chars (hashed)
+            assertThat(sentryUser.id).hasSize(EXPECTED_HASH_LENGTH)
+            assertThat(sentryUser.id).matches("[0-9a-f]{$EXPECTED_HASH_LENGTH}")
             // Raw UID must not appear in the Sentry user id
             assertThat(sentryUser.id).doesNotContain(uid)
         }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryContextBinderTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryContextBinderTest.kt
@@ -1,0 +1,132 @@
+package com.homeservices.customer.observability
+
+import com.homeservices.customer.domain.auth.model.AuthState
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
+import io.sentry.protocol.User
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD (E18-S06) — SentryContextBinder: user-context binding and navigation breadcrumbs.
+ *
+ * Tests verify:
+ * 1. Authenticated state → Sentry.setUser called with hashed uid (never raw uid).
+ * 2. Unauthenticated state → Sentry.setUser(null) called.
+ * 3. recordNavigationBreadcrumb → Breadcrumb with correct from/to.
+ */
+public class SentryContextBinderTest {
+    @BeforeEach
+    public fun setUp() {
+        mockkStatic(Sentry::class)
+        every { Sentry.setUser(any()) } returns Unit
+        every { Sentry.setUser(null) } returns Unit
+        every { Sentry.addBreadcrumb(any<Breadcrumb>()) } returns Unit
+    }
+
+    @AfterEach
+    public fun tearDown() {
+        unmockkStatic(Sentry::class)
+    }
+
+    // ─── User-context binding ────────────────────────────────────────────────
+
+    @Test
+    public fun `bindAuthState sets hashed user on Authenticated`(): Unit =
+        runTest {
+            val uid = "firebase-raw-uid-should-not-appear"
+            val state = flowOf(AuthState.Authenticated(uid = uid))
+            val userSlot = slot<User>()
+            every { Sentry.setUser(capture(userSlot)) } returns Unit
+
+            SentryContextBinder.bindAuthState(state)
+
+            verify(exactly = 1) { Sentry.setUser(any<User>()) }
+            val sentryUser = userSlot.captured
+            // Must be 16 hex chars (hashed)
+            assertThat(sentryUser.id).hasSize(16)
+            assertThat(sentryUser.id).matches("[0-9a-f]{16}")
+            // Raw UID must not appear in the Sentry user id
+            assertThat(sentryUser.id).doesNotContain(uid)
+        }
+
+    @Test
+    public fun `bindAuthState sets null user on Unauthenticated`(): Unit =
+        runTest {
+            val state = flowOf<AuthState>(AuthState.Unauthenticated)
+
+            SentryContextBinder.bindAuthState(state)
+
+            verify(exactly = 1) { Sentry.setUser(null) }
+        }
+
+    @Test
+    public fun `bindAuthState handles auth state transitions`(): Unit =
+        runTest {
+            // Collect first emission only (Authenticated)
+            SentryContextBinder.bindAuthState(flowOf(AuthState.Authenticated(uid = "user-abc")))
+            verify(exactly = 1) { Sentry.setUser(any<User>()) }
+
+            // Now simulate transition to Unauthenticated
+            SentryContextBinder.bindAuthState(flowOf(AuthState.Unauthenticated))
+            verify(exactly = 1) { Sentry.setUser(null) }
+        }
+
+    // ─── Navigation breadcrumbs ──────────────────────────────────────────────
+
+    @Test
+    public fun `recordNavigationBreadcrumb adds breadcrumb with from and to`() {
+        val crumbSlot = slot<Breadcrumb>()
+        every { Sentry.addBreadcrumb(capture(crumbSlot)) } returns Unit
+
+        SentryContextBinder.recordNavigationBreadcrumb(from = "auth", to = "main")
+
+        verify(exactly = 1) { Sentry.addBreadcrumb(any<Breadcrumb>()) }
+        val crumb = crumbSlot.captured
+        assertThat(crumb.data).containsEntry("from", "auth")
+        assertThat(crumb.data).containsEntry("to", "main")
+    }
+
+    @Test
+    public fun `recordNavigationBreadcrumb uses (initial) when from is null`() {
+        val crumbSlot = slot<Breadcrumb>()
+        every { Sentry.addBreadcrumb(capture(crumbSlot)) } returns Unit
+
+        SentryContextBinder.recordNavigationBreadcrumb(from = null, to = "auth")
+
+        val crumb = crumbSlot.captured
+        assertThat(crumb.data).containsEntry("from", "(initial)")
+        assertThat(crumb.data).containsEntry("to", "auth")
+    }
+
+    @Test
+    public fun `recordNavigationBreadcrumb uses (unknown) when to is null`() {
+        val crumbSlot = slot<Breadcrumb>()
+        every { Sentry.addBreadcrumb(capture(crumbSlot)) } returns Unit
+
+        SentryContextBinder.recordNavigationBreadcrumb(from = "main", to = null)
+
+        val crumb = crumbSlot.captured
+        assertThat(crumb.data).containsEntry("to", "(unknown)")
+    }
+
+    @Test
+    public fun `recordNavigationBreadcrumb sets category to navigation`() {
+        val crumbSlot = slot<Breadcrumb>()
+        every { Sentry.addBreadcrumb(capture(crumbSlot)) } returns Unit
+
+        SentryContextBinder.recordNavigationBreadcrumb(from = "home", to = "settings")
+
+        val crumb = crumbSlot.captured
+        assertThat(crumb.category).isEqualTo("navigation")
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryIdentityTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryIdentityTest.kt
@@ -1,0 +1,61 @@
+package com.homeservices.customer.observability
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD (E18-S06) — SentryIdentity: sha256 hash helper.
+ *
+ * Validates:
+ * 1. Hash output is deterministic — same UID → same hash every call.
+ * 2. Hash output is exactly 16 hex characters (take(16) of sha256 hex string).
+ * 3. Different UIDs produce different hashes (collision resistance at scale).
+ * 4. Raw UID is not present in the output (PII safety gate).
+ */
+public class SentryIdentityTest {
+    @Test
+    public fun `sentryUserId is deterministic for same uid`() {
+        val uid = "firebase-uid-abc123XYZ"
+        val first = SentryIdentity.sentryUserId(uid)
+        val second = SentryIdentity.sentryUserId(uid)
+        assertThat(first).isEqualTo(second)
+    }
+
+    @Test
+    public fun `sentryUserId returns exactly 16 characters`() {
+        val uid = "some-user-id"
+        val result = SentryIdentity.sentryUserId(uid)
+        assertThat(result).hasSize(16)
+    }
+
+    @Test
+    public fun `sentryUserId returns only hex characters`() {
+        val uid = "test-uid-for-hex-check"
+        val result = SentryIdentity.sentryUserId(uid)
+        assertThat(result).matches("[0-9a-f]{16}")
+    }
+
+    @Test
+    public fun `sentryUserId produces different output for different uids`() {
+        val id1 = SentryIdentity.sentryUserId("user-alpha")
+        val id2 = SentryIdentity.sentryUserId("user-beta")
+        assertThat(id1).isNotEqualTo(id2)
+    }
+
+    @Test
+    public fun `sentryUserId does not contain raw uid`() {
+        val uid = "very-recognisable-uid-12345"
+        val result = SentryIdentity.sentryUserId(uid)
+        // The hashed prefix must not be the uid itself (PII gate).
+        assertThat(result).doesNotContain(uid)
+        // Also must not be a substring of the raw uid.
+        assertThat(uid).doesNotContain(result)
+    }
+
+    @Test
+    public fun `sentryUserId handles empty string without throwing`() {
+        val result = SentryIdentity.sentryUserId("")
+        assertThat(result).hasSize(16)
+        assertThat(result).matches("[0-9a-f]{16}")
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryIdentityTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/observability/SentryIdentityTest.kt
@@ -13,6 +13,11 @@ import org.junit.jupiter.api.Test
  * 4. Raw UID is not present in the output (PII safety gate).
  */
 public class SentryIdentityTest {
+    // mirrors SentryIdentity.SENTRY_USER_ID_HEX_LENGTH
+    private companion object {
+        const val EXPECTED_HASH_LENGTH = 16
+    }
+
     @Test
     public fun `sentryUserId is deterministic for same uid`() {
         val uid = "firebase-uid-abc123XYZ"
@@ -25,14 +30,14 @@ public class SentryIdentityTest {
     public fun `sentryUserId returns exactly 16 characters`() {
         val uid = "some-user-id"
         val result = SentryIdentity.sentryUserId(uid)
-        assertThat(result).hasSize(16)
+        assertThat(result).hasSize(EXPECTED_HASH_LENGTH)
     }
 
     @Test
     public fun `sentryUserId returns only hex characters`() {
         val uid = "test-uid-for-hex-check"
         val result = SentryIdentity.sentryUserId(uid)
-        assertThat(result).matches("[0-9a-f]{16}")
+        assertThat(result).matches("[0-9a-f]{$EXPECTED_HASH_LENGTH}")
     }
 
     @Test
@@ -55,7 +60,7 @@ public class SentryIdentityTest {
     @Test
     public fun `sentryUserId handles empty string without throwing`() {
         val result = SentryIdentity.sentryUserId("")
-        assertThat(result).hasSize(16)
-        assertThat(result).matches("[0-9a-f]{16}")
+        assertThat(result).hasSize(EXPECTED_HASH_LENGTH)
+        assertThat(result).matches("[0-9a-f]{$EXPECTED_HASH_LENGTH}")
     }
 }

--- a/docs/adr/0022-defer-posthog-customer-app.md
+++ b/docs/adr/0022-defer-posthog-customer-app.md
@@ -1,0 +1,54 @@
+# ADR-0022: Defer PostHog SDK Integration in customer-app
+
+**Status:** Accepted  
+**Date:** 2026-05-12  
+**Deciders:** Alok Tiwari  
+**Story:** E18-S06 (Sentry user-context + breadcrumbs + PostHog decision)
+
+---
+
+## Context
+
+E18-S06 required a decision: integrate the PostHog Android SDK for product-analytics event capture now, or defer to a later story.
+
+The PostHog Cloud tier used in this project (1M events/month free) is confirmed in the ₹0 stack (CLAUDE.md, `docs/architecture.md`). PostHog is also listed as a planned dependency in `customer-app/CLAUDE.md`. However, the SDK was not present in `customer-app/gradle/libs.versions.toml` at the time this story was executed.
+
+## Decision
+
+**Defer PostHog SDK integration.** Do not add the SDK in this story.
+
+Sentry wiring (user-context + navigation breadcrumbs) is implemented as planned. PostHog integration is deferred to a dedicated story (E18-S07 or equivalent).
+
+## Rationale
+
+1. **Sentry already covers the must-haves.** Error monitoring, crash reports, navigation breadcrumbs, and user-session correlation are all in place after E18-S06. These are the operational observability essentials needed before pilot launch.
+
+2. **PostHog integration is a non-trivial SDK addition.** Adding the PostHog Android SDK introduces:
+   - A new Gradle dependency (≈1–2 MB APK size increase).
+   - An `Application.onCreate` initialisation path that must be guarded by a `BuildConfig` field (`POSTHOG_API_KEY`) wired through all three build variants.
+   - A Hilt-injected `Analytics` interface + `PostHogAnalytics` + `NoOpAnalytics` bindings.
+   - Call sites in `BookingViewModel` and future ViewModels.
+   - These changes deserve their own story, plan, and Codex review — not an appendage to E18-S06.
+
+3. **APK size budget.** The PostHog Android SDK + OkHttp transitive deps add measurable APK weight. At pilot scale (Ayodhya/UP rural target market with budget Android devices), APK size is a conscious quality metric. The addition should be intentional and accompanied by a Baseline Profile update.
+
+4. **Firebase Analytics is a zero-cost fallback.** Firebase Analytics (already a transitive dependency via `firebase-messaging`) can capture basic conversion events (booking created, payment succeeded/failed) without an additional SDK. If a lightweight analytics interim is needed before the dedicated PostHog story ships, Firebase Analytics is available.
+
+5. **Story scope discipline.** Combining PostHog SDK init, event taxonomy, ViewModel call sites, and Hilt bindings in the same PR as Sentry wiring exceeds feature-tier scope. Splitting avoids a bloated diff that is harder for Codex review to reason about.
+
+## Consequences
+
+- **Positive:** E18-S06 PR is focused, testable, and reviewable. Smoke gate passes cleanly.
+- **Positive:** PostHog integration gets proper ceremony (plan, TDD, Codex review) in E18-S07.
+- **Negative:** Product-analytics events (BookingCreated, PaymentSucceeded, etc.) are not captured during the gap between E18-S06 merge and E18-S07 execution. This is acceptable — the pilot phase has not started.
+- **Tracking:** E18-S07 (or equivalent) must add:
+  - `posthog-android` to `libs.versions.toml`
+  - `BuildConfig.POSTHOG_API_KEY` with env-var fallback
+  - `Analytics` interface + `PostHogAnalytics` / `NoOpAnalytics` Hilt bindings
+  - Event taxonomy in `customer-app/app/src/main/kotlin/com/homeservices/customer/analytics/Events.kt`
+  - Call sites: `BookingViewModel` (payment success/failure), future wallet/export/erasure screens
+
+## Alternatives Considered
+
+- **Integrate PostHog now (rejected):** The SDK is not yet in `libs.versions.toml`. Adding it mid-story increases PR scope beyond feature-tier limits and risks introducing an unreviewed dependency.
+- **Use Firebase Analytics as interim (deferred):** Possible, but adds its own wiring overhead. Better handled in E18-S07 where the analytics strategy can be decided holistically (PostHog vs Firebase Analytics vs both).


### PR DESCRIPTION
## Summary
- **Sentry user-context:** `setUser(sha256(uid).take(16))` on `Authenticated`, `setUser(null)` on `Unauthenticated`. Never sends raw UID — only a 16-char hex prefix of its SHA-256 digest.
- **Sentry navigation breadcrumbs:** `NavController.OnDestinationChangedListener` registered via `DisposableEffect(navController)` — records every route transition as a `Breadcrumb.navigation(from, to)` with `SentryLevel.INFO`.
- **PostHog deferred via ADR-0022:** PostHog Android SDK not yet in `libs.versions.toml`. Sentry covers operational observability must-haves. PostHog gets dedicated E18-S07 story with proper ceremony (plan, TDD, APK-size impact review).

Stream 2.6 of Week 2 customer-app gap closure.

## PostHog decision
PostHog SDK absent from `gradle/libs.versions.toml` — path taken: **ADR-0022 (defer)**. See `docs/adr/0022-defer-posthog-customer-app.md` for full rationale. Key points: Sentry already covers errors + breadcrumbs; PostHog adds ≥1MB APK weight that warrants dedicated scope; Firebase Analytics is available as a zero-cost interim if needed before E18-S07.

## Test plan
- [x] `SentryIdentityTest` (6 tests): sha256 hash deterministic, 16 hex chars, different UIDs → different hashes, raw UID absent from output, empty string handles without throw
- [x] `SentryContextBinderTest` (7 tests): `Authenticated` → `setUser` with hashed id; `Unauthenticated` → `setUser(null)`; auth state transitions; breadcrumb `from`/`to` data correct; null `from` → `(initial)`; null `to` → `(unknown)`; category = `navigation`
- [x] Smoke gate: `assembleDebug` + `ktlintCheck` + `testDebugUnitTest` + `koverVerify` — all green
- [ ] Manual: trigger a deliberate Sentry exception → verify the issue shows hashed user-ID and last 5 navigation breadcrumbs in Sentry dashboard
- [ ] Manual: authenticate → check Sentry session shows `user.id` = 16-char hex, no raw Firebase UID

## Coordination note — Stream 2.1 (E11-S01b-1)
Stream 2.1 also modifies `AppNavigation.kt` for cold-start tier-ladder routing. This PR's changes are **purely additive**:
- `LaunchedEffect(sessionManager)` — new block, does not touch existing effects
- `DisposableEffect(navController)` — new block, registers/removes listener cleanly
- **`AppNavigation` signature is unchanged** — same parameters, same visibility, same internal function modifier

If Stream 2.1 merges first, this PR rebases cleanly: at most a one-line listener-registration relocation within the `else` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)