### PR TITLE
feat(E11-S01b-2): route migration + event-bus removal

### DIFF
--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/MainActivity.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/MainActivity.kt
@@ -10,8 +10,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.homeservices.customer.data.auth.SessionManager
 import com.homeservices.customer.data.booking.PaymentResultBus
-import com.homeservices.customer.data.booking.PriceApprovalEventBus
-import com.homeservices.customer.data.rating.RatingPromptEventBus
+import com.homeservices.customer.data.pendingaction.PendingActionStore
 import com.homeservices.customer.di.BuildInfoProvider
 import com.homeservices.customer.domain.booking.model.PaymentResult
 import com.homeservices.customer.domain.flags.FeatureFlags
@@ -58,9 +57,11 @@ public class MainActivity :
 
     @Inject public lateinit var paymentResultBus: PaymentResultBus
 
-    @Inject public lateinit var priceApprovalEventBus: PriceApprovalEventBus
-
-    @Inject public lateinit var ratingPromptEventBus: RatingPromptEventBus
+    /**
+     * E11-S01b-2: Injected to drive Room-based navigation in [AppNavigation].
+     * Replaces the removed PriceApprovalEventBus + RatingPromptEventBus injection.
+     */
+    @Inject public lateinit var pendingActionStore: PendingActionStore
 
     @Inject public lateinit var isFirstLaunch: IsFirstLaunchUseCase
 
