### PR TITLE
chore: add detekt + lintDebug to pre-codex-smoke.sh

### DIFF
--- a/tools/pre-codex-smoke.sh
+++ b/tools/pre-codex-smoke.sh
@@ -2,6 +2,9 @@
 # Pre-Codex smoke gate for Android sub-projects (customer-app / technician-app).
 # Run this BEFORE /codex-review-gate. A non-zero exit means do NOT invoke Codex — fix the issue first.
 # Usage: bash tools/pre-codex-smoke.sh <customer-app|technician-app>
+#
+# Steps 3+4 (detekt + lintDebug) were added in the Week 2 (2026-05-13) retrospective.
+# Both were missing from the original gate and caused 6+ CI fix-rounds per PR.
 set -euo pipefail
 
 APP_DIR="${1:?Usage: pre-codex-smoke.sh <customer-app|technician-app>}"
@@ -11,16 +14,22 @@ cd "$REPO_ROOT/$APP_DIR"
 
 echo "=== Pre-Codex Smoke Gate: $APP_DIR ==="
 
-echo "[1/4] assembleDebug — catches missing deps, broken imports, unresolved references..."
+echo "[1/6] assembleDebug — catches missing deps, broken imports, unresolved references..."
 ./gradlew assembleDebug --quiet 2>&1 | tail -30
 
-echo "[2/4] ktlintCheck — formatting must be clean before Codex sees it..."
+echo "[2/6] ktlintCheck — formatting must be clean before Codex sees it..."
 ./gradlew ktlintCheck --quiet 2>&1 | tail -20
 
-echo "[3/4] testDebugUnitTest — TDD invariant: all unit tests must be green..."
+echo "[3/6] detekt — static analysis (LongMethod, MagicNumber, ReturnCount, NestedBlockDepth)..."
+./gradlew detekt --quiet 2>&1 | tail -20
+
+echo "[4/6] lintDebug — Android Lint (UnusedResources, MissingTranslation, ObsoleteSdkInt, Compose rules)..."
+./gradlew lintDebug --quiet 2>&1 | tail -20
+
+echo "[5/6] testDebugUnitTest — TDD invariant: all unit tests must be green..."
 ./gradlew testDebugUnitTest --quiet 2>&1 | tail -30
 
-echo "[4/4] koverVerify — coverage must meet >=80% threshold..."
+echo "[6/6] koverVerify — coverage must meet >=80% threshold..."
 ./gradlew koverVerify --quiet 2>&1 | tail -10
 
 echo ""


### PR DESCRIPTION
## Summary
- Adds `detekt` and `lintDebug` as steps 3 and 4 to the pre-codex smoke gate
- Gate now runs 6 steps instead of 4: assembleDebug → ktlintCheck → **detekt** → **lintDebug** → testDebugUnitTest → koverVerify

## Why
Week 2 (2026-05-13) every PR hit CI failures on detekt violations (LongMethod, MagicNumber, ReturnCount) and Android Lint errors (UnusedResources, MissingTranslation, ObsoleteSdkInt, UnrememberedGetBackStackEntry) that the smoke gate didn't catch locally. This caused 6+ CI fix-rounds per PR.

## Impact
- Wall-clock increases ~2-3 min per smoke run
- Eliminates the CI flap-and-fix loop that burned most of the Week 2 session budget
- Script-only change; no production code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)