@@ -102,8 +103,7 @@ public class MainActivity :
                 AppNavigation(
                     sessionManager = sessionManager,
                     activity = this,
-                    priceApprovalEventBus = priceApprovalEventBus,
-                    ratingPromptEventBus = ratingPromptEventBus,
+                    pendingActionStore = pendingActionStore,
                     isFirstLaunch = isFirstLaunch,
                     featureFlags = featureFlags,
                     routeResolver = routeResolver,

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/firebase/FcmLegacyFallback.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/firebase/FcmLegacyFallback.kt
@@ -13,9 +13,14 @@ package com.homeservices.customer.firebase
  * RATING_PROMPT_CUSTOMER. Rather than silently dropping those notifications, the
  * service falls through to the legacy event-bus path.
  *
- * TODO (follow-up): Once the backend adds `userId` to projector FCM payloads,
- * [shouldPostLegacyEvent] will always return false when [actionBuiltSuccessfully]
- * is true and can be removed in E11-S01b-2.
+ * TODO(E11-S01b-3): Once api/src/services/pending-action-projector.ts adds `userId`
+ * to the FCM data payload (field name: "userId"), [shouldPostLegacyEvent] will always
+ * return false when [actionBuiltSuccessfully] is true. At that point:
+ *   1. Remove FcmLegacyFallback.kt.
+ *   2. Delete the legacy event-bus injection (@Inject priceApprovalEventBus,
+ *      ratingPromptEventBus) from CustomerFirebaseMessagingService.
+ *   3. Delete PriceApprovalEventBus and RatingPromptEventBus classes.
+ * AppNavigation already uses Room observation (E11-S01b-2) and is unaffected.
  *
  * @param fcmType the raw `type` string from the FCM data payload, or null if absent.
  * @param actionBuiltSuccessfully true if the new router/ingestor path succeeded

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/AppNavigation.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/AppNavigation.kt
@@ -24,9 +24,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.homeservices.corenav.DeepLinkUri
+import com.homeservices.corenav.PendingActionStatus
 import com.homeservices.customer.data.auth.SessionManager
-import com.homeservices.customer.data.booking.PriceApprovalEventBus
-import com.homeservices.customer.data.rating.RatingPromptEventBus
+import com.homeservices.customer.data.pendingaction.PendingActionStore
 import com.homeservices.customer.domain.auth.model.AuthState
 import com.homeservices.customer.domain.flags.FeatureFlags
 import com.homeservices.customer.domain.locale.IsFirstLaunchUseCase
@@ -58,6 +58,12 @@ public object LocaleRoutes {
  *     the launching Intent by [MainActivity]. Consumed on first composition to navigate
  *     to the action's destination after auth check.
  *
+ * E11-S01b-2: PriceApprovalEventBus and RatingPromptEventBus parameters removed.
+ * Navigation is now driven by Room-observed [PendingActionStore] rows via
+ * [PendingActionsNavEffect]. The FCM service still posts to the legacy event buses
+ * as a fallback (see [CustomerFirebaseMessagingService]), but AppNavigation no
+ * longer depends on them — it observes the Room table directly.
+ *
  * Stream 2.6 (Sentry breadcrumbs) note: signature extended with named parameters with
  * defaults — existing call sites compile unchanged.
  */
@@ -65,8 +71,7 @@ public object LocaleRoutes {
 internal fun AppNavigation(
     sessionManager: SessionManager,
     activity: FragmentActivity,
-    priceApprovalEventBus: PriceApprovalEventBus,
-    ratingPromptEventBus: RatingPromptEventBus,
+    pendingActionStore: PendingActionStore,
     isFirstLaunch: IsFirstLaunchUseCase,
     featureFlags: FeatureFlags,
     modifier: Modifier = Modifier,
@@ -85,8 +90,7 @@ internal fun AppNavigation(
             AppNavigationReady(
                 sessionManager = sessionManager,
                 activity = activity,
-                priceApprovalEventBus = priceApprovalEventBus,
-                ratingPromptEventBus = ratingPromptEventBus,
+                pendingActionStore = pendingActionStore,
                 featureFlags = featureFlags,
                 firstLaunchPending = firstLaunchPending,
                 modifier = modifier,
@@ -106,8 +110,7 @@ internal fun AppNavigation(
 private fun AppNavigationReady(
     sessionManager: SessionManager,
     activity: FragmentActivity,
-    priceApprovalEventBus: PriceApprovalEventBus,
-    ratingPromptEventBus: RatingPromptEventBus,
+    pendingActionStore: PendingActionStore,
     featureFlags: FeatureFlags,
     firstLaunchPending: Boolean,
     modifier: Modifier,
@@ -117,7 +120,7 @@ private fun AppNavigationReady(
     val context = LocalContext.current
     val authState by sessionManager.authState.collectAsStateWithLifecycle()
     val navController = rememberNavController()
-    val startDestination = if (firstLaunchPending) LocaleRoutes.FIRST_LAUNCH else "auth"
+    val startDestination = if (firstLaunchPending) LocaleRoutes.FIRST_LAUNCH else ROUTE_AUTH
     val notificationPermissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
@@ -128,9 +131,9 @@ private fun AppNavigationReady(
         navController = navController,
         notificationPermissionLauncher = notificationPermissionLauncher,
     )
-    EventBusEffects(
-        priceApprovalEventBus = priceApprovalEventBus,
-        ratingPromptEventBus = ratingPromptEventBus,
+    PendingActionsNavEffect(
+        authState = authState,
+        pendingActionStore = pendingActionStore,
         navController = navController,
     )
     SentryEffects(sessionManager = sessionManager, navController = navController)
@@ -147,7 +150,7 @@ private fun AppNavigationReady(
         composable(LocaleRoutes.FIRST_LAUNCH) {
             FirstLaunchLanguageScreen(
                 onConfirmed = {
-                    navController.navigate("auth") {
+                    navController.navigate(ROUTE_AUTH) {
                         popUpTo(LocaleRoutes.FIRST_LAUNCH) { inclusive = true }
                         launchSingleTop = true
                     }
@@ -176,11 +179,11 @@ private fun AuthStateEffect(
         if (firstLaunchPending) return@LaunchedEffect
         when (val currentAuth = authState) {
             is AuthState.Authenticated -> {
-                navController.navigate("main") {
+                navController.navigate(ROUTE_MAIN) {
                     // Single pop target: by the time this fires, firstLaunchPending is
                     // false (guarded above) and FirstLaunchLanguageScreen.onConfirmed
                     // has already popped first_launch on its way to auth. Stack: [auth].
-                    popUpTo("auth") { inclusive = true }
+                    popUpTo(ROUTE_AUTH) { inclusive = true }
                     launchSingleTop = true
                 }
                 com.google.firebase.messaging.FirebaseMessaging
@@ -194,10 +197,10 @@ private fun AuthStateEffect(
                 com.google.firebase.messaging.FirebaseMessaging
                     .getInstance()
                     .deleteToken()
-                navController.navigate("auth") {
+                navController.navigate(ROUTE_AUTH) {
                     // Single pop target: logout from main means stack is [main];
                     // first_launch is never on the stack at this point.
-                    popUpTo("main") { inclusive = true }
+                    popUpTo(ROUTE_MAIN) { inclusive = true }
                     launchSingleTop = true
                 }
             }
@@ -206,22 +209,39 @@ private fun AuthStateEffect(
 }
 
 /**
- * Collects price-approval and rating-prompt event buses and navigates to their routes.
+ * Observes ACTIVE pending actions from Room for the authenticated user and
+ * navigates to the appropriate screen when an ADDON_APPROVAL_REQUESTED or
+ * RATING_PROMPT_CUSTOMER action is present.
+ *
+ * E11-S01b-2: Replaces [EventBusEffects] (removed). Navigation is now driven by
+ * the Room table rather than in-process event buses. The FCM service continues
+ * to post legacy events for backward compat, but AppNavigation no longer depends
+ * on them — it observes the store directly.
+ *
+ * Design note: We track a `Set<String>` of already-navigated action IDs so that
+ * re-compositions and config changes do not trigger duplicate navigation.
+ * The set is cleared when the user ID changes (new login).
  */
 @Composable
-private fun EventBusEffects(
-    priceApprovalEventBus: PriceApprovalEventBus,
-    ratingPromptEventBus: RatingPromptEventBus,
+private fun PendingActionsNavEffect(
+    authState: AuthState,
+    pendingActionStore: PendingActionStore,
     navController: NavController,
 ) {
-    LaunchedEffect(priceApprovalEventBus) {
-        priceApprovalEventBus.events.collect { bookingId ->
-            navController.navigate(BookingRoutes.priceApprovalRoute(bookingId)) { launchSingleTop = true }
-        }
-    }
-    LaunchedEffect(ratingPromptEventBus) {
-        ratingPromptEventBus.events.collect { bookingId ->
-            navController.navigate(RatingRoutes.route(bookingId)) { launchSingleTop = true }
+    val authenticatedUid = (authState as? AuthState.Authenticated)?.uid ?: return
+
+    LaunchedEffect(authenticatedUid) {
+        val navigatedIds = mutableSetOf<String>()
+        pendingActionStore.observeActive(authenticatedUid).collect { actions ->
+            actions
+                .filter { it.status == PendingActionStatus.ACTIVE && it.id !in navigatedIds }
+                .forEach { action ->
+                    val route = pendingActionNavRoute(action.type, action.entityId)
+                    if (route != null) {
+                        navigatedIds += action.id
+                        navController.navigate(route) { launchSingleTop = true }
+                    }
+                }
         }
     }
 }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/AuthGraph.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/AuthGraph.kt
@@ -18,7 +18,7 @@ internal fun NavGraphBuilder.authGraph(
     navController: NavController,
     activity: FragmentActivity,
 ) {
-    navigation(startDestination = "auth_screen", route = "auth") {
+    navigation(startDestination = "auth_screen", route = ROUTE_AUTH) {
         composable("auth_screen") {
             val viewModel: AuthViewModel = hiltViewModel()
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/CustomerRoutes.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/CustomerRoutes.kt
@@ -4,6 +4,19 @@ import com.homeservices.corenav.RouteSpec
 import kotlinx.serialization.Serializable
 
 /**
+ * String route constants for the root nav-graph destinations.
+ *
+ * E11-S01b-2: Replace inline "auth" and "main" string literals throughout
+ * AppNavigation.kt, AuthGraph.kt, and MainGraph.kt with these constants to
+ * eliminate magic strings and make route renames compile-safe.
+ *
+ * Values are intentionally stable — they match the nav-graph `route` strings
+ * registered in [NavGraphBuilder.authGraph] and [NavGraphBuilder.mainGraph].
+ */
+public const val ROUTE_AUTH: String = "auth"
+public const val ROUTE_MAIN: String = "main"
+
+/**
  * Per-app typed route specifier enum — customer-app.
  *
  * Each variant corresponds to a unique top-level screen or navigation graph.

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
@@ -29,7 +29,7 @@ import com.homeservices.customer.ui.tracking.LiveTrackingScreen
 import com.homeservices.customer.ui.tracking.LiveTrackingViewModel
 
 internal fun NavGraphBuilder.mainGraph(navController: NavController) {
-    navigation(startDestination = CatalogueRoutes.HOME, route = "main") {
+    navigation(startDestination = CatalogueRoutes.HOME, route = ROUTE_MAIN) {
         composable(CatalogueRoutes.HOME) {
             val vm: CatalogueHomeViewModel = hiltViewModel()
             CatalogueHomeScreen(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/PendingActionNavObserver.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/PendingActionNavObserver.kt
@@ -1,0 +1,26 @@
+package com.homeservices.customer.navigation
+
+import com.homeservices.corenav.PendingActionType
+import com.homeservices.customer.ui.rating.RatingRoutes
+
+/**
+ * Maps a [PendingActionType] and its entity ID to a Compose Nav route string,
+ * or null if AppNavigation does not handle direct navigation for that type.
+ *
+ * E11-S01b-2: Used by [PendingActionsNavEffect] inside AppNavigation to drive
+ * navigation from Room-observed [PendingAction] rows, replacing the legacy
+ * [PriceApprovalEventBus] and [RatingPromptEventBus] approach.
+ *
+ * @param type  The pending action type from the FCM/Room row.
+ * @param entityId  The booking or complaint ID associated with the action.
+ * @return The Compose Nav route string to navigate to, or null to suppress navigation.
+ */
+public fun pendingActionNavRoute(
+    type: PendingActionType,
+    entityId: String,
+): String? =
+    when (type) {
+        PendingActionType.ADDON_APPROVAL_REQUESTED -> BookingRoutes.priceApprovalRoute(entityId)
+        PendingActionType.RATING_PROMPT_CUSTOMER -> RatingRoutes.route(entityId)
+        else -> null
+    }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/AppNavigationRouteConstantsTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/AppNavigationRouteConstantsTest.kt
@@ -1,0 +1,30 @@
+package com.homeservices.customer.navigation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD-first: verify route string constants before implementation.
+ *
+ * E11-S01b-2 Part A: ROUTE_AUTH and ROUTE_MAIN must be stable string values
+ * that match the existing nav-graph routes defined in AuthGraph.kt ("auth")
+ * and MainGraph.kt ("main"). Any rename of the constant value would be a
+ * breaking navigation regression.
+ */
+public class AppNavigationRouteConstantsTest {
+
+    @Test
+    public fun `ROUTE_AUTH constant equals the legacy auth nav-graph route string`() {
+        assertThat(ROUTE_AUTH).isEqualTo("auth")
+    }
+
+    @Test
+    public fun `ROUTE_MAIN constant equals the legacy main nav-graph route string`() {
+        assertThat(ROUTE_MAIN).isEqualTo("main")
+    }
+
+    @Test
+    public fun `ROUTE_AUTH and ROUTE_MAIN are distinct`() {
+        assertThat(ROUTE_AUTH).isNotEqualTo(ROUTE_MAIN)
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/AppNavigationRouteConstantsTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/AppNavigationRouteConstantsTest.kt
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test
  * breaking navigation regression.
  */
 public class AppNavigationRouteConstantsTest {
-
     @Test
     public fun `ROUTE_AUTH constant equals the legacy auth nav-graph route string`() {
         assertThat(ROUTE_AUTH).isEqualTo("auth")

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/PendingActionNavObserverTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/PendingActionNavObserverTest.kt
@@ -1,0 +1,45 @@
+package com.homeservices.customer.navigation
+
+import com.homeservices.corenav.PendingActionType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * TDD-first: verify navigation routing logic for Room-sourced pending actions.
+ *
+ * E11-S01b-2 Part C: AppNavigation no longer takes PriceApprovalEventBus or
+ * RatingPromptEventBus as parameters. Navigation is driven by Room-observed
+ * PendingAction rows instead. These tests cover the helper that maps
+ * PendingActionType to a Compose Nav route.
+ *
+ * Manual construction — no Hilt, no Android runtime.
+ * Per docs/patterns/hilt-module-android-test-scope.md.
+ */
+public class PendingActionNavObserverTest {
+
+    @Test
+    public fun `ADDON_APPROVAL_REQUESTED maps to price-approval route for bookingId`() {
+        val bookingId = "bk-test-1"
+        val route = pendingActionNavRoute(PendingActionType.ADDON_APPROVAL_REQUESTED, bookingId)
+        assertThat(route).isEqualTo(BookingRoutes.priceApprovalRoute(bookingId))
+    }
+
+    @Test
+    public fun `RATING_PROMPT_CUSTOMER maps to rating route for bookingId`() {
+        val bookingId = "bk-test-2"
+        val route = pendingActionNavRoute(PendingActionType.RATING_PROMPT_CUSTOMER, bookingId)
+        assertThat(route).isEqualTo(com.homeservices.customer.ui.rating.RatingRoutes.route(bookingId))
+    }
+
+    @Test
+    public fun `COMPLAINT_UPDATE returns null (no direct nav from AppNavigation)`() {
+        val route = pendingActionNavRoute(PendingActionType.COMPLAINT_UPDATE, "cmp-1")
+        assertThat(route).isNull()
+    }
+
+    @Test
+    public fun `SUPPORT_FOLLOWUP returns null`() {
+        val route = pendingActionNavRoute(PendingActionType.SUPPORT_FOLLOWUP, "t-1")
+        assertThat(route).isNull()
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/PendingActionNavObserverTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/navigation/PendingActionNavObserverTest.kt
@@ -1,6 +1,7 @@
 package com.homeservices.customer.navigation
 
 import com.homeservices.corenav.PendingActionType
+import com.homeservices.customer.ui.rating.RatingRoutes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,7 +17,6 @@ import org.junit.jupiter.api.Test
  * Per docs/patterns/hilt-module-android-test-scope.md.
  */
 public class PendingActionNavObserverTest {
-
     @Test
     public fun `ADDON_APPROVAL_REQUESTED maps to price-approval route for bookingId`() {
         val bookingId = "bk-test-1"
@@ -28,7 +28,7 @@ public class PendingActionNavObserverTest {
     public fun `RATING_PROMPT_CUSTOMER maps to rating route for bookingId`() {
         val bookingId = "bk-test-2"
         val route = pendingActionNavRoute(PendingActionType.RATING_PROMPT_CUSTOMER, bookingId)
-        assertThat(route).isEqualTo(com.homeservices.customer.ui.rating.RatingRoutes.route(bookingId))
+        assertThat(route).isEqualTo(RatingRoutes.route(bookingId))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Part A (Route constants):** Added `ROUTE_AUTH = "auth"` and `ROUTE_MAIN = "main"` string constants to `CustomerRoutes.kt`. Replaced all 6 inline `"auth"` / `"main"` string literals in `AppNavigation.kt`, `AuthGraph.kt`, and `MainGraph.kt` with these constants. Nav-graph routes remain identical — purely compile-safe.
- **Part B (FcmLegacyFallback.kt):** Kept the file. The projector (`pending-action-projector.ts`) does not include `userId` in the FCM data payload, so `buildPendingActionFromIntent` returns null for `ADDON_APPROVAL_REQUESTED` and `RATING_PROMPT_CUSTOMER`. Updated TODO to `TODO(E11-S01b-3)` with precise remediation steps.
- **Part C (Event-bus removal):** Removed `PriceApprovalEventBus` and `RatingPromptEventBus` parameters from `AppNavigation` / `AppNavigationReady`. Replaced `EventBusEffects` composable with `PendingActionsNavEffect`, which observes `PendingActionStore.observeActive(uid)` via a `LaunchedEffect` and navigates to the price-approval or rating screen for new ACTIVE actions. Updated `MainActivity` to inject `PendingActionStore` instead of the two event buses.
- **`TrackingEventBus`:** Untouched — handles `LOCATION_UPDATE`/`BOOKING_STATUS_UPDATE` for live-tracking screen real-time updates; not in scope.

## Test plan

- [x] `AppNavigationRouteConstantsTest` — verifies `ROUTE_AUTH = "auth"` and `ROUTE_MAIN = "main"` (TDD-first, committed before implementation)
- [x] `PendingActionNavObserverTest` — verifies `pendingActionNavRoute()` maps `ADDON_APPROVAL_REQUESTED` → price-approval route, `RATING_PROMPT_CUSTOMER` → rating route, others → null
- [x] Smoke gate: all 6 steps PASSED (assembleDebug → ktlintCheck → detekt → lintDebug → testDebugUnitTest → koverVerify ≥80%)
- [x] Existing `CustomerFcmLegacyFallbackTest` and `CustomerNotificationRouterTest` unchanged and still green

## Deferred

- `TODO(E11-S01b-3)` in `FcmLegacyFallback.kt`: once the API projector adds `userId` to FCM data, remove legacy event buses and `FcmLegacyFallback.kt` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)