### PR TITLE
feat(E16-S02): slot availability API + conflict locking

### DIFF
--- a/.codex-review-passed
+++ b/.codex-review-passed
@@ -1,1 +1,1 @@
-{"timestamp":"2026-05-17T07:59:02-04:00","commit":"0ca7129e73e04c1f7d8da9a68ac69a9c7b637b39","reviewer":"codex","rounds":3,"open_findings":[{"id":"BOOKING_STATUS_UPDATE-handler","severity":"P2","resolution":"paired-PR — handler ships in PR #233 (E11-S05a-client)"}]}
+{"timestamp":"2026-05-16T09:40:49-04:00","commit":"ce64aa029aa496c650aa3adc9e0205ceb0460c2f","reviewer":"codex","model":"gpt-5.5","story":"E16-S02"}

--- a/admin-web/src/api/generated/openapi.json
+++ b/admin-web/src/api/generated/openapi.json
@@ -449,6 +449,14 @@
           },
           "isActive": {
             "type": "boolean"
+          },
+          "workStart": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
+          },
+          "workEnd": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
           }
         },
         "required": [
@@ -684,6 +692,14 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "workStart": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
+          },
+          "workEnd": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
           }
         },
         "required": [
@@ -2173,6 +2189,14 @@
                         "required"
                       ]
                     }
+                  },
+                  "workStart": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
+                  },
+                  "workEnd": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
                   }
                 },
                 "required": [
@@ -2389,6 +2413,14 @@
                         "required"
                       ]
                     }
+                  },
+                  "workStart": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
+                  },
+                  "workEnd": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
                   }
                 },
                 "required": [

--- a/admin-web/src/api/generated/schema.d.ts
+++ b/admin-web/src/api/generated/schema.d.ts
@@ -603,6 +603,8 @@ export interface components {
                 required: boolean;
             }[];
             isActive: boolean;
+            workStart?: string;
+            workEnd?: string;
         };
         CategoryWithServices: {
             id: string;
@@ -661,6 +663,8 @@ export interface components {
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
+            workStart?: string;
+            workEnd?: string;
         };
         InternalNote: {
             adminId: string;
@@ -1353,6 +1357,8 @@ export interface operations {
                         label: string;
                         required: boolean;
                     }[];
+                    workStart?: string;
+                    workEnd?: string;
                 };
             };
         };
@@ -1462,6 +1468,8 @@ export interface operations {
                         label: string;
                         required: boolean;
                     }[];
+                    workStart?: string;
+                    workEnd?: string;
                 };
             };
         };

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -449,6 +449,14 @@
           },
           "isActive": {
             "type": "boolean"
+          },
+          "workStart": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
+          },
+          "workEnd": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
           }
         },
         "required": [
@@ -684,6 +692,14 @@
           "updatedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "workStart": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
+          },
+          "workEnd": {
+            "type": "string",
+            "pattern": "^\\d{2}:\\d{2}$"
           }
         },
         "required": [
@@ -2173,6 +2189,14 @@
                         "required"
                       ]
                     }
+                  },
+                  "workStart": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
+                  },
+                  "workEnd": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
                   }
                 },
                 "required": [
@@ -2389,6 +2413,14 @@
                         "required"
                       ]
                     }
+                  },
+                  "workStart": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
+                  },
+                  "workEnd": {
+                    "type": "string",
+                    "pattern": "^\\d{2}:\\d{2}$"
                   }
                 },
                 "required": [

--- a/api/scripts/setup-cosmos.ts
+++ b/api/scripts/setup-cosmos.ts
@@ -95,6 +95,15 @@ async function main() {
     });
     console.log(`Container '${leaseId}' ready.`);
   }
+
+  // E16-S02: Slot holds for conflict locking — partition by composite serviceId|date key.
+  // Default TTL = 30 s (soft hold). commitHold sets TTL = -1 on the doc to make permanent.
+  await database.containers.createIfNotExists({
+    id: 'slot_holds',
+    partitionKey: { paths: ['/servicePartitionKey'] },
+    defaultTtl: 30,
+  });
+  console.log("Container 'slot_holds' ready.");
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/api/src/cosmos/booking-repository.ts
+++ b/api/src/cosmos/booking-repository.ts
@@ -262,6 +262,25 @@ export const bookingRepo = {
       throw e;
     }
   },
+
+  // E16-S02: Returns slotWindow strings for all active (non-cancelled/unfulfilled) bookings
+  // for a given service on a given date. Used by the availability handler to mark slots
+  // as hard-booked. Cross-partition scan — acceptable at pilot scale (≤5,000 bookings/mo).
+  async getBookedWindowsByServiceDate(serviceId: string, date: string): Promise<string[]> {
+    const { resources } = await getBookingsContainer()
+      .items.query<{ slotWindow: string }>({
+        query: `SELECT c.slotWindow FROM c
+                WHERE c.serviceId = @serviceId
+                  AND c.slotDate = @date
+                  AND c.status NOT IN ('CUSTOMER_CANCELLED', 'UNFULFILLED')`,
+        parameters: [
+          { name: '@serviceId', value: serviceId },
+          { name: '@date', value: date },
+        ],
+      })
+      .fetchAll();
+    return resources.map((r) => r.slotWindow);
+  },
 };
 
 export async function updateBookingFields(

--- a/api/src/cosmos/client.ts
+++ b/api/src/cosmos/client.ts
@@ -119,6 +119,15 @@ export function getAppliedCreditIdempotencyContainer(): Container {
   return getCosmosClient().database(DB_NAME).container('applied_credit_idempotency');
 }
 
+/**
+ * E16-S02: Slot holds for conflict locking.
+ * Partitioned by /servicePartitionKey ("<serviceId>|<date>"). Default TTL = 30 s.
+ * commitHold sets ttl=-1 on committed docs to make them permanent.
+ */
+export function getSlotHoldsContainer(): Container {
+  return getCosmosClient().database(DB_NAME).container('slot_holds');
+}
+
 /** Inject a mock CosmosClient in tests. */
 export function _setCosmosClientForTest(mock: CosmosClient): void {
   _client = mock;

--- a/api/src/cosmos/slot-holds-repository.ts
+++ b/api/src/cosmos/slot-holds-repository.ts
@@ -1,0 +1,81 @@
+import { getSlotHoldsContainer } from './client.js';
+import type { SlotHoldDoc } from '../schemas/slot-hold.js';
+
+export class SlotHoldsRepository {
+  private get container() { return getSlotHoldsContainer(); }
+
+  /**
+   * Attempts to create a soft hold for the given slot.
+   * Returns the hold doc on success, or 'CONFLICT' if the slot is already held
+   * (Cosmos 409) or there is an optimistic-concurrency conflict (Cosmos 412 —
+   * same fallback pattern as ADR-0017 §5 wallet etag).
+   */
+  async createHold(
+    serviceId: string,
+    date: string,
+    window: string,
+    customerId: string,
+  ): Promise<SlotHoldDoc | 'CONFLICT'> {
+    const id = `${serviceId}|${date}|${window}`;
+    const servicePartitionKey = `${serviceId}|${date}`;
+    // Note: ttl is intentionally omitted — the container default (30 s) applies automatically.
+    // exactOptionalPropertyTypes=true means we can't pass ttl?: number | undefined to create<T>.
+    const doc = {
+      id,
+      servicePartitionKey,
+      serviceId,
+      date,
+      window,
+      customerId,
+      heldAt: new Date().toISOString(),
+    } satisfies Omit<SlotHoldDoc, 'bookingId' | 'ttl'>;
+
+    try {
+      const { resource } = await this.container.items.create(doc);
+      return resource as SlotHoldDoc;
+    } catch (err: unknown) {
+      const code = (err as { statusCode?: number }).statusCode;
+      if (code === 409 || code === 412) return 'CONFLICT';
+      throw err;
+    }
+  }
+
+  /**
+   * Converts a soft hold to a permanent booking-owned slot record.
+   * Uses Cosmos PATCH to write bookingId and set ttl=-1 (no expiry).
+   * If the hold has already expired (404), logs a warning and returns silently —
+   * the booking succeeded and the slot will be visible via the bookings query.
+   */
+  async commitHold(holdId: string, servicePartitionKey: string, bookingId: string): Promise<void> {
+    try {
+      await this.container.item(holdId, servicePartitionKey).patch([
+        { op: 'add', path: '/bookingId', value: bookingId },
+        { op: 'replace', path: '/ttl', value: -1 },
+      ]);
+    } catch (err: unknown) {
+      const code = (err as { statusCode?: number }).statusCode;
+      if (code === 404) {
+        console.warn('[slotHoldsRepo] commitHold: hold already expired (non-fatal)', { holdId, bookingId });
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Lists all hold docs for a given service+date partition.
+   * Cosmos TTL means expired docs are excluded automatically by the engine.
+   */
+  async listHolds(serviceId: string, date: string): Promise<SlotHoldDoc[]> {
+    const pk = `${serviceId}|${date}`;
+    const { resources } = await this.container.items
+      .query<SlotHoldDoc>({
+        query: 'SELECT * FROM c WHERE c.servicePartitionKey = @pk',
+        parameters: [{ name: '@pk', value: pk }],
+      })
+      .fetchAll();
+    return resources;
+  }
+}
+
+export const slotHoldsRepo = new SlotHoldsRepository();

--- a/api/src/cosmos/slot-holds-repository.ts
+++ b/api/src/cosmos/slot-holds-repository.ts
@@ -34,7 +34,8 @@ export class SlotHoldsRepository {
       const { resource } = await this.container.items.create(doc);
       return resource as SlotHoldDoc;
     } catch (err: unknown) {
-      const code = (err as { statusCode?: number }).statusCode;
+      // @azure/cosmos ErrorResponse sets the HTTP status on err.code, not err.statusCode
+      const code = (err as { code?: number }).code;
       if (code === 409 || code === 412) return 'CONFLICT';
       throw err;
     }
@@ -50,10 +51,11 @@ export class SlotHoldsRepository {
     try {
       await this.container.item(holdId, servicePartitionKey).patch([
         { op: 'add', path: '/bookingId', value: bookingId },
-        { op: 'replace', path: '/ttl', value: -1 },
+        // 'add' (not 'replace') — soft holds omit ttl entirely; replace fails on absent fields
+        { op: 'add', path: '/ttl', value: -1 },
       ]);
     } catch (err: unknown) {
-      const code = (err as { statusCode?: number }).statusCode;
+      const code = (err as { code?: number }).code;
       if (code === 404) {
         console.warn('[slotHoldsRepo] commitHold: hold already expired (non-fatal)', { holdId, bookingId });
         return;

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -21,7 +21,7 @@ import { normalizeAddressText } from '../shared/address-text.js';
 import { isLatLngInServiceArea } from '../services/service-area.service.js';
 import { AYODHYA_SERVICE_AREA } from '../data/service-area-ayodhya.js';
 import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
-import { generateSlots } from '../shared/slot-utils.js';
+import { generateSlots, filterElapsedSlots, currentIstMinuteOfDay, todayIst } from '../shared/slot-utils.js';
 
 function makeRazorpayReceipt(customerId: string): string {
   return `bk_${Date.now().toString(36)}_${customerId.slice(0, 20)}`;
@@ -151,10 +151,28 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
 
   // E16-S02: Validate slotWindow against server-generated windows for this service + date.
-  // Rejects fabricated windows that don't align with the service's durationMinutes / workStart-workEnd.
-  const validWindows = generateSlots(service, parsed.data.slotDate);
+  // Rejects fabricated windows and past windows (elapsed slots for today's date).
+  let validWindows = generateSlots(service, parsed.data.slotDate);
+  if (parsed.data.slotDate === todayIst()) {
+    validWindows = filterElapsedSlots(validWindows, currentIstMinuteOfDay());
+  }
   if (!validWindows.includes(parsed.data.slotWindow)) {
     return { status: 422, jsonBody: { code: 'INVALID_SLOT_WINDOW', message: 'The requested time slot does not match this service\'s schedule.' } };
+  }
+
+  // E16-S02: Guard against pre-deployment or post-expiry booking gaps.
+  // The slot_holds container only prevents concurrent holds — it does not know about bookings
+  // that pre-date the container deployment or whose hold doc expired. Check existing bookings
+  // directly before attempting the hold so we never create a duplicate booking.
+  const existingBookedWindows = await bookingRepo.getBookedWindowsByServiceDate(
+    parsed.data.serviceId,
+    parsed.data.slotDate,
+  );
+  if (existingBookedWindows.includes(parsed.data.slotWindow)) {
+    return {
+      status: 409,
+      jsonBody: { code: 'SLOT_UNAVAILABLE', message: 'This time slot is no longer available.' },
+    };
   }
 
   // E16-S02: Slot-conflict locking — attempt to hold the slot before writing the booking.

--- a/api/src/functions/bookings.ts
+++ b/api/src/functions/bookings.ts
@@ -20,6 +20,8 @@ import { posthog } from '../observability/posthog.js';
 import { normalizeAddressText } from '../shared/address-text.js';
 import { isLatLngInServiceArea } from '../services/service-area.service.js';
 import { AYODHYA_SERVICE_AREA } from '../data/service-area-ayodhya.js';
+import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
+import { generateSlots } from '../shared/slot-utils.js';
 
 function makeRazorpayReceipt(customerId: string): string {
   return `bk_${Date.now().toString(36)}_${customerId.slice(0, 20)}`;
@@ -148,6 +150,30 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
   const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
   if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
 
+  // E16-S02: Validate slotWindow against server-generated windows for this service + date.
+  // Rejects fabricated windows that don't align with the service's durationMinutes / workStart-workEnd.
+  const validWindows = generateSlots(service, parsed.data.slotDate);
+  if (!validWindows.includes(parsed.data.slotWindow)) {
+    return { status: 422, jsonBody: { code: 'INVALID_SLOT_WINDOW', message: 'The requested time slot does not match this service\'s schedule.' } };
+  }
+
+  // E16-S02: Slot-conflict locking — attempt to hold the slot before writing the booking.
+  // createHold returns 'CONFLICT' if another hold or booking already occupies this window.
+  const holdResult = await slotHoldsRepo.createHold(
+    parsed.data.serviceId,
+    parsed.data.slotDate,
+    parsed.data.slotWindow,
+    customer.customerId,
+  );
+  if (holdResult === 'CONFLICT') {
+    return {
+      status: 409,
+      jsonBody: { code: 'SLOT_UNAVAILABLE', message: 'This time slot is no longer available.' },
+    };
+  }
+  const holdId = holdResult.id;
+  const holdPk = holdResult.servicePartitionKey;
+
   if (parsed.data.paymentMethod === 'CASH_ON_SERVICE') {
     const cashOrderId = `cash_${randomUUID()}`;
     const booking = await bookingRepo.createPending(
@@ -159,6 +185,12 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
     );
     const paid = await bookingRepo.markPaid(booking.id, 'cash_on_service_pending');
     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+
+    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
+    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+      Sentry.captureException(err);
+      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+    });
 
     // E13-S01: Apply wallet credit for cash bookings
     let appliedCreditAmount = 0;
@@ -215,6 +247,13 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
     );
     const paid = await bookingRepo.markPaid(booking.id, 'manual_payment_not_configured');
     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+
+    // E16-S02: Commit hold (non-fatal)
+    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+      Sentry.captureException(err);
+      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+    });
+
     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
       Sentry.captureException(err);
       console.error('[createBooking] manual-payment dispatch failed', { bookingId: booking.id, err });
@@ -318,6 +357,12 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
     // Mark PAID immediately (no Razorpay payment involved)
     const paid = await bookingRepo.markPaid(booking.id, 'credit_full_payment');
     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+
+    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
+    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+      Sentry.captureException(err);
+      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+    });
 
     try {
       posthog.capture({
@@ -445,6 +490,13 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
     preGeneratedBookingId,
     razorpayCreditOptions,
   );
+
+  // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
+  slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+    Sentry.captureException(err);
+    console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+  });
+
   try {
     posthog.capture({
       distinctId: customer.customerId,

--- a/api/src/functions/services-availability.ts
+++ b/api/src/functions/services-availability.ts
@@ -4,16 +4,7 @@ import { requireCustomer, type CustomerHttpHandler } from '../middleware/require
 import { catalogueRepo } from '../cosmos/catalogue-repository.js';
 import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
 import { bookingRepo } from '../cosmos/booking-repository.js';
-import { generateSlots } from '../shared/slot-utils.js';
-
-// IST offset from UTC in minutes (UTC+5:30)
-const IST_OFFSET_MINUTES = 5 * 60 + 30;
-
-function todayIst(): string {
-  const now = new Date();
-  const istMs = now.getTime() + IST_OFFSET_MINUTES * 60_000;
-  return new Date(istMs).toISOString().slice(0, 10);
-}
+import { generateSlots, filterElapsedSlots, currentIstMinuteOfDay, todayIst } from '../shared/slot-utils.js';
 
 function addDays(yyyymmdd: string, days: number): string {
   const d = new Date(`${yyyymmdd}T00:00:00Z`);
@@ -56,8 +47,11 @@ export const availabilityHandler: CustomerHttpHandler = async (req, _ctx, _custo
     return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
   }
 
-  // Generate server-side slot windows
-  const allWindows = generateSlots(service, date);
+  // Generate server-side slot windows; filter elapsed slots when date is today
+  let allWindows = generateSlots(service, date);
+  if (date === today) {
+    allWindows = filterElapsedSlots(allWindows, currentIstMinuteOfDay());
+  }
 
   // Load held + hard-booked windows in parallel
   const [holds, bookedWindows] = await Promise.all([

--- a/api/src/functions/services-availability.ts
+++ b/api/src/functions/services-availability.ts
@@ -1,0 +1,88 @@
+import { app } from '@azure/functions';
+import { z } from 'zod';
+import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
+import { bookingRepo } from '../cosmos/booking-repository.js';
+import { generateSlots } from '../shared/slot-utils.js';
+
+// IST offset from UTC in minutes (UTC+5:30)
+const IST_OFFSET_MINUTES = 5 * 60 + 30;
+
+function todayIst(): string {
+  const now = new Date();
+  const istMs = now.getTime() + IST_OFFSET_MINUTES * 60_000;
+  return new Date(istMs).toISOString().slice(0, 10);
+}
+
+function addDays(yyyymmdd: string, days: number): string {
+  const d = new Date(`${yyyymmdd}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+const DateQuerySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((s) => {
+  const d = new Date(`${s}T00:00:00Z`);
+  return !isNaN(d.getTime());
+}, { message: 'Invalid calendar date' });
+
+export const availabilityHandler: CustomerHttpHandler = async (req, _ctx, _customer) => {
+  const { id: serviceId } = (req as unknown as { params: { id: string } }).params;
+  const dateParam = (req as unknown as { query: { get(k: string): string | null } }).query.get('date');
+
+  // Validate date param format
+  const dateParsed = DateQuerySchema.safeParse(dateParam);
+  if (!dateParsed.success) {
+    return { status: 422, jsonBody: { code: 'INVALID_DATE_RANGE', message: 'date must be YYYY-MM-DD' } };
+  }
+  const date = dateParsed.data;
+
+  // Validate range: today IST ≤ date ≤ today+7 IST
+  const today = todayIst();
+  const max = addDays(today, 7);
+  if (date < today || date > max) {
+    return {
+      status: 422,
+      jsonBody: {
+        code: 'INVALID_DATE_RANGE',
+        message: `date must be between ${today} and ${max} (IST)`,
+      },
+    };
+  }
+
+  // Look up service
+  const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
+  if (!service || !service.isActive) {
+    return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+  }
+
+  // Generate server-side slot windows
+  const allWindows = generateSlots(service, date);
+
+  // Load held + hard-booked windows in parallel
+  const [holds, bookedWindows] = await Promise.all([
+    slotHoldsRepo.listHolds(serviceId, date),
+    bookingRepo.getBookedWindowsByServiceDate(serviceId, date),
+  ]);
+
+  const unavailable = new Set<string>([
+    ...holds.map((h) => h.window),
+    ...bookedWindows,
+  ]);
+
+  return {
+    status: 200,
+    jsonBody: {
+      serviceId,
+      date,
+      slotGranularityMinutes: service.durationMinutes,
+      slots: allWindows.map((window) => ({ window, available: !unavailable.has(window) })),
+    },
+  };
+};
+
+app.http('servicesAvailability', {
+  methods: ['GET'],
+  route: 'v1/services/{id}/availability',
+  handler: requireCustomer(availabilityHandler),
+});

--- a/api/src/schemas/service.ts
+++ b/api/src/schemas/service.ts
@@ -39,6 +39,9 @@ export const ServiceSchema = z
     updatedBy: z.string().min(1),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
+    // E16-S02: optional scheduling window; defaults applied server-side (08:00 / 20:00)
+    workStart: z.string().regex(/^\d{2}:\d{2}$/).optional(),
+    workEnd: z.string().regex(/^\d{2}:\d{2}$/).optional(),
   })
   .strict();
 
@@ -80,3 +83,19 @@ export type ServiceCard = z.infer<typeof ServiceCardSchema>;
 export type ServiceDetail = z.infer<typeof ServiceDetailSchema>;
 export type CreateServiceBody = z.infer<typeof CreateServiceBodySchema>;
 export type UpdateServiceBody = z.infer<typeof UpdateServiceBodySchema>;
+
+// E16-S02: Slot availability response schemas
+export const SlotWindowSchema = z.object({
+  window: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  available: z.boolean(),
+});
+
+export const AvailabilityResponseSchema = z.object({
+  serviceId: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  slotGranularityMinutes: z.number().int().positive(),
+  slots: z.array(SlotWindowSchema),
+});
+
+export type SlotWindow = z.infer<typeof SlotWindowSchema>;
+export type AvailabilityResponse = z.infer<typeof AvailabilityResponseSchema>;

--- a/api/src/schemas/slot-hold.ts
+++ b/api/src/schemas/slot-hold.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const SlotHoldDocSchema = z.object({
+  id: z.string(),                     // "<serviceId>|<date>|<window>"
+  servicePartitionKey: z.string(),    // "<serviceId>|<date>"
+  serviceId: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  window: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  customerId: z.string(),
+  heldAt: z.string().datetime(),
+  bookingId: z.string().optional(),   // set on commitHold; absent = soft hold
+  ttl: z.number().int().optional(),   // -1 when committed; absent = container default
+});
+
+export type SlotHoldDoc = z.infer<typeof SlotHoldDocSchema>;

--- a/api/src/shared/slot-utils.ts
+++ b/api/src/shared/slot-utils.ts
@@ -1,0 +1,30 @@
+import type { Service } from '../schemas/service.js';
+
+function timeToMinutes(hhmm: string): number {
+  const [h, m] = hhmm.split(':').map(Number);
+  return (h ?? 0) * 60 + (m ?? 0);
+}
+
+function minutesToTime(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/**
+ * Generates non-overlapping slot windows for a service on a given date.
+ * Returns strings like "08:00-09:00". Does not filter past times — caller
+ * is responsible for date range validation.
+ */
+export function generateSlots(service: Service, _date: string): string[] {
+  const startMin = timeToMinutes(service.workStart ?? '08:00');
+  const endMin = timeToMinutes(service.workEnd ?? '20:00');
+  const duration = service.durationMinutes;
+  const slots: string[] = [];
+
+  for (let cur = startMin; cur + duration <= endMin; cur += duration) {
+    slots.push(`${minutesToTime(cur)}-${minutesToTime(cur + duration)}`);
+  }
+
+  return slots;
+}

--- a/api/src/shared/slot-utils.ts
+++ b/api/src/shared/slot-utils.ts
@@ -1,6 +1,15 @@
 import type { Service } from '../schemas/service.js';
 
-function timeToMinutes(hhmm: string): number {
+// IST offset from UTC in minutes (UTC+5:30)
+const IST_OFFSET_MINUTES = 5 * 60 + 30;
+
+/** Returns today's date in IST as "YYYY-MM-DD". */
+export function todayIst(): string {
+  const now = new Date();
+  return new Date(now.getTime() + IST_OFFSET_MINUTES * 60_000).toISOString().slice(0, 10);
+}
+
+export function timeToMinutes(hhmm: string): number {
   const [h, m] = hhmm.split(':').map(Number);
   return (h ?? 0) * 60 + (m ?? 0);
 }
@@ -11,10 +20,18 @@ function minutesToTime(minutes: number): string {
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
 }
 
+/** Returns current minute-of-day in IST (0–1439). */
+export function currentIstMinuteOfDay(): number {
+  const now = new Date();
+  const istMs = now.getTime() + IST_OFFSET_MINUTES * 60_000;
+  const istDate = new Date(istMs);
+  return istDate.getUTCHours() * 60 + istDate.getUTCMinutes();
+}
+
 /**
  * Generates non-overlapping slot windows for a service on a given date.
- * Returns strings like "08:00-09:00". Does not filter past times — caller
- * is responsible for date range validation.
+ * Returns strings like "08:00-09:00". Does not filter past times — call
+ * filterElapsedSlots() when the date is today (IST) to remove past windows.
  */
 export function generateSlots(service: Service, _date: string): string[] {
   const startMin = timeToMinutes(service.workStart ?? '08:00');
@@ -27,4 +44,15 @@ export function generateSlots(service: Service, _date: string): string[] {
   }
 
   return slots;
+}
+
+/**
+ * Removes slots whose start time is at or before nowMinute (minute-of-day, IST).
+ * Apply when date === today IST to prevent booking/showing past time slots.
+ */
+export function filterElapsedSlots(slots: string[], nowMinute: number): string[] {
+  return slots.filter((window) => {
+    const startTime = window.split('-')[0] ?? '';
+    return timeToMinutes(startTime) > nowMinute;
+  });
 }

--- a/api/tests/bookings/create-apply-credit.test.ts
+++ b/api/tests/bookings/create-apply-credit.test.ts
@@ -33,6 +33,8 @@ vi.mock('../../src/middleware/requireCustomer.js', () => ({
 
 vi.mock('../../src/cosmos/booking-repository.js', () => ({
   bookingRepo: {
+    // E16-S02: must return [] for the pre-hold existing-bookings gate
+    getBookedWindowsByServiceDate: vi.fn().mockResolvedValue([]),
     createPending: vi.fn().mockResolvedValue({
       id: 'bk-100',
       customerId: 'cust-1',

--- a/api/tests/bookings/create-apply-credit.test.ts
+++ b/api/tests/bookings/create-apply-credit.test.ts
@@ -68,12 +68,22 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
 
 vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
   catalogueRepo: {
+    // durationMinutes: 120 → '10:00-12:00' is a valid generated slot (default 08:00–20:00 window)
     getServiceByIdCrossPartition: vi.fn().mockResolvedValue({
       id: 'svc-1',
       name: 'AC Deep Clean',
       basePrice: 59900,
       isActive: true,
+      durationMinutes: 120,
     }),
+  },
+}));
+
+// E16-S02: slot-hold gate — mock so existing credit tests don't need Cosmos
+vi.mock('../../src/cosmos/slot-holds-repository.js', () => ({
+  slotHoldsRepo: {
+    createHold: vi.fn().mockResolvedValue({ id: 'svc-1|2026-05-15|10:00-12:00', servicePartitionKey: 'svc-1|2026-05-15', serviceId: 'svc-1', date: '2026-05-15', window: '10:00-12:00', customerId: 'cust-1', heldAt: new Date().toISOString() }),
+    commitHold: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/api/tests/bookings/create-service-area.test.ts
+++ b/api/tests/bookings/create-service-area.test.ts
@@ -45,9 +45,18 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
 
 vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
   catalogueRepo: {
+    // durationMinutes: 120 → '10:00-12:00' is a valid generated slot (default 08:00–20:00 window)
     getServiceByIdCrossPartition: vi.fn().mockResolvedValue({
-      id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true,
+      id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true, durationMinutes: 120,
     }),
+  },
+}));
+
+// E16-S02: slot-hold gate — mock so service-area tests don't need Cosmos
+vi.mock('../../src/cosmos/slot-holds-repository.js', () => ({
+  slotHoldsRepo: {
+    createHold: vi.fn().mockResolvedValue({ id: 'svc-1|2026-05-01|10:00-12:00', servicePartitionKey: 'svc-1|2026-05-01', serviceId: 'svc-1', date: '2026-05-01', window: '10:00-12:00', customerId: 'cust-area-1', heldAt: new Date().toISOString() }),
+    commitHold: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/api/tests/bookings/create-service-area.test.ts
+++ b/api/tests/bookings/create-service-area.test.ts
@@ -20,6 +20,8 @@ vi.mock('../../src/middleware/requireCustomer.js', () => ({
 
 vi.mock('../../src/cosmos/booking-repository.js', () => ({
   bookingRepo: {
+    // E16-S02: must return [] for the pre-hold existing-bookings gate
+    getBookedWindowsByServiceDate: vi.fn().mockResolvedValue([]),
     createPending: vi.fn().mockResolvedValue({
       id: 'bk-area-1', customerId: 'cust-area-1', serviceId: 'svc-1', categoryId: 'cat-1',
       slotDate: '2026-05-01', slotWindow: '10:00-12:00',

--- a/api/tests/bookings/create.test.ts
+++ b/api/tests/bookings/create.test.ts
@@ -45,7 +45,16 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
 
 vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
   catalogueRepo: {
-    getServiceByIdCrossPartition: vi.fn().mockResolvedValue({ id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true }),
+    // durationMinutes: 120 → generates 08:00-10:00, 10:00-12:00, … slots so '10:00-12:00' passes
+    getServiceByIdCrossPartition: vi.fn().mockResolvedValue({ id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true, durationMinutes: 120 }),
+  },
+}));
+
+// E16-S02: slot-hold gate — mock so existing tests don't need Cosmos
+vi.mock('../../src/cosmos/slot-holds-repository.js', () => ({
+  slotHoldsRepo: {
+    createHold: vi.fn().mockResolvedValue({ id: 'svc-1|2026-05-01|10:00-12:00', servicePartitionKey: 'svc-1|2026-05-01', serviceId: 'svc-1', date: '2026-05-01', window: '10:00-12:00', customerId: 'cust-1', heldAt: new Date().toISOString() }),
+    commitHold: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/api/tests/bookings/create.test.ts
+++ b/api/tests/bookings/create.test.ts
@@ -11,6 +11,8 @@ vi.mock('../../src/middleware/requireCustomer.js', () => ({
 
 vi.mock('../../src/cosmos/booking-repository.js', () => ({
   bookingRepo: {
+    // E16-S02: must return [] (no existing bookings) for the slot gate check
+    getBookedWindowsByServiceDate: vi.fn().mockResolvedValue([]),
     createPending: vi.fn().mockResolvedValue({
       id: 'bk-1', customerId: 'cust-1', serviceId: 'svc-1', categoryId: 'cat-1',
       slotDate: '2026-05-01', slotWindow: '10:00-12:00',

--- a/api/tests/unit/cosmos/slot-holds-repository.test.ts
+++ b/api/tests/unit/cosmos/slot-holds-repository.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before module import
+// ---------------------------------------------------------------------------
+
+const mockCreate = vi.fn();
+const mockPatch = vi.fn();
+const mockFetchAll = vi.fn();
+const mockQuery = vi.fn(() => ({ fetchAll: mockFetchAll }));
+const mockItem = vi.fn(() => ({ patch: mockPatch }));
+
+vi.mock('../../../src/cosmos/client.js', () => ({
+  getSlotHoldsContainer: vi.fn(() => ({
+    items: { create: mockCreate, query: mockQuery },
+    item: mockItem,
+  })),
+}));
+
+import { slotHoldsRepo } from '../../../src/cosmos/slot-holds-repository.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SVC = 'svc-ac';
+const DATE = '2026-05-20';
+const WINDOW = '10:00-11:00';
+const CUST = 'cust-1';
+const HOLD_ID = `${SVC}|${DATE}|${WINDOW}`;
+const HOLD_PK = `${SVC}|${DATE}`;
+
+const HOLD_DOC = {
+  id: HOLD_ID,
+  servicePartitionKey: HOLD_PK,
+  serviceId: SVC,
+  date: DATE,
+  window: WINDOW,
+  customerId: CUST,
+  heldAt: '2026-05-20T04:30:00.000Z',
+};
+
+// ---------------------------------------------------------------------------
+// createHold
+// ---------------------------------------------------------------------------
+
+describe('slotHoldsRepo.createHold', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('happy path: returns hold doc when Cosmos create succeeds', async () => {
+    mockCreate.mockResolvedValue({ resource: HOLD_DOC });
+
+    const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
+
+    expect(result).not.toBe('CONFLICT');
+    expect((result as typeof HOLD_DOC).id).toBe(HOLD_ID);
+    expect(mockCreate).toHaveBeenCalledOnce();
+  });
+
+  it('returns CONFLICT when Cosmos responds 409 (slot already held)', async () => {
+    mockCreate.mockRejectedValue({ statusCode: 409 });
+
+    const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
+
+    expect(result).toBe('CONFLICT');
+  });
+
+  it('returns CONFLICT when Cosmos responds 412 (etag mismatch — ADR-0017 pattern)', async () => {
+    mockCreate.mockRejectedValue({ statusCode: 412 });
+
+    const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
+
+    expect(result).toBe('CONFLICT');
+  });
+
+  it('rethrows non-409/412 errors for Sentry to capture upstream', async () => {
+    mockCreate.mockRejectedValue({ statusCode: 500, message: 'Internal error' });
+
+    await expect(slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST)).rejects.toMatchObject({ statusCode: 500 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commitHold
+// ---------------------------------------------------------------------------
+
+describe('slotHoldsRepo.commitHold', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('happy path: patches bookingId and ttl=-1', async () => {
+    mockPatch.mockResolvedValue({ resource: { ...HOLD_DOC, bookingId: 'bk-1', ttl: -1 } });
+
+    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
+
+    expect(mockItem).toHaveBeenCalledWith(HOLD_ID, HOLD_PK);
+    expect(mockPatch).toHaveBeenCalledWith([
+      { op: 'add', path: '/bookingId', value: 'bk-1' },
+      { op: 'replace', path: '/ttl', value: -1 },
+    ]);
+  });
+
+  it('silently returns when hold has already expired (Cosmos 404)', async () => {
+    mockPatch.mockRejectedValue({ statusCode: 404 });
+
+    // Should NOT throw — expired hold is non-fatal
+    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
+  });
+
+  it('rethrows non-404 errors', async () => {
+    mockPatch.mockRejectedValue({ statusCode: 503 });
+
+    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).rejects.toMatchObject({ statusCode: 503 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listHolds
+// ---------------------------------------------------------------------------
+
+describe('slotHoldsRepo.listHolds', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns active hold docs for the given serviceId + date partition', async () => {
+    mockFetchAll.mockResolvedValue({ resources: [HOLD_DOC] });
+
+    const result = await slotHoldsRepo.listHolds(SVC, DATE);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.window).toBe(WINDOW);
+    // Verify it queries on the composite partition key
+    const rawCall = mockQuery.mock.calls[0];
+    const callArg = (rawCall as unknown as [{ query: string; parameters: { name: string; value: string }[] }])[0]!;
+    expect(callArg.parameters[0]!.value).toBe(HOLD_PK);
+  });
+
+  it('returns empty array when no active holds exist', async () => {
+    mockFetchAll.mockResolvedValue({ resources: [] });
+
+    const result = await slotHoldsRepo.listHolds(SVC, DATE);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/api/tests/unit/cosmos/slot-holds-repository.test.ts
+++ b/api/tests/unit/cosmos/slot-holds-repository.test.ts
@@ -58,7 +58,8 @@ describe('slotHoldsRepo.createHold', () => {
   });
 
   it('returns CONFLICT when Cosmos responds 409 (slot already held)', async () => {
-    mockCreate.mockRejectedValue({ statusCode: 409 });
+    // @azure/cosmos ErrorResponse uses err.code, not err.statusCode
+    mockCreate.mockRejectedValue({ code: 409 });
 
     const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
 
@@ -66,7 +67,7 @@ describe('slotHoldsRepo.createHold', () => {
   });
 
   it('returns CONFLICT when Cosmos responds 412 (etag mismatch — ADR-0017 pattern)', async () => {
-    mockCreate.mockRejectedValue({ statusCode: 412 });
+    mockCreate.mockRejectedValue({ code: 412 });
 
     const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
 
@@ -74,9 +75,9 @@ describe('slotHoldsRepo.createHold', () => {
   });
 
   it('rethrows non-409/412 errors for Sentry to capture upstream', async () => {
-    mockCreate.mockRejectedValue({ statusCode: 500, message: 'Internal error' });
+    mockCreate.mockRejectedValue({ code: 500, message: 'Internal error' });
 
-    await expect(slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST)).rejects.toMatchObject({ statusCode: 500 });
+    await expect(slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST)).rejects.toMatchObject({ code: 500 });
   });
 });
 
@@ -95,21 +96,21 @@ describe('slotHoldsRepo.commitHold', () => {
     expect(mockItem).toHaveBeenCalledWith(HOLD_ID, HOLD_PK);
     expect(mockPatch).toHaveBeenCalledWith([
       { op: 'add', path: '/bookingId', value: 'bk-1' },
-      { op: 'replace', path: '/ttl', value: -1 },
+      { op: 'add', path: '/ttl', value: -1 },
     ]);
   });
 
   it('silently returns when hold has already expired (Cosmos 404)', async () => {
-    mockPatch.mockRejectedValue({ statusCode: 404 });
+    mockPatch.mockRejectedValue({ code: 404 });
 
     // Should NOT throw — expired hold is non-fatal
     await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
   });
 
   it('rethrows non-404 errors', async () => {
-    mockPatch.mockRejectedValue({ statusCode: 503 });
+    mockPatch.mockRejectedValue({ code: 503 });
 
-    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).rejects.toMatchObject({ statusCode: 503 });
+    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).rejects.toMatchObject({ code: 503 });
   });
 });
 

--- a/api/tests/unit/functions/bookings-slot-gate.test.ts
+++ b/api/tests/unit/functions/bookings-slot-gate.test.ts
@@ -1,0 +1,232 @@
+/**
+ * E16-S02 — Unit tests for the slot-hold gate inserted in POST /v1/bookings (createHandler).
+ *
+ * Tests the three new behaviors:
+ *   1. createHold returns hold doc → booking proceeds normally
+ *   2. createHold returns 'CONFLICT' → 409 SLOT_UNAVAILABLE
+ *   3. slotWindow not in generated slots → 422 INVALID_SLOT_WINDOW
+ *   4. commitHold rejects → Sentry captures; booking response still returned
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import type { SlotHoldDoc } from '../../../src/schemas/slot-hold.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — vi.hoisted() required for variables used inside vi.mock() factories
+// ---------------------------------------------------------------------------
+
+const { mockCreateHold, mockCommitHold } = vi.hoisted(() => ({
+  mockCreateHold: vi.fn(),
+  mockCommitHold: vi.fn(),
+}));
+
+vi.mock('../../../src/cosmos/slot-holds-repository.js', () => ({
+  slotHoldsRepo: { createHold: mockCreateHold, commitHold: mockCommitHold },
+}));
+
+vi.mock('../../../src/services/firebaseAdmin.js', () => ({
+  verifyFirebaseIdToken: vi.fn().mockResolvedValue({ uid: 'cust-1', phone_number: '+919999999999' }),
+}));
+
+vi.mock('../../../src/cosmos/catalogue-repository.js', () => ({
+  catalogueRepo: { getServiceByIdCrossPartition: vi.fn() },
+}));
+
+vi.mock('../../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: {
+    createPending: vi.fn(),
+    markPaid: vi.fn(),
+    getBookedWindowsByServiceDate: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('../../../src/services/razorpay.service.js', () => ({
+  createRazorpayOrder: vi.fn(),
+  verifyPaymentSignature: vi.fn(),
+}));
+
+vi.mock('../../../src/services/featureFlags.service.js', () => ({
+  isSoftLaunchEnabled: vi.fn().mockResolvedValue(true),
+  isMarketingPaused: vi.fn().mockResolvedValue(false),
+  isServiceAreaGatingEnabled: vi.fn().mockResolvedValue(false),
+  isWalletCreditEnabled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../../src/services/dispatcher.service.js', () => ({
+  dispatcherService: { triggerDispatch: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('../../../src/cosmos/audit-log-repository.js', () => ({
+  appendAuditEntry: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/cosmos/customer-credit-ledger-repository.js', () => ({
+  customerCreditLedgerRepo: { getBalance: vi.fn().mockResolvedValue({ balanceInPaise: 0 }) },
+}));
+
+vi.mock('../../../src/observability/posthog.js', () => ({
+  posthog: { capture: vi.fn() },
+}));
+
+vi.mock('@sentry/node', () => ({ captureException: vi.fn() }));
+
+import { createBookingHandler } from '../../../src/functions/bookings.js';
+import { catalogueRepo } from '../../../src/cosmos/catalogue-repository.js';
+import { bookingRepo } from '../../../src/cosmos/booking-repository.js';
+import * as Sentry from '@sentry/node';
+import type { Service } from '../../../src/schemas/service.js';
+import type { BookingDoc } from '../../../src/schemas/booking.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ctx = { log: vi.fn(), error: vi.fn(), info: vi.fn() } as unknown as InvocationContext;
+
+function makeService(overrides: Partial<Service> = {}): Service {
+  return {
+    id: 'svc-ac',
+    categoryId: 'cat-1',
+    name: 'AC Deep Clean',
+    shortDescription: 'Deep clean',
+    heroImageUrl: 'https://example.com/img.jpg',
+    basePrice: 59900,
+    commissionBps: 2000,
+    durationMinutes: 60,
+    includes: [],
+    faq: [],
+    addOns: [],
+    photoStages: [],
+    isActive: true,
+    updatedBy: 'admin',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    workStart: '10:00',
+    workEnd: '11:00', // single slot: 10:00-11:00
+    ...overrides,
+  };
+}
+
+function makeBooking(): BookingDoc {
+  return {
+    id: 'bk-1',
+    customerId: 'cust-1',
+    serviceId: 'svc-ac',
+    categoryId: 'cat-1',
+    slotDate: '2026-05-20',
+    slotWindow: '10:00-11:00',
+    addressText: '1 Main St',
+    addressLatLng: { lat: 26.79, lng: 82.19 },
+    status: 'PENDING_PAYMENT',
+    paymentOrderId: 'cash_abc',
+    paymentMethod: 'CASH_ON_SERVICE',
+    paymentId: null,
+    paymentSignature: null,
+    amount: 59900,
+    createdAt: '2026-05-20T04:30:00.000Z',
+  };
+}
+
+function makeHold(): SlotHoldDoc {
+  return {
+    id: 'svc-ac|2026-05-20|10:00-11:00',
+    servicePartitionKey: 'svc-ac|2026-05-20',
+    serviceId: 'svc-ac',
+    date: '2026-05-20',
+    window: '10:00-11:00',
+    customerId: 'cust-1',
+    heldAt: new Date().toISOString(),
+  };
+}
+
+function makeReq(body: object): HttpRequest {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    headers: { get: (h: string) => h.toLowerCase() === 'authorization' ? 'Bearer token' : null },
+    params: {},
+  } as unknown as HttpRequest;
+}
+
+const VALID_BODY = {
+  serviceId: 'svc-ac',
+  categoryId: 'cat-1',
+  slotDate: '2026-05-20',
+  slotWindow: '10:00-11:00',
+  addressText: '1 Main St',
+  addressLatLng: { lat: 26.79, lng: 82.19 },
+  paymentMethod: 'CASH_ON_SERVICE',
+  applyCredit: false,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService());
+  vi.mocked(bookingRepo.createPending).mockResolvedValue(makeBooking());
+  vi.mocked(bookingRepo.markPaid).mockResolvedValue(makeBooking());
+  mockCommitHold.mockResolvedValue(undefined);
+});
+
+describe('E16-S02: slot-hold gate in POST /v1/bookings', () => {
+  it('proceeds normally when createHold returns a hold doc', async () => {
+    mockCreateHold.mockResolvedValue(makeHold());
+
+    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
+
+    expect(res.status).toBe(201);
+    expect(mockCreateHold).toHaveBeenCalledOnce();
+    expect(mockCreateHold).toHaveBeenCalledWith('svc-ac', '2026-05-20', '10:00-11:00', 'cust-1');
+  });
+
+  it('returns 409 SLOT_UNAVAILABLE when createHold returns CONFLICT', async () => {
+    mockCreateHold.mockResolvedValue('CONFLICT');
+
+    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
+
+    expect(res.status).toBe(409);
+    expect(((res as unknown as HttpResponseInit).jsonBody as { code: string }).code).toBe('SLOT_UNAVAILABLE');
+    expect(bookingRepo.createPending).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 INVALID_SLOT_WINDOW when slotWindow is not in generated slots', async () => {
+    // Service window is 10:00-11:00 (1 slot); request a fabricated window
+    const body = { ...VALID_BODY, slotWindow: '99:00-00:00' };
+
+    const res = await createBookingHandler(makeReq(body), ctx);
+
+    expect(res.status).toBe(422);
+    expect(((res as unknown as HttpResponseInit).jsonBody as { code: string }).code).toBe('INVALID_SLOT_WINDOW');
+    expect(mockCreateHold).not.toHaveBeenCalled();
+  });
+
+  it('returns 201 and captures Sentry error when commitHold rejects (non-fatal)', async () => {
+    mockCreateHold.mockResolvedValue(makeHold());
+    mockCommitHold.mockRejectedValue(new Error('Cosmos timeout'));
+
+    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
+
+    // Booking still succeeds
+    expect(res.status).toBe(201);
+    // Wait for the non-blocking commitHold promise to settle
+    await new Promise((r) => setTimeout(r, 10));
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it('calls commitHold with holdId and bookingId after successful booking', async () => {
+    mockCreateHold.mockResolvedValue(makeHold());
+
+    await createBookingHandler(makeReq(VALID_BODY), ctx);
+
+    // Allow the fire-and-forget to resolve
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockCommitHold).toHaveBeenCalledWith(
+      'svc-ac|2026-05-20|10:00-11:00',
+      'svc-ac|2026-05-20',
+      'bk-1',
+    );
+  });
+});

--- a/api/tests/unit/functions/bookings-slot-gate.test.ts
+++ b/api/tests/unit/functions/bookings-slot-gate.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../../src/cosmos/booking-repository.js', () => ({
   bookingRepo: {
     createPending: vi.fn(),
     markPaid: vi.fn(),
+    // Called before createHold to guard against pre-deployment booking gaps (P1 Codex fix)
     getBookedWindowsByServiceDate: vi.fn().mockResolvedValue([]),
   },
 }));
@@ -168,6 +169,8 @@ beforeEach(() => {
   vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService());
   vi.mocked(bookingRepo.createPending).mockResolvedValue(makeBooking());
   vi.mocked(bookingRepo.markPaid).mockResolvedValue(makeBooking());
+  // Reset to empty so the existing-bookings gate doesn't block subsequent tests
+  vi.mocked(bookingRepo.getBookedWindowsByServiceDate).mockResolvedValue([]);
   mockCommitHold.mockResolvedValue(undefined);
 });
 
@@ -214,6 +217,17 @@ describe('E16-S02: slot-hold gate in POST /v1/bookings', () => {
     // Wait for the non-blocking commitHold promise to settle
     await new Promise((r) => setTimeout(r, 10));
     expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it('returns 409 SLOT_UNAVAILABLE when an existing booking already occupies the window', async () => {
+    // Pre-deployment gap: booking exists but no hold doc (hold container newly deployed)
+    vi.mocked(bookingRepo.getBookedWindowsByServiceDate).mockResolvedValue(['10:00-11:00']);
+
+    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
+
+    expect(res.status).toBe(409);
+    expect(((res as unknown as HttpResponseInit).jsonBody as { code: string }).code).toBe('SLOT_UNAVAILABLE');
+    expect(mockCreateHold).not.toHaveBeenCalled();
   });
 
   it('calls commitHold with holdId and bookingId after successful booking', async () => {

--- a/api/tests/unit/functions/services-availability.test.ts
+++ b/api/tests/unit/functions/services-availability.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HttpRequest, InvocationContext } from '@azure/functions';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/services/firebaseAdmin.js', () => ({
+  verifyFirebaseIdToken: vi.fn().mockResolvedValue({ uid: 'cust-1' }),
+}));
+vi.mock('../../../src/cosmos/catalogue-repository.js', () => ({
+  catalogueRepo: { getServiceByIdCrossPartition: vi.fn() },
+}));
+vi.mock('../../../src/cosmos/slot-holds-repository.js', () => ({
+  slotHoldsRepo: { listHolds: vi.fn() },
+}));
+vi.mock('../../../src/cosmos/booking-repository.js', () => ({
+  bookingRepo: { getBookedWindowsByServiceDate: vi.fn() },
+}));
+
+import { availabilityHandler } from '../../../src/functions/services-availability.js';
+import { catalogueRepo } from '../../../src/cosmos/catalogue-repository.js';
+import { slotHoldsRepo } from '../../../src/cosmos/slot-holds-repository.js';
+import { bookingRepo } from '../../../src/cosmos/booking-repository.js';
+import type { Service } from '../../../src/schemas/service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ctx = { log: vi.fn(), error: vi.fn() } as unknown as InvocationContext;
+const CUSTOMER = { customerId: 'cust-1' };
+
+// A date 3 days from now — always within the 7-day window regardless of timezone
+const VALID_DATE = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10)!;
+
+function makeReq(serviceId: string, date: string): HttpRequest {
+  return {
+    params: { id: serviceId },
+    query: { get: (k: string) => (k === 'date' ? date : null) },
+    headers: { get: () => 'Bearer token' },
+  } as unknown as HttpRequest;
+}
+
+function makeService(overrides: Partial<Service> = {}): Service {
+  return {
+    id: 'svc-ac',
+    categoryId: 'cat-1',
+    name: 'AC Deep Clean',
+    shortDescription: 'Deep clean',
+    heroImageUrl: 'https://example.com/img.jpg',
+    basePrice: 59900,
+    commissionBps: 2000,
+    durationMinutes: 60,
+    includes: [],
+    faq: [],
+    addOns: [],
+    photoStages: [],
+    isActive: true,
+    updatedBy: 'admin',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService());
+  vi.mocked(slotHoldsRepo.listHolds).mockResolvedValue([]);
+  vi.mocked(bookingRepo.getBookedWindowsByServiceDate).mockResolvedValue([]);
+});
+
+describe('GET /v1/services/{id}/availability', () => {
+  describe('happy path', () => {
+    it('returns 200 with all slots available when no holds or bookings exist', async () => {
+      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
+
+      expect(res.status).toBe(200);
+      const body = res.jsonBody as { slots: { window: string; available: boolean }[]; slotGranularityMinutes: number };
+      expect(body.slotGranularityMinutes).toBe(60);
+      expect(body.slots.length).toBeGreaterThan(0);
+      expect(body.slots.every((s) => s.available)).toBe(true);
+    });
+
+    it('marks a held slot as unavailable', async () => {
+      const service = makeService({ workStart: '08:00', workEnd: '09:00', durationMinutes: 60 });
+      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(service);
+      vi.mocked(slotHoldsRepo.listHolds).mockResolvedValue([
+        { id: 'x', servicePartitionKey: 'y', serviceId: 'svc-ac', date: VALID_DATE, window: '08:00-09:00', customerId: 'other', heldAt: new Date().toISOString() },
+      ]);
+
+      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
+
+      expect(res.status).toBe(200);
+      const body = res.jsonBody as { slots: { window: string; available: boolean }[] };
+      expect(body.slots[0]!.available).toBe(false);
+    });
+
+    it('marks a hard-booked slot as unavailable', async () => {
+      const service = makeService({ workStart: '08:00', workEnd: '09:00', durationMinutes: 60 });
+      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(service);
+      vi.mocked(bookingRepo.getBookedWindowsByServiceDate).mockResolvedValue(['08:00-09:00']);
+
+      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
+
+      expect(res.status).toBe(200);
+      const body = res.jsonBody as { slots: { window: string; available: boolean }[] };
+      expect(body.slots[0]!.available).toBe(false);
+    });
+  });
+
+  describe('date validation (422)', () => {
+    it('rejects a past date', async () => {
+      const res = await availabilityHandler(makeReq('svc-ac', '2020-01-01'), ctx, CUSTOMER as any);
+      expect(res.status).toBe(422);
+      const body = res.jsonBody as { code: string };
+      expect(body.code).toBe('INVALID_DATE_RANGE');
+    });
+
+    it('rejects a date more than 7 days in the future', async () => {
+      const res = await availabilityHandler(makeReq('svc-ac', '2099-12-31'), ctx, CUSTOMER as any);
+      expect(res.status).toBe(422);
+      const body = res.jsonBody as { code: string };
+      expect(body.code).toBe('INVALID_DATE_RANGE');
+    });
+
+    it('rejects a malformed date string', async () => {
+      const res = await availabilityHandler(makeReq('svc-ac', '2026-13-01'), ctx, CUSTOMER as any);
+      expect(res.status).toBe(422);
+    });
+
+    it('rejects a missing date query param', async () => {
+      const req = { ...makeReq('svc-ac', ''), query: { get: () => null } } as unknown as HttpRequest;
+      const res = await availabilityHandler(req, ctx, CUSTOMER as any);
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('service lookup', () => {
+    it('returns 404 when service does not exist', async () => {
+      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(null);
+
+      const res = await availabilityHandler(makeReq('svc-unknown', VALID_DATE), ctx, CUSTOMER as any);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 when service exists but is inactive', async () => {
+      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService({ isActive: false }));
+
+      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/api/tests/unit/schemas/slot-hold.test.ts
+++ b/api/tests/unit/schemas/slot-hold.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { SlotHoldDocSchema, type SlotHoldDoc } from '../../../src/schemas/slot-hold.js';
+
+const VALID_HOLD: SlotHoldDoc = {
+  id: 'svc-ac|2026-05-20|10:00-11:00',
+  servicePartitionKey: 'svc-ac|2026-05-20',
+  serviceId: 'svc-ac',
+  date: '2026-05-20',
+  window: '10:00-11:00',
+  customerId: 'cust-1',
+  heldAt: '2026-05-20T04:30:00.000Z',
+};
+
+describe('SlotHoldDocSchema', () => {
+  it('accepts a valid soft hold (no bookingId / ttl)', () => {
+    expect(() => SlotHoldDocSchema.parse(VALID_HOLD)).not.toThrow();
+  });
+
+  it('accepts a committed hold with bookingId and ttl=-1', () => {
+    const committed = { ...VALID_HOLD, bookingId: 'bk-999', ttl: -1 };
+    expect(() => SlotHoldDocSchema.parse(committed)).not.toThrow();
+  });
+
+  it('rejects when required field id is missing', () => {
+    const { id: _id, ...without } = VALID_HOLD;
+    expect(SlotHoldDocSchema.safeParse(without).success).toBe(false);
+  });
+
+  it('rejects malformed date (wrong format)', () => {
+    const result = SlotHoldDocSchema.safeParse({ ...VALID_HOLD, date: '20-05-2026' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects malformed window (missing separator)', () => {
+    const result = SlotHoldDocSchema.safeParse({ ...VALID_HOLD, window: '1000-1100' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-datetime heldAt', () => {
+    const result = SlotHoldDocSchema.safeParse({ ...VALID_HOLD, heldAt: '2026-05-20' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('AvailabilityResponseSchema', () => {
+  it('round-trips a mixed-availability slot array', async () => {
+    const { AvailabilityResponseSchema } = await import('../../../src/schemas/service.js');
+    const input = {
+      serviceId: 'svc-ac',
+      date: '2026-05-20',
+      slotGranularityMinutes: 60,
+      slots: [
+        { window: '08:00-09:00', available: true },
+        { window: '09:00-10:00', available: false },
+        { window: '10:00-11:00', available: true },
+      ],
+    };
+    const result = AvailabilityResponseSchema.parse(input);
+    expect(result.slots).toHaveLength(3);
+    expect(result.slots[1]!.available).toBe(false);
+  });
+});

--- a/api/tests/unit/shared/slot-utils.test.ts
+++ b/api/tests/unit/shared/slot-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { generateSlots } from '../../../src/shared/slot-utils.js';
+import type { Service } from '../../../src/schemas/service.js';
+
+function makeService(overrides: Partial<Service> = {}): Service {
+  return {
+    id: 'svc-ac',
+    categoryId: 'cat-1',
+    name: 'AC Deep Clean',
+    shortDescription: 'Deep clean',
+    heroImageUrl: 'https://example.com/img.jpg',
+    basePrice: 59900,
+    commissionBps: 2000,
+    durationMinutes: 60,
+    includes: [],
+    faq: [],
+    addOns: [],
+    photoStages: [],
+    isActive: true,
+    updatedBy: 'admin',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('generateSlots', () => {
+  it('generates 12 hourly slots for a 60-min service with default 08:00–20:00 window', () => {
+    const slots = generateSlots(makeService(), '2026-05-20');
+    expect(slots).toHaveLength(12);
+    expect(slots[0]).toBe('08:00-09:00');
+    expect(slots[11]).toBe('19:00-20:00');
+  });
+
+  it('generates 6 slots for a 120-min service with default window', () => {
+    const slots = generateSlots(makeService({ durationMinutes: 120 }), '2026-05-20');
+    expect(slots).toHaveLength(6);
+    expect(slots[0]).toBe('08:00-10:00');
+    expect(slots[5]).toBe('18:00-20:00');
+  });
+
+  it('respects custom workStart and workEnd', () => {
+    const slots = generateSlots(makeService({ workStart: '09:00', workEnd: '12:00' }), '2026-05-20');
+    // 3 × 60-min slots: 09:00, 10:00, 11:00
+    expect(slots).toHaveLength(3);
+    expect(slots[0]).toBe('09:00-10:00');
+    expect(slots[2]).toBe('11:00-12:00');
+  });
+
+  it('returns empty array when workStart equals workEnd', () => {
+    const slots = generateSlots(makeService({ workStart: '08:00', workEnd: '08:00' }), '2026-05-20');
+    expect(slots).toHaveLength(0);
+  });
+
+  it('does not include a slot whose end would exceed workEnd', () => {
+    // 90-min service, 08:00–11:00 → fits: 08:00-09:30, 09:30-11:00; next would be 11:00-12:30 (exceeds 11:00)
+    const slots = generateSlots(makeService({ durationMinutes: 90, workStart: '08:00', workEnd: '11:00' }), '2026-05-20');
+    expect(slots).toHaveLength(2);
+    expect(slots[1]).toBe('09:30-11:00');
+  });
+
+  it('formats minutes correctly (e.g., 08:30-09:30)', () => {
+    const slots = generateSlots(makeService({ durationMinutes: 30, workStart: '08:00', workEnd: '09:30' }), '2026-05-20');
+    expect(slots).toContain('08:00-08:30');
+    expect(slots).toContain('08:30-09:00');
+    expect(slots).toContain('09:00-09:30');
+  });
+});

--- a/docs/reviews/codex-e16s02-20260516-0928.md
+++ b/docs/reviews/codex-e16s02-20260516-0928.md
@@ -1,0 +1,5608 @@
+OpenAI Codex v0.125.0 (research preview)
+--------
+workdir: C:\Alok\Business Projects\Urbanclap-dup
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, C:\Users\alokt\.codex\memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019e30f9-022a-76b2-a4b7-e7134e183283
+--------
+user
+changes against 'main'
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'git diff f39ac4b37a5f76121433cc6ac340508f273858ef' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 764ms:
+diff --git a/api/openapi.json b/api/openapi.json
+index 9c02efb6..218749f3 100644
+--- a/api/openapi.json
++++ b/api/openapi.json
+@@ -449,6 +449,14 @@
+           },
+           "isActive": {
+             "type": "boolean"
++          },
++          "workStart": {
++            "type": "string",
++            "pattern": "^\\d{2}:\\d{2}$"
++          },
++          "workEnd": {
++            "type": "string",
++            "pattern": "^\\d{2}:\\d{2}$"
+           }
+         },
+         "required": [
+@@ -684,6 +692,14 @@
+           "updatedAt": {
+             "type": "string",
+             "format": "date-time"
++          },
++          "workStart": {
++            "type": "string",
++            "pattern": "^\\d{2}:\\d{2}$"
++          },
++          "workEnd": {
++            "type": "string",
++            "pattern": "^\\d{2}:\\d{2}$"
+           }
+         },
+         "required": [
+@@ -2173,6 +2189,14 @@
+                         "required"
+                       ]
+                     }
++                  },
++                  "workStart": {
++                    "type": "string",
++                    "pattern": "^\\d{2}:\\d{2}$"
++                  },
++                  "workEnd": {
++                    "type": "string",
++                    "pattern": "^\\d{2}:\\d{2}$"
+                   }
+                 },
+                 "required": [
+@@ -2389,6 +2413,14 @@
+                         "required"
+                       ]
+                     }
++                  },
++                  "workStart": {
++                    "type": "string",
++                    "pattern": "^\\d{2}:\\d{2}$"
++                  },
++                  "workEnd": {
++                    "type": "string",
++                    "pattern": "^\\d{2}:\\d{2}$"
+                   }
+                 },
+                 "required": [
+diff --git a/api/scripts/setup-cosmos.ts b/api/scripts/setup-cosmos.ts
+index f0322897..65696867 100644
+--- a/api/scripts/setup-cosmos.ts
++++ b/api/scripts/setup-cosmos.ts
+@@ -95,6 +95,15 @@ async function main() {
+     });
+     console.log(`Container '${leaseId}' ready.`);
+   }
++
++  // E16-S02: Slot holds for conflict locking — partition by composite serviceId|date key.
++  // Default TTL = 30 s (soft hold). commitHold sets TTL = -1 on the doc to make permanent.
++  await database.containers.createIfNotExists({
++    id: 'slot_holds',
++    partitionKey: { paths: ['/servicePartitionKey'] },
++    defaultTtl: 30,
++  });
++  console.log("Container 'slot_holds' ready.");
+ }
+ 
+ main().catch((e) => { console.error(e); process.exit(1); });
+diff --git a/api/src/cosmos/booking-repository.ts b/api/src/cosmos/booking-repository.ts
+index 0ef5bdc6..04a96c9c 100644
+--- a/api/src/cosmos/booking-repository.ts
++++ b/api/src/cosmos/booking-repository.ts
+@@ -262,6 +262,25 @@ export const bookingRepo = {
+       throw e;
+     }
+   },
++
++  // E16-S02: Returns slotWindow strings for all active (non-cancelled/unfulfilled) bookings
++  // for a given service on a given date. Used by the availability handler to mark slots
++  // as hard-booked. Cross-partition scan — acceptable at pilot scale (≤5,000 bookings/mo).
++  async getBookedWindowsByServiceDate(serviceId: string, date: string): Promise<string[]> {
++    const { resources } = await getBookingsContainer()
++      .items.query<{ slotWindow: string }>({
++        query: `SELECT c.slotWindow FROM c
++                WHERE c.serviceId = @serviceId
++                  AND c.slotDate = @date
++                  AND c.status NOT IN ('CUSTOMER_CANCELLED', 'UNFULFILLED')`,
++        parameters: [
++          { name: '@serviceId', value: serviceId },
++          { name: '@date', value: date },
++        ],
++      })
++      .fetchAll();
++    return resources.map((r) => r.slotWindow);
++  },
+ };
+ 
+ export async function updateBookingFields(
+diff --git a/api/src/cosmos/client.ts b/api/src/cosmos/client.ts
+index 0009b957..55a6bd00 100644
+--- a/api/src/cosmos/client.ts
++++ b/api/src/cosmos/client.ts
+@@ -119,6 +119,15 @@ export function getAppliedCreditIdempotencyContainer(): Container {
+   return getCosmosClient().database(DB_NAME).container('applied_credit_idempotency');
+ }
+ 
++/**
++ * E16-S02: Slot holds for conflict locking.
++ * Partitioned by /servicePartitionKey ("<serviceId>|<date>"). Default TTL = 30 s.
++ * commitHold sets ttl=-1 on committed docs to make them permanent.
++ */
++export function getSlotHoldsContainer(): Container {
++  return getCosmosClient().database(DB_NAME).container('slot_holds');
++}
++
+ /** Inject a mock CosmosClient in tests. */
+ export function _setCosmosClientForTest(mock: CosmosClient): void {
+   _client = mock;
+diff --git a/api/src/cosmos/slot-holds-repository.ts b/api/src/cosmos/slot-holds-repository.ts
+new file mode 100644
+index 00000000..1d5274e6
+--- /dev/null
++++ b/api/src/cosmos/slot-holds-repository.ts
+@@ -0,0 +1,81 @@
++import { getSlotHoldsContainer } from './client.js';
++import type { SlotHoldDoc } from '../schemas/slot-hold.js';
++
++export class SlotHoldsRepository {
++  private get container() { return getSlotHoldsContainer(); }
++
++  /**
++   * Attempts to create a soft hold for the given slot.
++   * Returns the hold doc on success, or 'CONFLICT' if the slot is already held
++   * (Cosmos 409) or there is an optimistic-concurrency conflict (Cosmos 412 —
++   * same fallback pattern as ADR-0017 §5 wallet etag).
++   */
++  async createHold(
++    serviceId: string,
++    date: string,
++    window: string,
++    customerId: string,
++  ): Promise<SlotHoldDoc | 'CONFLICT'> {
++    const id = `${serviceId}|${date}|${window}`;
++    const servicePartitionKey = `${serviceId}|${date}`;
++    // Note: ttl is intentionally omitted — the container default (30 s) applies automatically.
++    // exactOptionalPropertyTypes=true means we can't pass ttl?: number | undefined to create<T>.
++    const doc = {
++      id,
++      servicePartitionKey,
++      serviceId,
++      date,
++      window,
++      customerId,
++      heldAt: new Date().toISOString(),
++    } satisfies Omit<SlotHoldDoc, 'bookingId' | 'ttl'>;
++
++    try {
++      const { resource } = await this.container.items.create(doc);
++      return resource as SlotHoldDoc;
++    } catch (err: unknown) {
++      const code = (err as { statusCode?: number }).statusCode;
++      if (code === 409 || code === 412) return 'CONFLICT';
++      throw err;
++    }
++  }
++
++  /**
++   * Converts a soft hold to a permanent booking-owned slot record.
++   * Uses Cosmos PATCH to write bookingId and set ttl=-1 (no expiry).
++   * If the hold has already expired (404), logs a warning and returns silently —
++   * the booking succeeded and the slot will be visible via the bookings query.
++   */
++  async commitHold(holdId: string, servicePartitionKey: string, bookingId: string): Promise<void> {
++    try {
++      await this.container.item(holdId, servicePartitionKey).patch([
++        { op: 'add', path: '/bookingId', value: bookingId },
++        { op: 'replace', path: '/ttl', value: -1 },
++      ]);
++    } catch (err: unknown) {
++      const code = (err as { statusCode?: number }).statusCode;
++      if (code === 404) {
++        console.warn('[slotHoldsRepo] commitHold: hold already expired (non-fatal)', { holdId, bookingId });
++        return;
++      }
++      throw err;
++    }
++  }
++
++  /**
++   * Lists all hold docs for a given service+date partition.
++   * Cosmos TTL means expired docs are excluded automatically by the engine.
++   */
++  async listHolds(serviceId: string, date: string): Promise<SlotHoldDoc[]> {
++    const pk = `${serviceId}|${date}`;
++    const { resources } = await this.container.items
++      .query<SlotHoldDoc>({
++        query: 'SELECT * FROM c WHERE c.servicePartitionKey = @pk',
++        parameters: [{ name: '@pk', value: pk }],
++      })
++      .fetchAll();
++    return resources;
++  }
++}
++
++export const slotHoldsRepo = new SlotHoldsRepository();
+diff --git a/api/src/functions/bookings.ts b/api/src/functions/bookings.ts
+index 448bdea5..17b85ae9 100644
+--- a/api/src/functions/bookings.ts
++++ b/api/src/functions/bookings.ts
+@@ -20,6 +20,8 @@ import { posthog } from '../observability/posthog.js';
+ import { normalizeAddressText } from '../shared/address-text.js';
+ import { isLatLngInServiceArea } from '../services/service-area.service.js';
+ import { AYODHYA_SERVICE_AREA } from '../data/service-area-ayodhya.js';
++import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
++import { generateSlots } from '../shared/slot-utils.js';
+ 
+ function makeRazorpayReceipt(customerId: string): string {
+   return `bk_${Date.now().toString(36)}_${customerId.slice(0, 20)}`;
+@@ -148,6 +150,30 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+   const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
+   if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+ 
++  // E16-S02: Validate slotWindow against server-generated windows for this service + date.
++  // Rejects fabricated windows that don't align with the service's durationMinutes / workStart-workEnd.
++  const validWindows = generateSlots(service, parsed.data.slotDate);
++  if (!validWindows.includes(parsed.data.slotWindow)) {
++    return { status: 422, jsonBody: { code: 'INVALID_SLOT_WINDOW', message: 'The requested time slot does not match this service\'s schedule.' } };
++  }
++
++  // E16-S02: Slot-conflict locking — attempt to hold the slot before writing the booking.
++  // createHold returns 'CONFLICT' if another hold or booking already occupies this window.
++  const holdResult = await slotHoldsRepo.createHold(
++    parsed.data.serviceId,
++    parsed.data.slotDate,
++    parsed.data.slotWindow,
++    customer.customerId,
++  );
++  if (holdResult === 'CONFLICT') {
++    return {
++      status: 409,
++      jsonBody: { code: 'SLOT_UNAVAILABLE', message: 'This time slot is no longer available.' },
++    };
++  }
++  const holdId = holdResult.id;
++  const holdPk = holdResult.servicePartitionKey;
++
+   if (parsed.data.paymentMethod === 'CASH_ON_SERVICE') {
+     const cashOrderId = `cash_${randomUUID()}`;
+     const booking = await bookingRepo.createPending(
+@@ -160,6 +186,12 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+     const paid = await bookingRepo.markPaid(booking.id, 'cash_on_service_pending');
+     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 
++    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
++    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++      Sentry.captureException(err);
++      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++    });
++
+     // E13-S01: Apply wallet credit for cash bookings
+     let appliedCreditAmount = 0;
+     if (parsed.data.applyCredit && idempotencyKey) {
+@@ -215,6 +247,13 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+     );
+     const paid = await bookingRepo.markPaid(booking.id, 'manual_payment_not_configured');
+     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
++
++    // E16-S02: Commit hold (non-fatal)
++    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++      Sentry.captureException(err);
++      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++    });
++
+     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+       Sentry.captureException(err);
+       console.error('[createBooking] manual-payment dispatch failed', { bookingId: booking.id, err });
+@@ -319,6 +358,12 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+     const paid = await bookingRepo.markPaid(booking.id, 'credit_full_payment');
+     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 
++    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
++    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++      Sentry.captureException(err);
++      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++    });
++
+     try {
+       posthog.capture({
+         distinctId: customer.customerId,
+@@ -445,6 +490,13 @@ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+     preGeneratedBookingId,
+     razorpayCreditOptions,
+   );
++
++  // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
++  slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++    Sentry.captureException(err);
++    console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++  });
++
+   try {
+     posthog.capture({
+       distinctId: customer.customerId,
+diff --git a/api/src/functions/services-availability.ts b/api/src/functions/services-availability.ts
+new file mode 100644
+index 00000000..efc9eb9f
+--- /dev/null
++++ b/api/src/functions/services-availability.ts
+@@ -0,0 +1,88 @@
++import { app } from '@azure/functions';
++import { z } from 'zod';
++import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
++import { catalogueRepo } from '../cosmos/catalogue-repository.js';
++import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
++import { bookingRepo } from '../cosmos/booking-repository.js';
++import { generateSlots } from '../shared/slot-utils.js';
++
++// IST offset from UTC in minutes (UTC+5:30)
++const IST_OFFSET_MINUTES = 5 * 60 + 30;
++
++function todayIst(): string {
++  const now = new Date();
++  const istMs = now.getTime() + IST_OFFSET_MINUTES * 60_000;
++  return new Date(istMs).toISOString().slice(0, 10);
++}
++
++function addDays(yyyymmdd: string, days: number): string {
++  const d = new Date(`${yyyymmdd}T00:00:00Z`);
++  d.setUTCDate(d.getUTCDate() + days);
++  return d.toISOString().slice(0, 10);
++}
++
++const DateQuerySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((s) => {
++  const d = new Date(`${s}T00:00:00Z`);
++  return !isNaN(d.getTime());
++}, { message: 'Invalid calendar date' });
++
++export const availabilityHandler: CustomerHttpHandler = async (req, _ctx, _customer) => {
++  const { id: serviceId } = (req as unknown as { params: { id: string } }).params;
++  const dateParam = (req as unknown as { query: { get(k: string): string | null } }).query.get('date');
++
++  // Validate date param format
++  const dateParsed = DateQuerySchema.safeParse(dateParam);
++  if (!dateParsed.success) {
++    return { status: 422, jsonBody: { code: 'INVALID_DATE_RANGE', message: 'date must be YYYY-MM-DD' } };
++  }
++  const date = dateParsed.data;
++
++  // Validate range: today IST ≤ date ≤ today+7 IST
++  const today = todayIst();
++  const max = addDays(today, 7);
++  if (date < today || date > max) {
++    return {
++      status: 422,
++      jsonBody: {
++        code: 'INVALID_DATE_RANGE',
++        message: `date must be between ${today} and ${max} (IST)`,
++      },
++    };
++  }
++
++  // Look up service
++  const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
++  if (!service || !service.isActive) {
++    return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
++  }
++
++  // Generate server-side slot windows
++  const allWindows = generateSlots(service, date);
++
++  // Load held + hard-booked windows in parallel
++  const [holds, bookedWindows] = await Promise.all([
++    slotHoldsRepo.listHolds(serviceId, date),
++    bookingRepo.getBookedWindowsByServiceDate(serviceId, date),
++  ]);
++
++  const unavailable = new Set<string>([
++    ...holds.map((h) => h.window),
++    ...bookedWindows,
++  ]);
++
++  return {
++    status: 200,
++    jsonBody: {
++      serviceId,
++      date,
++      slotGranularityMinutes: service.durationMinutes,
++      slots: allWindows.map((window) => ({ window, available: !unavailable.has(window) })),
++    },
++  };
++};
++
++app.http('servicesAvailability', {
++  methods: ['GET'],
++  route: 'v1/services/{id}/availability',
++  handler: requireCustomer(availabilityHandler),
++});
+diff --git a/api/src/schemas/service.ts b/api/src/schemas/service.ts
+index 41f7cbbe..2e2e6cab 100644
+--- a/api/src/schemas/service.ts
++++ b/api/src/schemas/service.ts
+@@ -39,6 +39,9 @@ export const ServiceSchema = z
+     updatedBy: z.string().min(1),
+     createdAt: z.string().datetime(),
+     updatedAt: z.string().datetime(),
++    // E16-S02: optional scheduling window; defaults applied server-side (08:00 / 20:00)
++    workStart: z.string().regex(/^\d{2}:\d{2}$/).optional(),
++    workEnd: z.string().regex(/^\d{2}:\d{2}$/).optional(),
+   })
+   .strict();
+ 
+@@ -80,3 +83,19 @@ export type ServiceCard = z.infer<typeof ServiceCardSchema>;
+ export type ServiceDetail = z.infer<typeof ServiceDetailSchema>;
+ export type CreateServiceBody = z.infer<typeof CreateServiceBodySchema>;
+ export type UpdateServiceBody = z.infer<typeof UpdateServiceBodySchema>;
++
++// E16-S02: Slot availability response schemas
++export const SlotWindowSchema = z.object({
++  window: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
++  available: z.boolean(),
++});
++
++export const AvailabilityResponseSchema = z.object({
++  serviceId: z.string(),
++  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
++  slotGranularityMinutes: z.number().int().positive(),
++  slots: z.array(SlotWindowSchema),
++});
++
++export type SlotWindow = z.infer<typeof SlotWindowSchema>;
++export type AvailabilityResponse = z.infer<typeof AvailabilityResponseSchema>;
+diff --git a/api/src/schemas/slot-hold.ts b/api/src/schemas/slot-hold.ts
+new file mode 100644
+index 00000000..0c49febe
+--- /dev/null
++++ b/api/src/schemas/slot-hold.ts
+@@ -0,0 +1,15 @@
++import { z } from 'zod';
++
++export const SlotHoldDocSchema = z.object({
++  id: z.string(),                     // "<serviceId>|<date>|<window>"
++  servicePartitionKey: z.string(),    // "<serviceId>|<date>"
++  serviceId: z.string(),
++  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
++  window: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
++  customerId: z.string(),
++  heldAt: z.string().datetime(),
++  bookingId: z.string().optional(),   // set on commitHold; absent = soft hold
++  ttl: z.number().int().optional(),   // -1 when committed; absent = container default
++});
++
++export type SlotHoldDoc = z.infer<typeof SlotHoldDocSchema>;
+diff --git a/api/src/shared/slot-utils.ts b/api/src/shared/slot-utils.ts
+new file mode 100644
+index 00000000..1c70ced7
+--- /dev/null
++++ b/api/src/shared/slot-utils.ts
+@@ -0,0 +1,30 @@
++import type { Service } from '../schemas/service.js';
++
++function timeToMinutes(hhmm: string): number {
++  const [h, m] = hhmm.split(':').map(Number);
++  return (h ?? 0) * 60 + (m ?? 0);
++}
++
++function minutesToTime(minutes: number): string {
++  const h = Math.floor(minutes / 60);
++  const m = minutes % 60;
++  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
++}
++
++/**
++ * Generates non-overlapping slot windows for a service on a given date.
++ * Returns strings like "08:00-09:00". Does not filter past times — caller
++ * is responsible for date range validation.
++ */
++export function generateSlots(service: Service, _date: string): string[] {
++  const startMin = timeToMinutes(service.workStart ?? '08:00');
++  const endMin = timeToMinutes(service.workEnd ?? '20:00');
++  const duration = service.durationMinutes;
++  const slots: string[] = [];
++
++  for (let cur = startMin; cur + duration <= endMin; cur += duration) {
++    slots.push(`${minutesToTime(cur)}-${minutesToTime(cur + duration)}`);
++  }
++
++  return slots;
++}
+diff --git a/api/tests/bookings/create-apply-credit.test.ts b/api/tests/bookings/create-apply-credit.test.ts
+index 6515db00..a1f9822c 100644
+--- a/api/tests/bookings/create-apply-credit.test.ts
++++ b/api/tests/bookings/create-apply-credit.test.ts
+@@ -68,15 +68,25 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
+ 
+ vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
+   catalogueRepo: {
++    // durationMinutes: 120 → '10:00-12:00' is a valid generated slot (default 08:00–20:00 window)
+     getServiceByIdCrossPartition: vi.fn().mockResolvedValue({
+       id: 'svc-1',
+       name: 'AC Deep Clean',
+       basePrice: 59900,
+       isActive: true,
++      durationMinutes: 120,
+     }),
+   },
+ }));
+ 
++// E16-S02: slot-hold gate — mock so existing credit tests don't need Cosmos
++vi.mock('../../src/cosmos/slot-holds-repository.js', () => ({
++  slotHoldsRepo: {
++    createHold: vi.fn().mockResolvedValue({ id: 'svc-1|2026-05-15|10:00-12:00', servicePartitionKey: 'svc-1|2026-05-15', serviceId: 'svc-1', date: '2026-05-15', window: '10:00-12:00', customerId: 'cust-1', heldAt: new Date().toISOString() }),
++    commitHold: vi.fn().mockResolvedValue(undefined),
++  },
++}));
++
+ vi.mock('../../src/cosmos/customer-credit-ledger-repository.js', () => ({
+   customerCreditLedgerRepo: {
+     getBalance: vi.fn(),
+diff --git a/api/tests/bookings/create-service-area.test.ts b/api/tests/bookings/create-service-area.test.ts
+index a80f2fe2..2f5f8b9f 100644
+--- a/api/tests/bookings/create-service-area.test.ts
++++ b/api/tests/bookings/create-service-area.test.ts
+@@ -45,12 +45,21 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
+ 
+ vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
+   catalogueRepo: {
++    // durationMinutes: 120 → '10:00-12:00' is a valid generated slot (default 08:00–20:00 window)
+     getServiceByIdCrossPartition: vi.fn().mockResolvedValue({
+-      id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true,
++      id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true, durationMinutes: 120,
+     }),
+   },
+ }));
+ 
++// E16-S02: slot-hold gate — mock so service-area tests don't need Cosmos
++vi.mock('../../src/cosmos/slot-holds-repository.js', () => ({
++  slotHoldsRepo: {
++    createHold: vi.fn().mockResolvedValue({ id: 'svc-1|2026-05-01|10:00-12:00', servicePartitionKey: 'svc-1|2026-05-01', serviceId: 'svc-1', date: '2026-05-01', window: '10:00-12:00', customerId: 'cust-area-1', heldAt: new Date().toISOString() }),
++    commitHold: vi.fn().mockResolvedValue(undefined),
++  },
++}));
++
+ // featureFlags mock — we control isServiceAreaGatingEnabled per-test
+ vi.mock('../../src/services/featureFlags.service.js', () => ({
+   isSoftLaunchEnabled: vi.fn().mockResolvedValue(true),
+diff --git a/api/tests/bookings/create.test.ts b/api/tests/bookings/create.test.ts
+index 35972ea1..58fc0589 100644
+--- a/api/tests/bookings/create.test.ts
++++ b/api/tests/bookings/create.test.ts
+@@ -45,7 +45,16 @@ vi.mock('../../src/services/dispatcher.service.js', () => ({
+ 
+ vi.mock('../../src/cosmos/catalogue-repository.js', () => ({
+   catalogueRepo: {
+-    getServiceByIdCrossPartition: vi.fn().mockResolvedValue({ id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true }),
++    // durationMinutes: 120 → generates 08:00-10:00, 10:00-12:00, … slots so '10:00-12:00' passes
++    getServiceByIdCrossPartition: vi.fn().mockResolvedValue({ id: 'svc-1', name: 'AC Deep Clean', basePrice: 59900, isActive: true, durationMinutes: 120 }),
++  },
++}));
++
++// E16-S02: slot-hold gate — mock so existing tests don't need Cosmos
++vi.mock('../../src/cosmos/slot-holds-repository.js', () => ({
++  slotHoldsRepo: {
++    createHold: vi.fn().mockResolvedValue({ id: 'svc-1|2026-05-01|10:00-12:00', servicePartitionKey: 'svc-1|2026-05-01', serviceId: 'svc-1', date: '2026-05-01', window: '10:00-12:00', customerId: 'cust-1', heldAt: new Date().toISOString() }),
++    commitHold: vi.fn().mockResolvedValue(undefined),
+   },
+ }));
+ 
+diff --git a/api/tests/unit/cosmos/slot-holds-repository.test.ts b/api/tests/unit/cosmos/slot-holds-repository.test.ts
+new file mode 100644
+index 00000000..d78a839d
+--- /dev/null
++++ b/api/tests/unit/cosmos/slot-holds-repository.test.ts
+@@ -0,0 +1,143 @@
++import { describe, it, expect, vi, beforeEach } from 'vitest';
++
++// ---------------------------------------------------------------------------
++// Mocks — must be declared before module import
++// ---------------------------------------------------------------------------
++
++const mockCreate = vi.fn();
++const mockPatch = vi.fn();
++const mockFetchAll = vi.fn();
++const mockQuery = vi.fn(() => ({ fetchAll: mockFetchAll }));
++const mockItem = vi.fn(() => ({ patch: mockPatch }));
++
++vi.mock('../../../src/cosmos/client.js', () => ({
++  getSlotHoldsContainer: vi.fn(() => ({
++    items: { create: mockCreate, query: mockQuery },
++    item: mockItem,
++  })),
++}));
++
++import { slotHoldsRepo } from '../../../src/cosmos/slot-holds-repository.js';
++
++// ---------------------------------------------------------------------------
++// Helpers
++// ---------------------------------------------------------------------------
++
++const SVC = 'svc-ac';
++const DATE = '2026-05-20';
++const WINDOW = '10:00-11:00';
++const CUST = 'cust-1';
++const HOLD_ID = `${SVC}|${DATE}|${WINDOW}`;
++const HOLD_PK = `${SVC}|${DATE}`;
++
++const HOLD_DOC = {
++  id: HOLD_ID,
++  servicePartitionKey: HOLD_PK,
++  serviceId: SVC,
++  date: DATE,
++  window: WINDOW,
++  customerId: CUST,
++  heldAt: '2026-05-20T04:30:00.000Z',
++};
++
++// ---------------------------------------------------------------------------
++// createHold
++// ---------------------------------------------------------------------------
++
++describe('slotHoldsRepo.createHold', () => {
++  beforeEach(() => vi.clearAllMocks());
++
++  it('happy path: returns hold doc when Cosmos create succeeds', async () => {
++    mockCreate.mockResolvedValue({ resource: HOLD_DOC });
++
++    const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
++
++    expect(result).not.toBe('CONFLICT');
++    expect((result as typeof HOLD_DOC).id).toBe(HOLD_ID);
++    expect(mockCreate).toHaveBeenCalledOnce();
++  });
++
++  it('returns CONFLICT when Cosmos responds 409 (slot already held)', async () => {
++    mockCreate.mockRejectedValue({ statusCode: 409 });
++
++    const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
++
++    expect(result).toBe('CONFLICT');
++  });
++
++  it('returns CONFLICT when Cosmos responds 412 (etag mismatch — ADR-0017 pattern)', async () => {
++    mockCreate.mockRejectedValue({ statusCode: 412 });
++
++    const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
++
++    expect(result).toBe('CONFLICT');
++  });
++
++  it('rethrows non-409/412 errors for Sentry to capture upstream', async () => {
++    mockCreate.mockRejectedValue({ statusCode: 500, message: 'Internal error' });
++
++    await expect(slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST)).rejects.toMatchObject({ statusCode: 500 });
++  });
++});
++
++// ---------------------------------------------------------------------------
++// commitHold
++// ---------------------------------------------------------------------------
++
++describe('slotHoldsRepo.commitHold', () => {
++  beforeEach(() => vi.clearAllMocks());
++
++  it('happy path: patches bookingId and ttl=-1', async () => {
++    mockPatch.mockResolvedValue({ resource: { ...HOLD_DOC, bookingId: 'bk-1', ttl: -1 } });
++
++    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
++
++    expect(mockItem).toHaveBeenCalledWith(HOLD_ID, HOLD_PK);
++    expect(mockPatch).toHaveBeenCalledWith([
++      { op: 'add', path: '/bookingId', value: 'bk-1' },
++      { op: 'replace', path: '/ttl', value: -1 },
++    ]);
++  });
++
++  it('silently returns when hold has already expired (Cosmos 404)', async () => {
++    mockPatch.mockRejectedValue({ statusCode: 404 });
++
++    // Should NOT throw — expired hold is non-fatal
++    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
++  });
++
++  it('rethrows non-404 errors', async () => {
++    mockPatch.mockRejectedValue({ statusCode: 503 });
++
++    await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).rejects.toMatchObject({ statusCode: 503 });
++  });
++});
++
++// ---------------------------------------------------------------------------
++// listHolds
++// ---------------------------------------------------------------------------
++
++describe('slotHoldsRepo.listHolds', () => {
++  beforeEach(() => vi.clearAllMocks());
++
++  it('returns active hold docs for the given serviceId + date partition', async () => {
++    mockFetchAll.mockResolvedValue({ resources: [HOLD_DOC] });
++
++    const result = await slotHoldsRepo.listHolds(SVC, DATE);
++
++    expect(result).toHaveLength(1);
++    expect(result[0]!.window).toBe(WINDOW);
++    // Verify it queries on the composite partition key
++    const rawCall = mockQuery.mock.calls[0];
++    const callArg = (rawCall as unknown as [{ query: string; parameters: { name: string; value: string }[] }])[0]!;
++    expect(callArg.parameters[0]!.value).toBe(HOLD_PK);
++  });
++
++  it('returns empty array when no active holds exist', async () => {
++    mockFetchAll.mockResolvedValue({ resources: [] });
++
++    const result = await slotHoldsRepo.listHolds(SVC, DATE);
++
++    expect(result).toEqual([]);
++  });
++});
+diff --git a/api/tests/unit/functions/bookings-slot-gate.test.ts b/api/tests/unit/functions/bookings-slot-gate.test.ts
+new file mode 100644
+index 00000000..b6743cdc
+--- /dev/null
++++ b/api/tests/unit/functions/bookings-slot-gate.test.ts
+@@ -0,0 +1,232 @@
++/**
++ * E16-S02 — Unit tests for the slot-hold gate inserted in POST /v1/bookings (createHandler).
++ *
++ * Tests the three new behaviors:
++ *   1. createHold returns hold doc → booking proceeds normally
++ *   2. createHold returns 'CONFLICT' → 409 SLOT_UNAVAILABLE
++ *   3. slotWindow not in generated slots → 422 INVALID_SLOT_WINDOW
++ *   4. commitHold rejects → Sentry captures; booking response still returned
++ */
++
++import { describe, it, expect, vi, beforeEach } from 'vitest';
++import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
++import type { SlotHoldDoc } from '../../../src/schemas/slot-hold.js';
++
++// ---------------------------------------------------------------------------
++// Mocks — vi.hoisted() required for variables used inside vi.mock() factories
++// ---------------------------------------------------------------------------
++
++const { mockCreateHold, mockCommitHold } = vi.hoisted(() => ({
++  mockCreateHold: vi.fn(),
++  mockCommitHold: vi.fn(),
++}));
++
++vi.mock('../../../src/cosmos/slot-holds-repository.js', () => ({
++  slotHoldsRepo: { createHold: mockCreateHold, commitHold: mockCommitHold },
++}));
++
++vi.mock('../../../src/services/firebaseAdmin.js', () => ({
++  verifyFirebaseIdToken: vi.fn().mockResolvedValue({ uid: 'cust-1', phone_number: '+919999999999' }),
++}));
++
++vi.mock('../../../src/cosmos/catalogue-repository.js', () => ({
++  catalogueRepo: { getServiceByIdCrossPartition: vi.fn() },
++}));
++
++vi.mock('../../../src/cosmos/booking-repository.js', () => ({
++  bookingRepo: {
++    createPending: vi.fn(),
++    markPaid: vi.fn(),
++    getBookedWindowsByServiceDate: vi.fn().mockResolvedValue([]),
++  },
++}));
++
++vi.mock('../../../src/services/razorpay.service.js', () => ({
++  createRazorpayOrder: vi.fn(),
++  verifyPaymentSignature: vi.fn(),
++}));
++
++vi.mock('../../../src/services/featureFlags.service.js', () => ({
++  isSoftLaunchEnabled: vi.fn().mockResolvedValue(true),
++  isMarketingPaused: vi.fn().mockResolvedValue(false),
++  isServiceAreaGatingEnabled: vi.fn().mockResolvedValue(false),
++  isWalletCreditEnabled: vi.fn().mockResolvedValue(false),
++}));
++
++vi.mock('../../../src/services/dispatcher.service.js', () => ({
++  dispatcherService: { triggerDispatch: vi.fn().mockResolvedValue(undefined) },
++}));
++
++vi.mock('../../../src/cosmos/audit-log-repository.js', () => ({
++  appendAuditEntry: vi.fn().mockResolvedValue(undefined),
++}));
++
++vi.mock('../../../src/cosmos/customer-credit-ledger-repository.js', () => ({
++  customerCreditLedgerRepo: { getBalance: vi.fn().mockResolvedValue({ balanceInPaise: 0 }) },
++}));
++
++vi.mock('../../../src/observability/posthog.js', () => ({
++  posthog: { capture: vi.fn() },
++}));
++
++vi.mock('@sentry/node', () => ({ captureException: vi.fn() }));
++
++import { createBookingHandler } from '../../../src/functions/bookings.js';
++import { catalogueRepo } from '../../../src/cosmos/catalogue-repository.js';
++import { bookingRepo } from '../../../src/cosmos/booking-repository.js';
++import * as Sentry from '@sentry/node';
++import type { Service } from '../../../src/schemas/service.js';
++import type { BookingDoc } from '../../../src/schemas/booking.js';
++
++// ---------------------------------------------------------------------------
++// Helpers
++// ---------------------------------------------------------------------------
++
++const ctx = { log: vi.fn(), error: vi.fn(), info: vi.fn() } as unknown as InvocationContext;
++
++function makeService(overrides: Partial<Service> = {}): Service {
++  return {
++    id: 'svc-ac',
++    categoryId: 'cat-1',
++    name: 'AC Deep Clean',
++    shortDescription: 'Deep clean',
++    heroImageUrl: 'https://example.com/img.jpg',
++    basePrice: 59900,
++    commissionBps: 2000,
++    durationMinutes: 60,
++    includes: [],
++    faq: [],
++    addOns: [],
++    photoStages: [],
++    isActive: true,
++    updatedBy: 'admin',
++    createdAt: '2026-01-01T00:00:00.000Z',
++    updatedAt: '2026-01-01T00:00:00.000Z',
++    workStart: '10:00',
++    workEnd: '11:00', // single slot: 10:00-11:00
++    ...overrides,
++  };
++}
++
++function makeBooking(): BookingDoc {
++  return {
++    id: 'bk-1',
++    customerId: 'cust-1',
++    serviceId: 'svc-ac',
++    categoryId: 'cat-1',
++    slotDate: '2026-05-20',
++    slotWindow: '10:00-11:00',
++    addressText: '1 Main St',
++    addressLatLng: { lat: 26.79, lng: 82.19 },
++    status: 'PENDING_PAYMENT',
++    paymentOrderId: 'cash_abc',
++    paymentMethod: 'CASH_ON_SERVICE',
++    paymentId: null,
++    paymentSignature: null,
++    amount: 59900,
++    createdAt: '2026-05-20T04:30:00.000Z',
++  };
++}
++
++function makeHold(): SlotHoldDoc {
++  return {
++    id: 'svc-ac|2026-05-20|10:00-11:00',
++    servicePartitionKey: 'svc-ac|2026-05-20',
++    serviceId: 'svc-ac',
++    date: '2026-05-20',
++    window: '10:00-11:00',
++    customerId: 'cust-1',
++    heldAt: new Date().toISOString(),
++  };
++}
++
++function makeReq(body: object): HttpRequest {
++  return {
++    json: vi.fn().mockResolvedValue(body),
++    headers: { get: (h: string) => h.toLowerCase() === 'authorization' ? 'Bearer token' : null },
++    params: {},
++  } as unknown as HttpRequest;
++}
++
++const VALID_BODY = {
++  serviceId: 'svc-ac',
++  categoryId: 'cat-1',
++  slotDate: '2026-05-20',
++  slotWindow: '10:00-11:00',
++  addressText: '1 Main St',
++  addressLatLng: { lat: 26.79, lng: 82.19 },
++  paymentMethod: 'CASH_ON_SERVICE',
++  applyCredit: false,
++};
++
++// ---------------------------------------------------------------------------
++// Tests
++// ---------------------------------------------------------------------------
++
++beforeEach(() => {
++  vi.clearAllMocks();
++  vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService());
++  vi.mocked(bookingRepo.createPending).mockResolvedValue(makeBooking());
++  vi.mocked(bookingRepo.markPaid).mockResolvedValue(makeBooking());
++  mockCommitHold.mockResolvedValue(undefined);
++});
++
++describe('E16-S02: slot-hold gate in POST /v1/bookings', () => {
++  it('proceeds normally when createHold returns a hold doc', async () => {
++    mockCreateHold.mockResolvedValue(makeHold());
++
++    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
++
++    expect(res.status).toBe(201);
++    expect(mockCreateHold).toHaveBeenCalledOnce();
++    expect(mockCreateHold).toHaveBeenCalledWith('svc-ac', '2026-05-20', '10:00-11:00', 'cust-1');
++  });
++
++  it('returns 409 SLOT_UNAVAILABLE when createHold returns CONFLICT', async () => {
++    mockCreateHold.mockResolvedValue('CONFLICT');
++
++    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
++
++    expect(res.status).toBe(409);
++    expect(((res as unknown as HttpResponseInit).jsonBody as { code: string }).code).toBe('SLOT_UNAVAILABLE');
++    expect(bookingRepo.createPending).not.toHaveBeenCalled();
++  });
++
++  it('returns 422 INVALID_SLOT_WINDOW when slotWindow is not in generated slots', async () => {
++    // Service window is 10:00-11:00 (1 slot); request a fabricated window
++    const body = { ...VALID_BODY, slotWindow: '99:00-00:00' };
++
++    const res = await createBookingHandler(makeReq(body), ctx);
++
++    expect(res.status).toBe(422);
++    expect(((res as unknown as HttpResponseInit).jsonBody as { code: string }).code).toBe('INVALID_SLOT_WINDOW');
++    expect(mockCreateHold).not.toHaveBeenCalled();
++  });
++
++  it('returns 201 and captures Sentry error when commitHold rejects (non-fatal)', async () => {
++    mockCreateHold.mockResolvedValue(makeHold());
++    mockCommitHold.mockRejectedValue(new Error('Cosmos timeout'));
++
++    const res = await createBookingHandler(makeReq(VALID_BODY), ctx);
++
++    // Booking still succeeds
++    expect(res.status).toBe(201);
++    // Wait for the non-blocking commitHold promise to settle
++    await new Promise((r) => setTimeout(r, 10));
++    expect(Sentry.captureException).toHaveBeenCalled();
++  });
++
++  it('calls commitHold with holdId and bookingId after successful booking', async () => {
++    mockCreateHold.mockResolvedValue(makeHold());
++
++    await createBookingHandler(makeReq(VALID_BODY), ctx);
++
++    // Allow the fire-and-forget to resolve
++    await new Promise((r) => setTimeout(r, 10));
++    expect(mockCommitHold).toHaveBeenCalledWith(
++      'svc-ac|2026-05-20|10:00-11:00',
++      'svc-ac|2026-05-20',
++      'bk-1',
++    );
++  });
++});
+diff --git a/api/tests/unit/functions/services-availability.test.ts b/api/tests/unit/functions/services-availability.test.ts
+new file mode 100644
+index 00000000..331bb132
+--- /dev/null
++++ b/api/tests/unit/functions/services-availability.test.ts
+@@ -0,0 +1,159 @@
++import { describe, it, expect, vi, beforeEach } from 'vitest';
++import type { HttpRequest, InvocationContext } from '@azure/functions';
++
++// ---------------------------------------------------------------------------
++// Mocks
++// ---------------------------------------------------------------------------
++
++vi.mock('../../../src/services/firebaseAdmin.js', () => ({
++  verifyFirebaseIdToken: vi.fn().mockResolvedValue({ uid: 'cust-1' }),
++}));
++vi.mock('../../../src/cosmos/catalogue-repository.js', () => ({
++  catalogueRepo: { getServiceByIdCrossPartition: vi.fn() },
++}));
++vi.mock('../../../src/cosmos/slot-holds-repository.js', () => ({
++  slotHoldsRepo: { listHolds: vi.fn() },
++}));
++vi.mock('../../../src/cosmos/booking-repository.js', () => ({
++  bookingRepo: { getBookedWindowsByServiceDate: vi.fn() },
++}));
++
++import { availabilityHandler } from '../../../src/functions/services-availability.js';
++import { catalogueRepo } from '../../../src/cosmos/catalogue-repository.js';
++import { slotHoldsRepo } from '../../../src/cosmos/slot-holds-repository.js';
++import { bookingRepo } from '../../../src/cosmos/booking-repository.js';
++import type { Service } from '../../../src/schemas/service.js';
++
++// ---------------------------------------------------------------------------
++// Helpers
++// ---------------------------------------------------------------------------
++
++const ctx = { log: vi.fn(), error: vi.fn() } as unknown as InvocationContext;
++const CUSTOMER = { customerId: 'cust-1' };
++
++// A date 3 days from now — always within the 7-day window regardless of timezone
++const VALID_DATE = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10)!;
++
++function makeReq(serviceId: string, date: string): HttpRequest {
++  return {
++    params: { id: serviceId },
++    query: { get: (k: string) => (k === 'date' ? date : null) },
++    headers: { get: () => 'Bearer token' },
++  } as unknown as HttpRequest;
++}
++
++function makeService(overrides: Partial<Service> = {}): Service {
++  return {
++    id: 'svc-ac',
++    categoryId: 'cat-1',
++    name: 'AC Deep Clean',
++    shortDescription: 'Deep clean',
++    heroImageUrl: 'https://example.com/img.jpg',
++    basePrice: 59900,
++    commissionBps: 2000,
++    durationMinutes: 60,
++    includes: [],
++    faq: [],
++    addOns: [],
++    photoStages: [],
++    isActive: true,
++    updatedBy: 'admin',
++    createdAt: '2026-01-01T00:00:00.000Z',
++    updatedAt: '2026-01-01T00:00:00.000Z',
++    ...overrides,
++  };
++}
++
++// ---------------------------------------------------------------------------
++// Tests
++// ---------------------------------------------------------------------------
++
++beforeEach(() => {
++  vi.clearAllMocks();
++  vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService());
++  vi.mocked(slotHoldsRepo.listHolds).mockResolvedValue([]);
++  vi.mocked(bookingRepo.getBookedWindowsByServiceDate).mockResolvedValue([]);
++});
++
++describe('GET /v1/services/{id}/availability', () => {
++  describe('happy path', () => {
++    it('returns 200 with all slots available when no holds or bookings exist', async () => {
++      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
++
++      expect(res.status).toBe(200);
++      const body = res.jsonBody as { slots: { window: string; available: boolean }[]; slotGranularityMinutes: number };
++      expect(body.slotGranularityMinutes).toBe(60);
++      expect(body.slots.length).toBeGreaterThan(0);
++      expect(body.slots.every((s) => s.available)).toBe(true);
++    });
++
++    it('marks a held slot as unavailable', async () => {
++      const service = makeService({ workStart: '08:00', workEnd: '09:00', durationMinutes: 60 });
++      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(service);
++      vi.mocked(slotHoldsRepo.listHolds).mockResolvedValue([
++        { id: 'x', servicePartitionKey: 'y', serviceId: 'svc-ac', date: VALID_DATE, window: '08:00-09:00', customerId: 'other', heldAt: new Date().toISOString() },
++      ]);
++
++      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
++
++      expect(res.status).toBe(200);
++      const body = res.jsonBody as { slots: { window: string; available: boolean }[] };
++      expect(body.slots[0]!.available).toBe(false);
++    });
++
++    it('marks a hard-booked slot as unavailable', async () => {
++      const service = makeService({ workStart: '08:00', workEnd: '09:00', durationMinutes: 60 });
++      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(service);
++      vi.mocked(bookingRepo.getBookedWindowsByServiceDate).mockResolvedValue(['08:00-09:00']);
++
++      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
++
++      expect(res.status).toBe(200);
++      const body = res.jsonBody as { slots: { window: string; available: boolean }[] };
++      expect(body.slots[0]!.available).toBe(false);
++    });
++  });
++
++  describe('date validation (422)', () => {
++    it('rejects a past date', async () => {
++      const res = await availabilityHandler(makeReq('svc-ac', '2020-01-01'), ctx, CUSTOMER as any);
++      expect(res.status).toBe(422);
++      const body = res.jsonBody as { code: string };
++      expect(body.code).toBe('INVALID_DATE_RANGE');
++    });
++
++    it('rejects a date more than 7 days in the future', async () => {
++      const res = await availabilityHandler(makeReq('svc-ac', '2099-12-31'), ctx, CUSTOMER as any);
++      expect(res.status).toBe(422);
++      const body = res.jsonBody as { code: string };
++      expect(body.code).toBe('INVALID_DATE_RANGE');
++    });
++
++    it('rejects a malformed date string', async () => {
++      const res = await availabilityHandler(makeReq('svc-ac', '2026-13-01'), ctx, CUSTOMER as any);
++      expect(res.status).toBe(422);
++    });
++
++    it('rejects a missing date query param', async () => {
++      const req = { ...makeReq('svc-ac', ''), query: { get: () => null } } as unknown as HttpRequest;
++      const res = await availabilityHandler(req, ctx, CUSTOMER as any);
++      expect(res.status).toBe(422);
++    });
++  });
++
++  describe('service lookup', () => {
++    it('returns 404 when service does not exist', async () => {
++      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(null);
++
++      const res = await availabilityHandler(makeReq('svc-unknown', VALID_DATE), ctx, CUSTOMER as any);
++      expect(res.status).toBe(404);
++    });
++
++    it('returns 404 when service exists but is inactive', async () => {
++      vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(makeService({ isActive: false }));
++
++      const res = await availabilityHandler(makeReq('svc-ac', VALID_DATE), ctx, CUSTOMER as any);
++      expect(res.status).toBe(404);
++    });
++  });
++});
+diff --git a/api/tests/unit/schemas/slot-hold.test.ts b/api/tests/unit/schemas/slot-hold.test.ts
+new file mode 100644
+index 00000000..13f31a54
+--- /dev/null
++++ b/api/tests/unit/schemas/slot-hold.test.ts
+@@ -0,0 +1,62 @@
++import { describe, it, expect } from 'vitest';
++import { SlotHoldDocSchema, type SlotHoldDoc } from '../../../src/schemas/slot-hold.js';
++
++const VALID_HOLD: SlotHoldDoc = {
++  id: 'svc-ac|2026-05-20|10:00-11:00',
++  servicePartitionKey: 'svc-ac|2026-05-20',
++  serviceId: 'svc-ac',
++  date: '2026-05-20',
++  window: '10:00-11:00',
++  customerId: 'cust-1',
++  heldAt: '2026-05-20T04:30:00.000Z',
++};
++
++describe('SlotHoldDocSchema', () => {
++  it('accepts a valid soft hold (no bookingId / ttl)', () => {
++    expect(() => SlotHoldDocSchema.parse(VALID_HOLD)).not.toThrow();
++  });
++
++  it('accepts a committed hold with bookingId and ttl=-1', () => {
++    const committed = { ...VALID_HOLD, bookingId: 'bk-999', ttl: -1 };
++    expect(() => SlotHoldDocSchema.parse(committed)).not.toThrow();
++  });
++
++  it('rejects when required field id is missing', () => {
++    const { id: _id, ...without } = VALID_HOLD;
++    expect(SlotHoldDocSchema.safeParse(without).success).toBe(false);
++  });
++
++  it('rejects malformed date (wrong format)', () => {
++    const result = SlotHoldDocSchema.safeParse({ ...VALID_HOLD, date: '20-05-2026' });
++    expect(result.success).toBe(false);
++  });
++
++  it('rejects malformed window (missing separator)', () => {
++    const result = SlotHoldDocSchema.safeParse({ ...VALID_HOLD, window: '1000-1100' });
++    expect(result.success).toBe(false);
++  });
++
++  it('rejects non-datetime heldAt', () => {
++    const result = SlotHoldDocSchema.safeParse({ ...VALID_HOLD, heldAt: '2026-05-20' });
++    expect(result.success).toBe(false);
++  });
++});
++
++describe('AvailabilityResponseSchema', () => {
++  it('round-trips a mixed-availability slot array', async () => {
++    const { AvailabilityResponseSchema } = await import('../../../src/schemas/service.js');
++    const input = {
++      serviceId: 'svc-ac',
++      date: '2026-05-20',
++      slotGranularityMinutes: 60,
++      slots: [
++        { window: '08:00-09:00', available: true },
++        { window: '09:00-10:00', available: false },
++        { window: '10:00-11:00', available: true },
++      ],
++    };
++    const result = AvailabilityResponseSchema.parse(input);
++    expect(result.slots).toHaveLength(3);
++    expect(result.slots[1]!.available).toBe(false);
++  });
++});
+diff --git a/api/tests/unit/shared/slot-utils.test.ts b/api/tests/unit/shared/slot-utils.test.ts
+new file mode 100644
+index 00000000..1daf6190
+--- /dev/null
++++ b/api/tests/unit/shared/slot-utils.test.ts
+@@ -0,0 +1,68 @@
++import { describe, it, expect } from 'vitest';
++import { generateSlots } from '../../../src/shared/slot-utils.js';
++import type { Service } from '../../../src/schemas/service.js';
++
++function makeService(overrides: Partial<Service> = {}): Service {
++  return {
++    id: 'svc-ac',
++    categoryId: 'cat-1',
++    name: 'AC Deep Clean',
++    shortDescription: 'Deep clean',
++    heroImageUrl: 'https://example.com/img.jpg',
++    basePrice: 59900,
++    commissionBps: 2000,
++    durationMinutes: 60,
++    includes: [],
++    faq: [],
++    addOns: [],
++    photoStages: [],
++    isActive: true,
++    updatedBy: 'admin',
++    createdAt: '2026-01-01T00:00:00.000Z',
++    updatedAt: '2026-01-01T00:00:00.000Z',
++    ...overrides,
++  };
++}
++
++describe('generateSlots', () => {
++  it('generates 12 hourly slots for a 60-min service with default 08:00–20:00 window', () => {
++    const slots = generateSlots(makeService(), '2026-05-20');
++    expect(slots).toHaveLength(12);
++    expect(slots[0]).toBe('08:00-09:00');
++    expect(slots[11]).toBe('19:00-20:00');
++  });
++
++  it('generates 6 slots for a 120-min service with default window', () => {
++    const slots = generateSlots(makeService({ durationMinutes: 120 }), '2026-05-20');
++    expect(slots).toHaveLength(6);
++    expect(slots[0]).toBe('08:00-10:00');
++    expect(slots[5]).toBe('18:00-20:00');
++  });
++
++  it('respects custom workStart and workEnd', () => {
++    const slots = generateSlots(makeService({ workStart: '09:00', workEnd: '12:00' }), '2026-05-20');
++    // 3 × 60-min slots: 09:00, 10:00, 11:00
++    expect(slots).toHaveLength(3);
++    expect(slots[0]).toBe('09:00-10:00');
++    expect(slots[2]).toBe('11:00-12:00');
++  });
++
++  it('returns empty array when workStart equals workEnd', () => {
++    const slots = generateSlots(makeService({ workStart: '08:00', workEnd: '08:00' }), '2026-05-20');
++    expect(slots).toHaveLength(0);
++  });
++
++  it('does not include a slot whose end would exceed workEnd', () => {
++    // 90-min service, 08:00–11:00 → fits: 08:00-09:30, 09:30-11:00; next would be 11:00-12:30 (exceeds 11:00)
++    const slots = generateSlots(makeService({ durationMinutes: 90, workStart: '08:00', workEnd: '11:00' }), '2026-05-20');
++    expect(slots).toHaveLength(2);
++    expect(slots[1]).toBe('09:30-11:00');
++  });
++
++  it('formats minutes correctly (e.g., 08:30-09:30)', () => {
++    const slots = generateSlots(makeService({ durationMinutes: 30, workStart: '08:00', workEnd: '09:30' }), '2026-05-20');
++    expect(slots).toContain('08:00-08:30');
++    expect(slots).toContain('08:30-09:00');
++    expect(slots).toContain('09:00-09:30');
++  });
++});
+warning: unable to access 'C:\Users\alokt/.config/git/ignore': Permission denied
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'git diff --stat f39ac4b37a5f76121433cc6ac340508f273858ef; git diff --name-only f39ac4b37a5f76121433cc6ac340508f273858ef' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 540ms:
+ api/openapi.json                                   |  32 +++
+ api/scripts/setup-cosmos.ts                        |   9 +
+ api/src/cosmos/booking-repository.ts               |  19 ++
+ api/src/cosmos/client.ts                           |   9 +
+ api/src/cosmos/slot-holds-repository.ts            |  81 +++++++
+ api/src/functions/bookings.ts                      |  52 +++++
+ api/src/functions/services-availability.ts         |  88 ++++++++
+ api/src/schemas/service.ts                         |  19 ++
+ api/src/schemas/slot-hold.ts                       |  15 ++
+ api/src/shared/slot-utils.ts                       |  30 +++
+ api/tests/bookings/create-apply-credit.test.ts     |  10 +
+ api/tests/bookings/create-service-area.test.ts     |  11 +-
+ api/tests/bookings/create.test.ts                  |  11 +-
+ .../unit/cosmos/slot-holds-repository.test.ts      | 143 +++++++++++++
+ .../unit/functions/bookings-slot-gate.test.ts      | 232 +++++++++++++++++++++
+ .../unit/functions/services-availability.test.ts   | 159 ++++++++++++++
+ api/tests/unit/schemas/slot-hold.test.ts           |  62 ++++++
+ api/tests/unit/shared/slot-utils.test.ts           |  68 ++++++
+ 18 files changed, 1048 insertions(+), 2 deletions(-)
+api/openapi.json
+api/scripts/setup-cosmos.ts
+api/src/cosmos/booking-repository.ts
+api/src/cosmos/client.ts
+api/src/cosmos/slot-holds-repository.ts
+api/src/functions/bookings.ts
+api/src/functions/services-availability.ts
+api/src/schemas/service.ts
+api/src/schemas/slot-hold.ts
+api/src/shared/slot-utils.ts
+api/tests/bookings/create-apply-credit.test.ts
+api/tests/bookings/create-service-area.test.ts
+api/tests/bookings/create.test.ts
+api/tests/unit/cosmos/slot-holds-repository.test.ts
+api/tests/unit/functions/bookings-slot-gate.test.ts
+api/tests/unit/functions/services-availability.test.ts
+api/tests/unit/schemas/slot-hold.test.ts
+api/tests/unit/shared/slot-utils.test.ts
+warning: unable to access 'C:\Users\alokt/.config/git/ignore': Permission denied
+warning: unable to access 'C:\Users\alokt/.config/git/ignore': Permission denied
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'git diff --no-ext-diff --unified=80 f39ac4b37a5f76121433cc6ac340508f273858ef -- api/src/functions/bookings.ts api/src/functions/services-availability.ts api/src/cosmos/slot-holds-repository.ts api/src/shared/slot-utils.ts api/src/schemas/service.ts api/src/cosmos/booking-repository.ts' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 767ms:
+diff --git a/api/src/cosmos/booking-repository.ts b/api/src/cosmos/booking-repository.ts
+index 0ef5bdc6..04a96c9c 100644
+--- a/api/src/cosmos/booking-repository.ts
++++ b/api/src/cosmos/booking-repository.ts
+@@ -185,157 +185,176 @@ export const bookingRepo = {
+       })
+       .fetchAll();
+     return resources.sort((a, b) => {
+       const slotCompare = b.slotDate.localeCompare(a.slotDate) || b.slotWindow.localeCompare(a.slotWindow);
+       return slotCompare || b.createdAt.localeCompare(a.createdAt);
+     });
+   },
+ 
+   async requestAddOn(id: string, addOn: PendingAddOn): Promise<BookingDoc | null> {
+     const existing = await this.getById(id);
+     if (!existing || existing.status !== 'IN_PROGRESS') return null;
+     const updated: BookingDoc = {
+       ...existing,
+       status: 'AWAITING_PRICE_APPROVAL',
+       pendingAddOns: [...(existing.pendingAddOns ?? []), addOn],
+       // Stable anchor for the ADDON_APPROVAL_REQUESTED pending-action expiry.
+       // Written atomically with the status transition so the change-feed projector
+       // can derive 24h from the actual request time (not the booking createdAt).
+       pendingAddOnsUpdatedAt: new Date().toISOString(),
+     };
+     const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+     return resource!;
+   },
+ 
+   async applyAddOnDecisions(id: string, customerId: string, decisions: AddOnDecision[]): Promise<BookingDoc | null> {
+     const existing = await this.getById(id);
+     if (!existing || existing.customerId !== customerId) return null;
+     if (existing.status !== 'AWAITING_PRICE_APPROVAL') return null;
+     const pending = existing.pendingAddOns ?? [];
+     const approved = pending.filter(a => decisions.find(d => d.name === a.name && d.approved));
+     const updated: BookingDoc = {
+       ...existing,
+       status: 'IN_PROGRESS',
+       pendingAddOns: [],
+       approvedAddOns: [...(existing.approvedAddOns ?? []), ...approved],
+       finalAmount: (existing.finalAmount ?? existing.amount) + approved.reduce((s, a) => s + a.price, 0),
+     };
+     const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+     return resource!;
+   },
+ 
+   async addPhoto(
+     bookingId: string,
+     stage: string,
+     photoUrl: string,
+   ): Promise<BookingDoc | null> {
+     const { resource: existing, etag } = await getBookingsContainer()
+       .item(bookingId, bookingId)
+       .read<BookingDoc>();
+     if (!existing) return null;
+     const stagePhotos = existing.photos?.[stage] ?? [];
+     const updated: BookingDoc = {
+       ...existing,
+       photos: { ...existing.photos, [stage]: [...stagePhotos, photoUrl] },
+     };
+     // Use ETag optimistic concurrency so concurrent uploads for the same
+     // booking/stage don't silently drop each other's photo URL.
+     const { resource } = await getBookingsContainer()
+       .item(bookingId, bookingId)
+       .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+     return resource ?? null;
+   },
+ 
+   async markSosActivated(id: string): Promise<BookingDoc | null> {
+     const { resource: existing, etag } = await getBookingsContainer().item(id, id).read<BookingDoc>();
+     if (!existing) return null;
+     if (existing.sosActivatedAt) return existing; // already activated — concurrent request lost the race
+     const updated: BookingDoc = { ...existing, sosActivatedAt: new Date().toISOString() };
+     try {
+       const { resource } = await getBookingsContainer()
+         .item(id, id)
+         .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+       return resource ?? null;
+     } catch (e: unknown) {
+       if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: number }).code === 412) {
+         return null; // lost ETag race — caller handles as already-activated
+       }
+       throw e;
+     }
+   },
++
++  // E16-S02: Returns slotWindow strings for all active (non-cancelled/unfulfilled) bookings
++  // for a given service on a given date. Used by the availability handler to mark slots
++  // as hard-booked. Cross-partition scan — acceptable at pilot scale (≤5,000 bookings/mo).
++  async getBookedWindowsByServiceDate(serviceId: string, date: string): Promise<string[]> {
++    const { resources } = await getBookingsContainer()
++      .items.query<{ slotWindow: string }>({
++        query: `SELECT c.slotWindow FROM c
++                WHERE c.serviceId = @serviceId
++                  AND c.slotDate = @date
++                  AND c.status NOT IN ('CUSTOMER_CANCELLED', 'UNFULFILLED')`,
++        parameters: [
++          { name: '@serviceId', value: serviceId },
++          { name: '@date', value: date },
++        ],
++      })
++      .fetchAll();
++    return resources.map((r) => r.slotWindow);
++  },
+ };
+ 
+ export async function updateBookingFields(
+   id: string,
+   fields: Partial<BookingDoc>,
+ ): Promise<BookingDoc | null> {
+   const existing = await bookingRepo.getById(id);
+   if (!existing) return null;
+   const updated: BookingDoc = { ...existing, ...fields };
+   const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+   return resource ?? null;
+ }
+ 
+ // ── Admin roster helpers (E09-S07a) ───────────────────────────────────────────
+ 
+ export async function getActiveBookingCountForTechnician(technicianId: string): Promise<number> {
+   const { resources } = await getBookingsContainer()
+     .items.query<number>({
+       query: `SELECT VALUE COUNT(1) FROM c
+               WHERE c.technicianId = @technicianId
+                 AND c.status IN ('ASSIGNED', 'EN_ROUTE', 'REACHED', 'IN_PROGRESS', 'AWAITING_PRICE_APPROVAL')`,
+       parameters: [{ name: '@technicianId', value: technicianId }],
+     })
+     .fetchAll();
+   return resources[0] ?? 0;
+ }
+ 
+ // ── Customer roster helpers (E09-S07a A4) ─────────────────────────────────────
+ 
+ export interface CustomerBookingSummary {
+   customerId: string;
+   bookingCount: number;
+   lastBookingDate?: string;
+   lastCity?: string;
+   recentBookings: Array<{
+     date: string; serviceId: string; technicianId: string; status: string;
+   }>;
+ }
+ 
+ export async function getCustomerSummaries(): Promise<CustomerBookingSummary[]> {
+   const { resources } = await getBookingsContainer()
+     .items.query<{
+       customerId: string; slotDate: string; serviceId: string;
+       technicianId: string; status: string; addressText: string;
+     }>(`SELECT c.customerId, c.slotDate, c.serviceId, c.technicianId,
+               c.status, c.addressText
+         FROM c`)
+     .fetchAll();
+ 
+   const map = new Map<string, CustomerBookingSummary>();
+   for (const r of resources) {
+     const cid = r.customerId;
+     if (!cid) continue;
+     if (!map.has(cid)) {
+       const rawCity = typeof r.addressText === 'string' ? r.addressText.split(',').pop()?.trim() : undefined;
+       const entry: CustomerBookingSummary = {
+         customerId: cid,
+         bookingCount: 0,
+         recentBookings: [],
+       };
+       if (r.slotDate) entry.lastBookingDate = r.slotDate;
+       if (rawCity) entry.lastCity = rawCity;
+       map.set(cid, entry);
+     }
+     const entry = map.get(cid)!;
+     entry.bookingCount++;
+     if (entry.recentBookings.length < 5) {
+       entry.recentBookings.push({
+         date: r.slotDate,
+         serviceId: r.serviceId,
+         technicianId: r.technicianId ?? '',
+         status: r.status,
+       });
+     }
+   }
+   return [...map.values()];
+ }
+diff --git a/api/src/cosmos/slot-holds-repository.ts b/api/src/cosmos/slot-holds-repository.ts
+new file mode 100644
+index 00000000..1d5274e6
+--- /dev/null
++++ b/api/src/cosmos/slot-holds-repository.ts
+@@ -0,0 +1,81 @@
++import { getSlotHoldsContainer } from './client.js';
++import type { SlotHoldDoc } from '../schemas/slot-hold.js';
++
++export class SlotHoldsRepository {
++  private get container() { return getSlotHoldsContainer(); }
++
++  /**
++   * Attempts to create a soft hold for the given slot.
++   * Returns the hold doc on success, or 'CONFLICT' if the slot is already held
++   * (Cosmos 409) or there is an optimistic-concurrency conflict (Cosmos 412 —
++   * same fallback pattern as ADR-0017 §5 wallet etag).
++   */
++  async createHold(
++    serviceId: string,
++    date: string,
++    window: string,
++    customerId: string,
++  ): Promise<SlotHoldDoc | 'CONFLICT'> {
++    const id = `${serviceId}|${date}|${window}`;
++    const servicePartitionKey = `${serviceId}|${date}`;
++    // Note: ttl is intentionally omitted — the container default (30 s) applies automatically.
++    // exactOptionalPropertyTypes=true means we can't pass ttl?: number | undefined to create<T>.
++    const doc = {
++      id,
++      servicePartitionKey,
++      serviceId,
++      date,
++      window,
++      customerId,
++      heldAt: new Date().toISOString(),
++    } satisfies Omit<SlotHoldDoc, 'bookingId' | 'ttl'>;
++
++    try {
++      const { resource } = await this.container.items.create(doc);
++      return resource as SlotHoldDoc;
++    } catch (err: unknown) {
++      const code = (err as { statusCode?: number }).statusCode;
++      if (code === 409 || code === 412) return 'CONFLICT';
++      throw err;
++    }
++  }
++
++  /**
++   * Converts a soft hold to a permanent booking-owned slot record.
++   * Uses Cosmos PATCH to write bookingId and set ttl=-1 (no expiry).
++   * If the hold has already expired (404), logs a warning and returns silently —
++   * the booking succeeded and the slot will be visible via the bookings query.
++   */
++  async commitHold(holdId: string, servicePartitionKey: string, bookingId: string): Promise<void> {
++    try {
++      await this.container.item(holdId, servicePartitionKey).patch([
++        { op: 'add', path: '/bookingId', value: bookingId },
++        { op: 'replace', path: '/ttl', value: -1 },
++      ]);
++    } catch (err: unknown) {
++      const code = (err as { statusCode?: number }).statusCode;
++      if (code === 404) {
++        console.warn('[slotHoldsRepo] commitHold: hold already expired (non-fatal)', { holdId, bookingId });
++        return;
++      }
++      throw err;
++    }
++  }
++
++  /**
++   * Lists all hold docs for a given service+date partition.
++   * Cosmos TTL means expired docs are excluded automatically by the engine.
++   */
++  async listHolds(serviceId: string, date: string): Promise<SlotHoldDoc[]> {
++    const pk = `${serviceId}|${date}`;
++    const { resources } = await this.container.items
++      .query<SlotHoldDoc>({
++        query: 'SELECT * FROM c WHERE c.servicePartitionKey = @pk',
++        parameters: [{ name: '@pk', value: pk }],
++      })
++      .fetchAll();
++    return resources;
++  }
++}
++
++export const slotHoldsRepo = new SlotHoldsRepository();
+diff --git a/api/src/functions/bookings.ts b/api/src/functions/bookings.ts
+index 448bdea5..17b85ae9 100644
+--- a/api/src/functions/bookings.ts
++++ b/api/src/functions/bookings.ts
+@@ -1,527 +1,579 @@
+ import { randomUUID } from 'node:crypto';
+ import type { HttpHandler } from '@azure/functions';
+ import { app } from '@azure/functions';
+ import * as Sentry from '@sentry/node';
+ import { withRateLimit } from '../middleware/withRateLimit.js';
+ import { requireIntegrity } from '../middleware/requireIntegrity.js';
+ import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+ import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
+ import { RequestAddOnBodySchema, ApproveAddOnsBodySchema } from '../schemas/addon-approval.js';
+ import { bookingRepo, type BookingCreateCreditOptions } from '../cosmos/booking-repository.js';
+ import { createRazorpayOrder, verifyPaymentSignature } from '../services/razorpay.service.js';
+ import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+ import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
+ import { sendPriceApprovalPush } from '../services/fcm.service.js';
+ import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+ import { isSoftLaunchEnabled, isMarketingPaused, isServiceAreaGatingEnabled, isWalletCreditEnabled } from '../services/featureFlags.service.js';
+ import { customerCreditLedgerRepo } from '../cosmos/customer-credit-ledger-repository.js';
+ import { dispatcherService } from '../services/dispatcher.service.js';
+ import { posthog } from '../observability/posthog.js';
+ import { normalizeAddressText } from '../shared/address-text.js';
+ import { isLatLngInServiceArea } from '../services/service-area.service.js';
+ import { AYODHYA_SERVICE_AREA } from '../data/service-area-ayodhya.js';
++import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
++import { generateSlots } from '../shared/slot-utils.js';
+ 
+ function makeRazorpayReceipt(customerId: string): string {
+   return `bk_${Date.now().toString(36)}_${customerId.slice(0, 20)}`;
+ }
+ 
+ function hasRazorpayCredentials(): boolean {
+   const hasUsableValue = (value: string | undefined): boolean => {
+     const normalized = value?.trim().toLowerCase();
+     if (!normalized) return false;
+     if (normalized === 'placeholder') return false;
+     if (normalized.endsWith('_placeholder')) return false;
+     return true;
+   };
+   return hasUsableValue(process.env.RAZORPAY_KEY_ID) && hasUsableValue(process.env.RAZORPAY_KEY_SECRET);
+ }
+ 
+ function bookingMetadata(
+   customer: Parameters<CustomerHttpHandler>[2],
+   serviceName: string,
+ ) {
+   return {
+     ...(customer.displayName ? { customerName: customer.displayName } : {}),
+     ...(customer.phoneNumber ? { customerPhone: customer.phoneNumber } : {}),
+     ...(customer.email ? { customerEmail: customer.email } : {}),
+     serviceName,
+   };
+ }
+ 
+ /**
+  * E13-S01: Attempt to apply wallet credit for a booking.
+  *
+  * Returns the applied amount (0 if none, or on any non-fatal error).
+  * 412 from Cosmos (etag conflict = concurrent apply) is treated as zero-credit:
+  * the booking still succeeds, credit just wasn't applied this time.
+  *
+  * @param customerId     - customer's UID
+  * @param bookingId      - pre-generated or created booking ID (used in ledger entry)
+  * @param bookingAmount  - booking total in paise (credit capped at this)
+  * @param idempotencyKey - UUID from Idempotency-Key header (caller must validate present)
+  */
+ async function attemptCreditApplication(
+   customerId: string,
+   bookingId: string,
+   bookingAmount: number,
+   idempotencyKey: string,
+ ): Promise<number> {
+   try {
+     const { balanceInPaise } = await customerCreditLedgerRepo.getBalance(customerId);
+     if (balanceInPaise <= 0) return 0;
+ 
+     const amountToApply = Math.min(balanceInPaise, bookingAmount);
+     const result = await customerCreditLedgerRepo.applyCredit(
+       customerId,
+       bookingId,
+       amountToApply,
+       idempotencyKey,
+     );
+     return result.appliedAmountInPaise;
+   } catch (err: unknown) {
+     const code = (err as { code?: number }).code;
+     if (code === 412) {
+       // Optimistic concurrency conflict — concurrent write, safe to return 0
+       console.warn('[createBooking] applyCredit 412 conflict — proceeding without credit', {
+         customerId, bookingId,
+       });
+       return 0;
+     }
+     // Non-412 unexpected errors — log and continue (never block the booking)
+     Sentry.captureException(err);
+     console.error('[createBooking] applyCredit unexpected error — proceeding without credit', {
+       customerId, bookingId, err,
+     });
+     return 0;
+   }
+ }
+ 
+ const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+   if (!(await isSoftLaunchEnabled(customer.customerId))) {
+     return { status: 503, jsonBody: { code: 'SERVICE_UNAVAILABLE', message: 'Launch coming soon' } };
+   }
+   if (await isMarketingPaused(customer.customerId)) {
+     return { status: 503, jsonBody: { code: 'TEMPORARILY_UNAVAILABLE', message: 'We are pausing new bookings briefly' } };
+   }
+ 
+   const body = await req.json().catch(() => null);
+   const parsed = CreateBookingRequestSchema.safeParse(body);
+   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+ 
+   // E13-S01: Validate Idempotency-Key is present when applyCredit=true
+   const idempotencyKey = req.headers.get('idempotency-key') ?? '';
+   if (parsed.data.applyCredit) {
+     const creditEnabled = await isWalletCreditEnabled(customer.customerId);
+     if (creditEnabled && !idempotencyKey) {
+       return { status: 422, jsonBody: { code: 'IDEMPOTENCY_KEY_REQUIRED', message: 'Idempotency-Key header is required when applyCredit=true' } };
+     }
+   }
+ 
+   // Service-area polygon gating — E16-S01 / ADR-0020 / Threat-model T-B1
+   // Zod already guarantees lat ∈ [-90,90] and lng ∈ [-180,180]; this is the
+   // geographic business rule enforcing the Ayodhya pilot boundary.
+   const { lat, lng } = parsed.data.addressLatLng;
+   const insideServiceArea = isLatLngInServiceArea(lat, lng, AYODHYA_SERVICE_AREA);
+   const gatingEnabled = await isServiceAreaGatingEnabled(customer.customerId);
+   // Structured log — always emitted (for observability in both warn-only and fail modes).
+   // Alert annotation: >5 rejections/min/customer is a recon signal (T-B1).
+   const gatingMode = gatingEnabled ? 'fail' : 'warn-only';
+   console.info('service_area_check', {
+     customerId: customer.customerId,
+     lat,
+     lng,
+     inside: insideServiceArea,
+     mode: gatingMode,
+   });
+   if (!insideServiceArea && gatingEnabled) {
+     return {
+       status: 400,
+       jsonBody: {
+         error: 'SERVICE_NOT_AVAILABLE_AT_LOCATION',
+         message: 'We currently only serve the Ayodhya region. We hope to expand soon.',
+         suggestedAction: 'join_waitlist',
+       },
+     };
+   }
+   // When flag is off (warn-only), an out-of-area coordinate is logged above but allowed through.
+ 
+   const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
+   if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+ 
++  // E16-S02: Validate slotWindow against server-generated windows for this service + date.
++  // Rejects fabricated windows that don't align with the service's durationMinutes / workStart-workEnd.
++  const validWindows = generateSlots(service, parsed.data.slotDate);
++  if (!validWindows.includes(parsed.data.slotWindow)) {
++    return { status: 422, jsonBody: { code: 'INVALID_SLOT_WINDOW', message: 'The requested time slot does not match this service\'s schedule.' } };
++  }
++
++  // E16-S02: Slot-conflict locking — attempt to hold the slot before writing the booking.
++  // createHold returns 'CONFLICT' if another hold or booking already occupies this window.
++  const holdResult = await slotHoldsRepo.createHold(
++    parsed.data.serviceId,
++    parsed.data.slotDate,
++    parsed.data.slotWindow,
++    customer.customerId,
++  );
++  if (holdResult === 'CONFLICT') {
++    return {
++      status: 409,
++      jsonBody: { code: 'SLOT_UNAVAILABLE', message: 'This time slot is no longer available.' },
++    };
++  }
++  const holdId = holdResult.id;
++  const holdPk = holdResult.servicePartitionKey;
++
+   if (parsed.data.paymentMethod === 'CASH_ON_SERVICE') {
+     const cashOrderId = `cash_${randomUUID()}`;
+     const booking = await bookingRepo.createPending(
+       parsed.data,
+       customer.customerId,
+       cashOrderId,
+       service.basePrice,
+       bookingMetadata(customer, service.name),
+     );
+     const paid = await bookingRepo.markPaid(booking.id, 'cash_on_service_pending');
+     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 
++    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
++    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++      Sentry.captureException(err);
++      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++    });
++
+     // E13-S01: Apply wallet credit for cash bookings
+     let appliedCreditAmount = 0;
+     if (parsed.data.applyCredit && idempotencyKey) {
+       const creditEnabled = await isWalletCreditEnabled(customer.customerId);
+       if (creditEnabled) {
+         appliedCreditAmount = await attemptCreditApplication(
+           customer.customerId,
+           booking.id,
+           service.basePrice,
+           idempotencyKey,
+         );
+       }
+     }
+ 
+     try {
+       posthog.capture({
+         distinctId: customer.customerId,
+         event: 'booking-created',
+         properties: {
+           bookingId: booking.id,
+           serviceId: parsed.data.serviceId,
+           paymentMethod: 'CASH_ON_SERVICE',
+           appliedCreditAmount,
+         },
+       });
+     } catch { /* never break the main path */ }
+     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+       Sentry.captureException(err);
+       console.error('[createBooking] cash-on-service dispatch failed', { bookingId: booking.id, err });
+     });
+     return {
+       status: 201,
+       jsonBody: {
+         bookingId: booking.id,
+         razorpayOrderId: cashOrderId,
+         amount: service.basePrice,
+         requiresPayment: false,
+         paymentMethod: 'CASH_ON_SERVICE',
+         appliedCreditAmount,
+       },
+     };
+   }
+ 
+   if (!hasRazorpayCredentials()) {
+     const manualOrderId = `manual_${randomUUID()}`;
+     const manualRequest = { ...parsed.data, paymentMethod: 'CASH_ON_SERVICE' as const };
+     const booking = await bookingRepo.createPending(
+       manualRequest,
+       customer.customerId,
+       manualOrderId,
+       service.basePrice,
+       bookingMetadata(customer, service.name),
+     );
+     const paid = await bookingRepo.markPaid(booking.id, 'manual_payment_not_configured');
+     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
++
++    // E16-S02: Commit hold (non-fatal)
++    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++      Sentry.captureException(err);
++      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++    });
++
+     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+       Sentry.captureException(err);
+       console.error('[createBooking] manual-payment dispatch failed', { bookingId: booking.id, err });
+     });
+     return {
+       status: 201,
+       jsonBody: {
+         bookingId: booking.id,
+         razorpayOrderId: manualOrderId,
+         amount: service.basePrice,
+         requiresPayment: false,
+         paymentMethod: 'CASH_ON_SERVICE',
+         appliedCreditAmount: 0,
+       },
+     };
+   }
+ 
+   // Pre-generate booking ID so we can embed it in Razorpay notes for the fast path.
+   // The webhook can then do a cheap point-read (getById) instead of a cross-partition scan.
+   const preGeneratedBookingId = randomUUID();
+ 
+   // E13-S01 (P1-6): Determine intended credit amount WITHOUT writing to the ledger yet.
+   // The actual ledger CREDIT_APPLIED entry is written in the Razorpay webhook (payment.captured),
+   // NOT here. This prevents the "debit-before-payment" bug where an unpaid/abandoned booking
+   // permanently consumes the customer's wallet credit.
+   //
+   // For the fully-credit-paid path (P1-5): if credit covers 100% of the booking, we skip
+   // Razorpay entirely and mark the booking PAID directly — no payment intent is needed.
+   let pendingCreditAmount = 0;
+   const creditEnabled = parsed.data.applyCredit && idempotencyKey
+     ? await isWalletCreditEnabled(customer.customerId)
+     : false;
+ 
+   if (creditEnabled) {
+     // Peek at current balance; we don't write the ledger entry here.
+     const { balanceInPaise } = await customerCreditLedgerRepo.getBalance(customer.customerId);
+     pendingCreditAmount = Math.min(balanceInPaise, service.basePrice);
+   }
+ 
+   const payableAmount = service.basePrice - pendingCreditAmount;
+ 
+   // P1-5: Credit covers 100% — skip Razorpay, mark PAID directly
+   if (payableAmount <= 0 && pendingCreditAmount > 0) {
+     const fullCreditOrderId = `credit_${randomUUID()}`;
+     const fullCreditCreditOptions: BookingCreateCreditOptions = {
+       pendingCreditAmountInPaise: pendingCreditAmount,
+       pendingCreditIdempotencyKey: idempotencyKey,
+     };
+     const booking = await bookingRepo.createPending(
+       parsed.data,
+       customer.customerId,
+       fullCreditOrderId,
+       service.basePrice,
+       bookingMetadata(customer, service.name),
+       preGeneratedBookingId,
+       fullCreditCreditOptions,
+     );
+ 
+     // Apply credit synchronously for the fully-credit-paid path (no payment to wait for)
+     const appliedCreditAmount = await attemptCreditApplication(
+       customer.customerId,
+       booking.id,
+       pendingCreditAmount,
+       idempotencyKey,
+     );
+ 
+     // P1-1: Verify the credit was actually applied before marking PAID.
+     //
+     // attemptCreditApplication returns 0 (or a partial amount) when:
+     //   - A 412 ETag conflict (race with another concurrent apply) exhausted all retries.
+     //   - An unexpected Cosmos error was swallowed by the non-blocking path.
+     //
+     // If we mark PAID without the credit being applied, the customer gets a free
+     // or underpaid booking (the Razorpay order was skipped entirely).
+     //
+     // Safe fallback: reject with 409 so the customer retries. We cannot safely
+     // fall back to Razorpay here because the booking doc was already created and
+     // the Razorpay order amount would need to be recomputed — doing so in a partially
+     // applied state risks double-charging or missed credit.
+     if (appliedCreditAmount < pendingCreditAmount) {
+       console.warn('[createBooking] full-credit path: applied amount < expected; rejecting with 409', {
+         customerId: customer.customerId,
+         bookingId: booking.id,
+         expected: pendingCreditAmount,
+         applied: appliedCreditAmount,
+       });
+       Sentry.captureException(
+         new Error(`CREDIT_RACE: applied ${appliedCreditAmount} < expected ${pendingCreditAmount}`),
+       );
+       // Booking is in PENDING_PAYMENT state and no Razorpay order was created — safe to
+       // leave it; it will expire naturally (stale-booking cleanup handles it).
+       return {
+         status: 409,
+         jsonBody: {
+           code: 'CREDIT_RACE',
+           message: 'Credit application conflict — please retry. Your wallet balance is unchanged.',
+         },
+       };
+     }
+ 
+     // Mark PAID immediately (no Razorpay payment involved)
+     const paid = await bookingRepo.markPaid(booking.id, 'credit_full_payment');
+     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 
++    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
++    slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++      Sentry.captureException(err);
++      console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++    });
++
+     try {
+       posthog.capture({
+         distinctId: customer.customerId,
+         event: 'booking-created',
+         properties: {
+           bookingId: booking.id,
+           serviceId: parsed.data.serviceId,
+           paymentMethod: 'CREDIT_FULL',
+           appliedCreditAmount,
+         },
+       });
+     } catch { /* never break the main path */ }
+ 
+     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+       Sentry.captureException(err);
+       console.error('[createBooking] credit-full dispatch failed', { bookingId: booking.id, err });
+     });
+ 
+     return {
+       status: 201,
+       jsonBody: {
+         bookingId: booking.id,
+         razorpayOrderId: fullCreditOrderId,
+         amount: service.basePrice,
+         requiresPayment: false,
+         paymentMethod: 'CREDIT_FULL',
+         appliedCreditAmount,
+       },
+     };
+   }
+ 
+   // Partial or no credit — create Razorpay order for the payable portion.
+   //
+   // P1-2: Reserve the credit BEFORE creating the discounted Razorpay order.
+   //
+   // Problem without reservation: `pendingCreditAmount` is only a balance peek. If:
+   //   (a) The same idempotency key is replayed (client retry), a second discounted
+   //       Razorpay order is created, potentially granting the discount twice.
+   //   (b) The wallet balance is spent elsewhere between here and payment.captured,
+   //       the webhook tries to apply a credit that no longer exists — the Razorpay
+   //       payment collected less than basePrice and the booking is undercollected.
+   //
+   // Fix: write a RESERVED idempotency doc with IfNoneMatch: * before creating the
+   // Razorpay order. This guarantees:
+   //   - Idempotency-key replay on Razorpay order creation returns 'already_reserved'
+   //     (same booking) → skip Razorpay creation and return the same pending credit amount.
+   //   - The wallet balance is not double-spent (the reservation does not debit the wallet;
+   //     the actual debit in applyCredit will see the RESERVED status and proceed to debit).
+   //   - On abandonment (no payment.captured within TTL): the reservation auto-expires, leaving
+   //     the wallet balance intact for the next booking.
+   if (pendingCreditAmount > 0) {
+     try {
+       const reserveResult = await customerCreditLedgerRepo.reserveCredit(
+         customer.customerId,
+         preGeneratedBookingId,
+         pendingCreditAmount,
+         idempotencyKey,
+       );
+       if (reserveResult === 'already_reserved') {
+         // Idempotent replay: same key, same booking — the Razorpay order was already created
+         // in a prior attempt (but the response may not have reached the client). Return the
+         // same pending credit info so the client can resume payment.
+         console.info('[createBooking] credit reservation already exists — idempotent replay', {
+           customerId: customer.customerId,
+           bookingId: preGeneratedBookingId,
+         });
+         // Fall through to create the Razorpay order (or it may already exist; Razorpay is
+         // idempotent on order ID because the receipt is unique per attempt — acceptable).
+       }
+     } catch (reserveErr: unknown) {
+       Sentry.captureException(reserveErr);
+       console.error('[createBooking] credit reservation failed — falling back to no-credit Razorpay', {
+         customerId: customer.customerId,
+         err: reserveErr,
+       });
+       // Non-fatal: fall back to full-price Razorpay (safer than blocking the booking).
+       // pendingCreditAmount is reset to 0 so no discount is applied.
+       // The unreserved credit stays in the wallet for the next booking.
+       // NOTE: if this was a 409 IDEMPOTENCY_KEY_ALREADY_USED for a different booking,
+       // that is an abuse signal — Sentry captures it above.
+       // For non-409 errors (Cosmos failures, timeouts, etc.), the reservation didn't
+       // happen — credit stays intact in the wallet for the next booking attempt.
+       // We fall through to create a full-price Razorpay order (no discount) which is safe.
+     }
+   }
+ 
+   let order: Awaited<ReturnType<typeof createRazorpayOrder>>;
+   try {
+     order = await createRazorpayOrder({
+       amount: payableAmount > 0 ? payableAmount : service.basePrice,
+       currency: 'INR',
+       receipt: makeRazorpayReceipt(customer.customerId),
+       notes: { bookingId: preGeneratedBookingId },
+     });
+   } catch (err) {
+     Sentry.captureException(err);
+     console.error('[createBooking] Razorpay order creation failed', {
+       customerId: customer.customerId,
+       serviceId: parsed.data.serviceId,
+       err,
+     });
+     return {
+       status: 502,
+       jsonBody: {
+         code: 'PAYMENT_ORDER_FAILED',
+         message: 'Could not start payment. Please try again.',
+       },
+     };
+   }
+ 
+   // P1-6: Store the intended credit amount on the booking doc.
+   // The webhook (payment.captured) will call applyCredit to debit the ledger.
+   // If the customer abandons payment, no credit is debited (it stays intact).
+   const razorpayCreditOptions: BookingCreateCreditOptions | undefined = pendingCreditAmount > 0
+     ? { pendingCreditAmountInPaise: pendingCreditAmount, pendingCreditIdempotencyKey: idempotencyKey }
+     : undefined;
+ 
+   const booking = await bookingRepo.createPending(
+     parsed.data,
+     customer.customerId,
+     order.id,
+     service.basePrice,
+     bookingMetadata(customer, service.name),
+     preGeneratedBookingId,
+     razorpayCreditOptions,
+   );
++
++  // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
++  slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
++    Sentry.captureException(err);
++    console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
++  });
++
+   try {
+     posthog.capture({
+       distinctId: customer.customerId,
+       event: 'booking-created',
+       properties: {
+         bookingId: booking.id,
+         serviceId: parsed.data.serviceId,
+         paymentMethod: 'RAZORPAY',
+         // appliedCreditAmount reported as 0 here — actual debit happens post-payment
+         appliedCreditAmount: 0,
+         pendingCreditAmount,
+       },
+     });
+   } catch { /* never break the main path */ }
+   return {
+     status: 201,
+     jsonBody: {
+       bookingId: booking.id,
+       razorpayOrderId: order.id,
+       amount: order.amount,
+       requiresPayment: true,
+       paymentMethod: 'RAZORPAY',
+       // Report pending credit to client so the UI can show "₹X will be applied after payment"
+       appliedCreditAmount: 0,
+       pendingCreditAmount,
+     },
+   };
+ };
+ 
+ const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+   const id = (req as unknown as { params: { id: string } }).params.id;
+   const body = await req.json().catch(() => null);
+   const parsed = ConfirmBookingRequestSchema.safeParse(body);
+   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+ 
+   const booking = await bookingRepo.getById(id);
+   if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+   if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+ 
+   if (!verifyPaymentSignature({
+     razorpayOrderId: parsed.data.razorpayOrderId,
+     razorpayPaymentId: parsed.data.razorpayPaymentId,
+     razorpaySignature: parsed.data.razorpaySignature,
+   })) return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+ 
+   const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
+   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
+ 
+   // Only audit when this call actually performed the transition. If status is PAID the webhook
+   // already processed the booking — this is an idempotent confirm, not a new event.
+   if (confirmed.status === 'SEARCHING') {
+     const _ts = new Date().toISOString();
+     void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+   }
+ 
+   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
+ };
+ 
+ export const createBookingHandler: HttpHandler = requireCustomer(createHandler);
+ export const confirmBookingHandler: HttpHandler = requireCustomer(confirmHandler);
+ 
+ const getBookingInner: CustomerHttpHandler = async (req, _ctx, customer) => {
+   const id = (req as unknown as { params: { id: string } }).params.id;
+   const booking = await bookingRepo.getById(id);
+   if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+   if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+   return {
+     status: 200,
+     jsonBody: {
+       bookingId: booking.id, status: booking.status, amount: booking.amount,
+       finalAmount: booking.finalAmount ?? null,
+       pendingAddOns: booking.pendingAddOns ?? [],
+       approvedAddOns: booking.approvedAddOns ?? [],
+     },
+   };
+ };
+ export const getBookingHandler: HttpHandler = requireCustomer(getBookingInner);
+ 
+ const getMyBookingsInner: CustomerHttpHandler = async (_req, ctx, customer) => {
+   try {
+diff --git a/api/src/functions/services-availability.ts b/api/src/functions/services-availability.ts
+new file mode 100644
+index 00000000..efc9eb9f
+--- /dev/null
++++ b/api/src/functions/services-availability.ts
+@@ -0,0 +1,88 @@
++import { app } from '@azure/functions';
++import { z } from 'zod';
++import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
++import { catalogueRepo } from '../cosmos/catalogue-repository.js';
++import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
++import { bookingRepo } from '../cosmos/booking-repository.js';
++import { generateSlots } from '../shared/slot-utils.js';
++
++// IST offset from UTC in minutes (UTC+5:30)
++const IST_OFFSET_MINUTES = 5 * 60 + 30;
++
++function todayIst(): string {
++  const now = new Date();
++  const istMs = now.getTime() + IST_OFFSET_MINUTES * 60_000;
++  return new Date(istMs).toISOString().slice(0, 10);
++}
++
++function addDays(yyyymmdd: string, days: number): string {
++  const d = new Date(`${yyyymmdd}T00:00:00Z`);
++  d.setUTCDate(d.getUTCDate() + days);
++  return d.toISOString().slice(0, 10);
++}
++
++const DateQuerySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((s) => {
++  const d = new Date(`${s}T00:00:00Z`);
++  return !isNaN(d.getTime());
++}, { message: 'Invalid calendar date' });
++
++export const availabilityHandler: CustomerHttpHandler = async (req, _ctx, _customer) => {
++  const { id: serviceId } = (req as unknown as { params: { id: string } }).params;
++  const dateParam = (req as unknown as { query: { get(k: string): string | null } }).query.get('date');
++
++  // Validate date param format
++  const dateParsed = DateQuerySchema.safeParse(dateParam);
++  if (!dateParsed.success) {
++    return { status: 422, jsonBody: { code: 'INVALID_DATE_RANGE', message: 'date must be YYYY-MM-DD' } };
++  }
++  const date = dateParsed.data;
++
++  // Validate range: today IST ≤ date ≤ today+7 IST
++  const today = todayIst();
++  const max = addDays(today, 7);
++  if (date < today || date > max) {
++    return {
++      status: 422,
++      jsonBody: {
++        code: 'INVALID_DATE_RANGE',
++        message: `date must be between ${today} and ${max} (IST)`,
++      },
++    };
++  }
++
++  // Look up service
++  const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
++  if (!service || !service.isActive) {
++    return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
++  }
++
++  // Generate server-side slot windows
++  const allWindows = generateSlots(service, date);
++
++  // Load held + hard-booked windows in parallel
++  const [holds, bookedWindows] = await Promise.all([
++    slotHoldsRepo.listHolds(serviceId, date),
++    bookingRepo.getBookedWindowsByServiceDate(serviceId, date),
++  ]);
++
++  const unavailable = new Set<string>([
++    ...holds.map((h) => h.window),
++    ...bookedWindows,
++  ]);
++
++  return {
++    status: 200,
++    jsonBody: {
++      serviceId,
++      date,
++      slotGranularityMinutes: service.durationMinutes,
++      slots: allWindows.map((window) => ({ window, available: !unavailable.has(window) })),
++    },
++  };
++};
++
++app.http('servicesAvailability', {
++  methods: ['GET'],
++  route: 'v1/services/{id}/availability',
++  handler: requireCustomer(availabilityHandler),
++});
+diff --git a/api/src/schemas/service.ts b/api/src/schemas/service.ts
+index 41f7cbbe..2e2e6cab 100644
+--- a/api/src/schemas/service.ts
++++ b/api/src/schemas/service.ts
+@@ -1,82 +1,101 @@
+ import { z } from 'zod';
+ import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+ 
+ extendZodWithOpenApi(z);
+ 
+ const AddOnSchema = z.object({
+   id: z.string().min(1),
+   name: z.string().min(1),
+   price: z.number().int().nonnegative(),
+   triggerCondition: z.string().min(1),
+ });
+ 
+ const PhotoStageSchema = z.object({
+   id: z.string().min(1),
+   label: z.string().min(1),
+   required: z.boolean(),
+ });
+ 
+ const FaqItemSchema = z.object({
+   question: z.string().min(1),
+   answer: z.string().min(1),
+ });
+ 
+ export const ServiceSchema = z
+   .object({
+     id: z.string().min(1).regex(/^[a-z0-9-]+$/).openapi({ example: 'ac-deep-clean' }),
+     categoryId: z.string().min(1),
+     name: z.string().min(1).max(100),
+     shortDescription: z.string().min(1).max(200),
+     heroImageUrl: z.string().url(),
+     basePrice: z.number().int().nonnegative().openapi({ description: 'Price in paise (₹599 = 59900)' }),
+     commissionBps: z.number().int().min(1500).max(3500).openapi({ description: 'Commission in basis points (2250 = 22.5%)' }),
+     durationMinutes: z.number().int().positive(),
+     includes: z.array(z.string().min(1)),
+     faq: z.array(FaqItemSchema),
+     addOns: z.array(AddOnSchema),
+     photoStages: z.array(PhotoStageSchema),
+     isActive: z.boolean(),
+     updatedBy: z.string().min(1),
+     createdAt: z.string().datetime(),
+     updatedAt: z.string().datetime(),
++    // E16-S02: optional scheduling window; defaults applied server-side (08:00 / 20:00)
++    workStart: z.string().regex(/^\d{2}:\d{2}$/).optional(),
++    workEnd: z.string().regex(/^\d{2}:\d{2}$/).optional(),
+   })
+   .strict();
+ 
+ export const ServiceCardSchema = ServiceSchema.pick({
+   id: true,
+   categoryId: true,
+   name: true,
+   shortDescription: true,
+   heroImageUrl: true,
+   basePrice: true,
+   durationMinutes: true,
+ }).strip();
+ 
+ export const ServiceDetailSchema = ServiceSchema.omit({
+   commissionBps: true,
+   updatedBy: true,
+   createdAt: true,
+   updatedAt: true,
+ }).strip();
+ 
+ export const CreateServiceBodySchema = ServiceSchema.omit({
+   isActive: true,
+   updatedBy: true,
+   createdAt: true,
+   updatedAt: true,
+ });
+ 
+ export const UpdateServiceBodySchema = ServiceSchema.omit({
+   id: true,
+   categoryId: true,
+   isActive: true,
+   updatedBy: true,
+   createdAt: true,
+   updatedAt: true,
+ });
+ 
+ export type Service = z.infer<typeof ServiceSchema>;
+ export type ServiceCard = z.infer<typeof ServiceCardSchema>;
+ export type ServiceDetail = z.infer<typeof ServiceDetailSchema>;
+ export type CreateServiceBody = z.infer<typeof CreateServiceBodySchema>;
+ export type UpdateServiceBody = z.infer<typeof UpdateServiceBodySchema>;
++
++// E16-S02: Slot availability response schemas
++export const SlotWindowSchema = z.object({
++  window: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
++  available: z.boolean(),
++});
++
++export const AvailabilityResponseSchema = z.object({
++  serviceId: z.string(),
++  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
++  slotGranularityMinutes: z.number().int().positive(),
++  slots: z.array(SlotWindowSchema),
++});
++
++export type SlotWindow = z.infer<typeof SlotWindowSchema>;
++export type AvailabilityResponse = z.infer<typeof AvailabilityResponseSchema>;
+diff --git a/api/src/shared/slot-utils.ts b/api/src/shared/slot-utils.ts
+new file mode 100644
+index 00000000..1c70ced7
+--- /dev/null
++++ b/api/src/shared/slot-utils.ts
+@@ -0,0 +1,30 @@
++import type { Service } from '../schemas/service.js';
++
++function timeToMinutes(hhmm: string): number {
++  const [h, m] = hhmm.split(':').map(Number);
++  return (h ?? 0) * 60 + (m ?? 0);
++}
++
++function minutesToTime(minutes: number): string {
++  const h = Math.floor(minutes / 60);
++  const m = minutes % 60;
++  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
++}
++
++/**
++ * Generates non-overlapping slot windows for a service on a given date.
++ * Returns strings like "08:00-09:00". Does not filter past times — caller
++ * is responsible for date range validation.
++ */
++export function generateSlots(service: Service, _date: string): string[] {
++  const startMin = timeToMinutes(service.workStart ?? '08:00');
++  const endMin = timeToMinutes(service.workEnd ?? '20:00');
++  const duration = service.durationMinutes;
++  const slots: string[] = [];
++
++  for (let cur = startMin; cur + duration <= endMin; cur += duration) {
++    slots.push(`${minutesToTime(cur)}-${minutesToTime(cur + duration)}`);
++  }
++
++  return slots;
++}
+warning: unable to access 'C:\Users\alokt/.config/git/ignore': Permission denied
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/functions/bookings.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 540' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 694ms:
+   1: import { randomUUID } from 'node:crypto';
+   2: import type { HttpHandler } from '@azure/functions';
+   3: import { app } from '@azure/functions';
+   4: import * as Sentry from '@sentry/node';
+   5: import { withRateLimit } from '../middleware/withRateLimit.js';
+   6: import { requireIntegrity } from '../middleware/requireIntegrity.js';
+   7: import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+   8: import { CreateBookingRequestSchema, ConfirmBookingRequestSchema } from '../schemas/booking.js';
+   9: import { RequestAddOnBodySchema, ApproveAddOnsBodySchema } from '../schemas/addon-approval.js';
+  10: import { bookingRepo, type BookingCreateCreditOptions } from '../cosmos/booking-repository.js';
+  11: import { createRazorpayOrder, verifyPaymentSignature } from '../services/razorpay.service.js';
+  12: import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+  13: import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
+  14: import { sendPriceApprovalPush } from '../services/fcm.service.js';
+  15: import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+  16: import { isSoftLaunchEnabled, isMarketingPaused, isServiceAreaGatingEnabled, isWalletCreditEnabled } from '../services/featureFlags.service.js';
+  17: import { customerCreditLedgerRepo } from '../cosmos/customer-credit-ledger-repository.js';
+  18: import { dispatcherService } from '../services/dispatcher.service.js';
+  19: import { posthog } from '../observability/posthog.js';
+  20: import { normalizeAddressText } from '../shared/address-text.js';
+  21: import { isLatLngInServiceArea } from '../services/service-area.service.js';
+  22: import { AYODHYA_SERVICE_AREA } from '../data/service-area-ayodhya.js';
+  23: import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
+  24: import { generateSlots } from '../shared/slot-utils.js';
+  25: 
+  26: function makeRazorpayReceipt(customerId: string): string {
+  27:   return `bk_${Date.now().toString(36)}_${customerId.slice(0, 20)}`;
+  28: }
+  29: 
+  30: function hasRazorpayCredentials(): boolean {
+  31:   const hasUsableValue = (value: string | undefined): boolean => {
+  32:     const normalized = value?.trim().toLowerCase();
+  33:     if (!normalized) return false;
+  34:     if (normalized === 'placeholder') return false;
+  35:     if (normalized.endsWith('_placeholder')) return false;
+  36:     return true;
+  37:   };
+  38:   return hasUsableValue(process.env.RAZORPAY_KEY_ID) && hasUsableValue(process.env.RAZORPAY_KEY_SECRET);
+  39: }
+  40: 
+  41: function bookingMetadata(
+  42:   customer: Parameters<CustomerHttpHandler>[2],
+  43:   serviceName: string,
+  44: ) {
+  45:   return {
+  46:     ...(customer.displayName ? { customerName: customer.displayName } : {}),
+  47:     ...(customer.phoneNumber ? { customerPhone: customer.phoneNumber } : {}),
+  48:     ...(customer.email ? { customerEmail: customer.email } : {}),
+  49:     serviceName,
+  50:   };
+  51: }
+  52: 
+  53: /**
+  54:  * E13-S01: Attempt to apply wallet credit for a booking.
+  55:  *
+  56:  * Returns the applied amount (0 if none, or on any non-fatal error).
+  57:  * 412 from Cosmos (etag conflict = concurrent apply) is treated as zero-credit:
+  58:  * the booking still succeeds, credit just wasn't applied this time.
+  59:  *
+  60:  * @param customerId     - customer's UID
+  61:  * @param bookingId      - pre-generated or created booking ID (used in ledger entry)
+  62:  * @param bookingAmount  - booking total in paise (credit capped at this)
+  63:  * @param idempotencyKey - UUID from Idempotency-Key header (caller must validate present)
+  64:  */
+  65: async function attemptCreditApplication(
+  66:   customerId: string,
+  67:   bookingId: string,
+  68:   bookingAmount: number,
+  69:   idempotencyKey: string,
+  70: ): Promise<number> {
+  71:   try {
+  72:     const { balanceInPaise } = await customerCreditLedgerRepo.getBalance(customerId);
+  73:     if (balanceInPaise <= 0) return 0;
+  74: 
+  75:     const amountToApply = Math.min(balanceInPaise, bookingAmount);
+  76:     const result = await customerCreditLedgerRepo.applyCredit(
+  77:       customerId,
+  78:       bookingId,
+  79:       amountToApply,
+  80:       idempotencyKey,
+  81:     );
+  82:     return result.appliedAmountInPaise;
+  83:   } catch (err: unknown) {
+  84:     const code = (err as { code?: number }).code;
+  85:     if (code === 412) {
+  86:       // Optimistic concurrency conflict â€” concurrent write, safe to return 0
+  87:       console.warn('[createBooking] applyCredit 412 conflict â€” proceeding without credit', {
+  88:         customerId, bookingId,
+  89:       });
+  90:       return 0;
+  91:     }
+  92:     // Non-412 unexpected errors â€” log and continue (never block the booking)
+  93:     Sentry.captureException(err);
+  94:     console.error('[createBooking] applyCredit unexpected error â€” proceeding without credit', {
+  95:       customerId, bookingId, err,
+  96:     });
+  97:     return 0;
+  98:   }
+  99: }
+ 100: 
+ 101: const createHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+ 102:   if (!(await isSoftLaunchEnabled(customer.customerId))) {
+ 103:     return { status: 503, jsonBody: { code: 'SERVICE_UNAVAILABLE', message: 'Launch coming soon' } };
+ 104:   }
+ 105:   if (await isMarketingPaused(customer.customerId)) {
+ 106:     return { status: 503, jsonBody: { code: 'TEMPORARILY_UNAVAILABLE', message: 'We are pausing new bookings briefly' } };
+ 107:   }
+ 108: 
+ 109:   const body = await req.json().catch(() => null);
+ 110:   const parsed = CreateBookingRequestSchema.safeParse(body);
+ 111:   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+ 112: 
+ 113:   // E13-S01: Validate Idempotency-Key is present when applyCredit=true
+ 114:   const idempotencyKey = req.headers.get('idempotency-key') ?? '';
+ 115:   if (parsed.data.applyCredit) {
+ 116:     const creditEnabled = await isWalletCreditEnabled(customer.customerId);
+ 117:     if (creditEnabled && !idempotencyKey) {
+ 118:       return { status: 422, jsonBody: { code: 'IDEMPOTENCY_KEY_REQUIRED', message: 'Idempotency-Key header is required when applyCredit=true' } };
+ 119:     }
+ 120:   }
+ 121: 
+ 122:   // Service-area polygon gating â€” E16-S01 / ADR-0020 / Threat-model T-B1
+ 123:   // Zod already guarantees lat âˆˆ [-90,90] and lng âˆˆ [-180,180]; this is the
+ 124:   // geographic business rule enforcing the Ayodhya pilot boundary.
+ 125:   const { lat, lng } = parsed.data.addressLatLng;
+ 126:   const insideServiceArea = isLatLngInServiceArea(lat, lng, AYODHYA_SERVICE_AREA);
+ 127:   const gatingEnabled = await isServiceAreaGatingEnabled(customer.customerId);
+ 128:   // Structured log â€” always emitted (for observability in both warn-only and fail modes).
+ 129:   // Alert annotation: >5 rejections/min/customer is a recon signal (T-B1).
+ 130:   const gatingMode = gatingEnabled ? 'fail' : 'warn-only';
+ 131:   console.info('service_area_check', {
+ 132:     customerId: customer.customerId,
+ 133:     lat,
+ 134:     lng,
+ 135:     inside: insideServiceArea,
+ 136:     mode: gatingMode,
+ 137:   });
+ 138:   if (!insideServiceArea && gatingEnabled) {
+ 139:     return {
+ 140:       status: 400,
+ 141:       jsonBody: {
+ 142:         error: 'SERVICE_NOT_AVAILABLE_AT_LOCATION',
+ 143:         message: 'We currently only serve the Ayodhya region. We hope to expand soon.',
+ 144:         suggestedAction: 'join_waitlist',
+ 145:       },
+ 146:     };
+ 147:   }
+ 148:   // When flag is off (warn-only), an out-of-area coordinate is logged above but allowed through.
+ 149: 
+ 150:   const service = await catalogueRepo.getServiceByIdCrossPartition(parsed.data.serviceId);
+ 151:   if (!service || !service.isActive) return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+ 152: 
+ 153:   // E16-S02: Validate slotWindow against server-generated windows for this service + date.
+ 154:   // Rejects fabricated windows that don't align with the service's durationMinutes / workStart-workEnd.
+ 155:   const validWindows = generateSlots(service, parsed.data.slotDate);
+ 156:   if (!validWindows.includes(parsed.data.slotWindow)) {
+ 157:     return { status: 422, jsonBody: { code: 'INVALID_SLOT_WINDOW', message: 'The requested time slot does not match this service\'s schedule.' } };
+ 158:   }
+ 159: 
+ 160:   // E16-S02: Slot-conflict locking â€” attempt to hold the slot before writing the booking.
+ 161:   // createHold returns 'CONFLICT' if another hold or booking already occupies this window.
+ 162:   const holdResult = await slotHoldsRepo.createHold(
+ 163:     parsed.data.serviceId,
+ 164:     parsed.data.slotDate,
+ 165:     parsed.data.slotWindow,
+ 166:     customer.customerId,
+ 167:   );
+ 168:   if (holdResult === 'CONFLICT') {
+ 169:     return {
+ 170:       status: 409,
+ 171:       jsonBody: { code: 'SLOT_UNAVAILABLE', message: 'This time slot is no longer available.' },
+ 172:     };
+ 173:   }
+ 174:   const holdId = holdResult.id;
+ 175:   const holdPk = holdResult.servicePartitionKey;
+ 176: 
+ 177:   if (parsed.data.paymentMethod === 'CASH_ON_SERVICE') {
+ 178:     const cashOrderId = `cash_${randomUUID()}`;
+ 179:     const booking = await bookingRepo.createPending(
+ 180:       parsed.data,
+ 181:       customer.customerId,
+ 182:       cashOrderId,
+ 183:       service.basePrice,
+ 184:       bookingMetadata(customer, service.name),
+ 185:     );
+ 186:     const paid = await bookingRepo.markPaid(booking.id, 'cash_on_service_pending');
+ 187:     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 188: 
+ 189:     // E16-S02: Commit hold â€” converts 30 s soft hold to permanent slot record.
+ 190:     slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+ 191:       Sentry.captureException(err);
+ 192:       console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+ 193:     });
+ 194: 
+ 195:     // E13-S01: Apply wallet credit for cash bookings
+ 196:     let appliedCreditAmount = 0;
+ 197:     if (parsed.data.applyCredit && idempotencyKey) {
+ 198:       const creditEnabled = await isWalletCreditEnabled(customer.customerId);
+ 199:       if (creditEnabled) {
+ 200:         appliedCreditAmount = await attemptCreditApplication(
+ 201:           customer.customerId,
+ 202:           booking.id,
+ 203:           service.basePrice,
+ 204:           idempotencyKey,
+ 205:         );
+ 206:       }
+ 207:     }
+ 208: 
+ 209:     try {
+ 210:       posthog.capture({
+ 211:         distinctId: customer.customerId,
+ 212:         event: 'booking-created',
+ 213:         properties: {
+ 214:           bookingId: booking.id,
+ 215:           serviceId: parsed.data.serviceId,
+ 216:           paymentMethod: 'CASH_ON_SERVICE',
+ 217:           appliedCreditAmount,
+ 218:         },
+ 219:       });
+ 220:     } catch { /* never break the main path */ }
+ 221:     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+ 222:       Sentry.captureException(err);
+ 223:       console.error('[createBooking] cash-on-service dispatch failed', { bookingId: booking.id, err });
+ 224:     });
+ 225:     return {
+ 226:       status: 201,
+ 227:       jsonBody: {
+ 228:         bookingId: booking.id,
+ 229:         razorpayOrderId: cashOrderId,
+ 230:         amount: service.basePrice,
+ 231:         requiresPayment: false,
+ 232:         paymentMethod: 'CASH_ON_SERVICE',
+ 233:         appliedCreditAmount,
+ 234:       },
+ 235:     };
+ 236:   }
+ 237: 
+ 238:   if (!hasRazorpayCredentials()) {
+ 239:     const manualOrderId = `manual_${randomUUID()}`;
+ 240:     const manualRequest = { ...parsed.data, paymentMethod: 'CASH_ON_SERVICE' as const };
+ 241:     const booking = await bookingRepo.createPending(
+ 242:       manualRequest,
+ 243:       customer.customerId,
+ 244:       manualOrderId,
+ 245:       service.basePrice,
+ 246:       bookingMetadata(customer, service.name),
+ 247:     );
+ 248:     const paid = await bookingRepo.markPaid(booking.id, 'manual_payment_not_configured');
+ 249:     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 250: 
+ 251:     // E16-S02: Commit hold (non-fatal)
+ 252:     slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+ 253:       Sentry.captureException(err);
+ 254:       console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+ 255:     });
+ 256: 
+ 257:     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+ 258:       Sentry.captureException(err);
+ 259:       console.error('[createBooking] manual-payment dispatch failed', { bookingId: booking.id, err });
+ 260:     });
+ 261:     return {
+ 262:       status: 201,
+ 263:       jsonBody: {
+ 264:         bookingId: booking.id,
+ 265:         razorpayOrderId: manualOrderId,
+ 266:         amount: service.basePrice,
+ 267:         requiresPayment: false,
+ 268:         paymentMethod: 'CASH_ON_SERVICE',
+ 269:         appliedCreditAmount: 0,
+ 270:       },
+ 271:     };
+ 272:   }
+ 273: 
+ 274:   // Pre-generate booking ID so we can embed it in Razorpay notes for the fast path.
+ 275:   // The webhook can then do a cheap point-read (getById) instead of a cross-partition scan.
+ 276:   const preGeneratedBookingId = randomUUID();
+ 277: 
+ 278:   // E13-S01 (P1-6): Determine intended credit amount WITHOUT writing to the ledger yet.
+ 279:   // The actual ledger CREDIT_APPLIED entry is written in the Razorpay webhook (payment.captured),
+ 280:   // NOT here. This prevents the "debit-before-payment" bug where an unpaid/abandoned booking
+ 281:   // permanently consumes the customer's wallet credit.
+ 282:   //
+ 283:   // For the fully-credit-paid path (P1-5): if credit covers 100% of the booking, we skip
+ 284:   // Razorpay entirely and mark the booking PAID directly â€” no payment intent is needed.
+ 285:   let pendingCreditAmount = 0;
+ 286:   const creditEnabled = parsed.data.applyCredit && idempotencyKey
+ 287:     ? await isWalletCreditEnabled(customer.customerId)
+ 288:     : false;
+ 289: 
+ 290:   if (creditEnabled) {
+ 291:     // Peek at current balance; we don't write the ledger entry here.
+ 292:     const { balanceInPaise } = await customerCreditLedgerRepo.getBalance(customer.customerId);
+ 293:     pendingCreditAmount = Math.min(balanceInPaise, service.basePrice);
+ 294:   }
+ 295: 
+ 296:   const payableAmount = service.basePrice - pendingCreditAmount;
+ 297: 
+ 298:   // P1-5: Credit covers 100% â€” skip Razorpay, mark PAID directly
+ 299:   if (payableAmount <= 0 && pendingCreditAmount > 0) {
+ 300:     const fullCreditOrderId = `credit_${randomUUID()}`;
+ 301:     const fullCreditCreditOptions: BookingCreateCreditOptions = {
+ 302:       pendingCreditAmountInPaise: pendingCreditAmount,
+ 303:       pendingCreditIdempotencyKey: idempotencyKey,
+ 304:     };
+ 305:     const booking = await bookingRepo.createPending(
+ 306:       parsed.data,
+ 307:       customer.customerId,
+ 308:       fullCreditOrderId,
+ 309:       service.basePrice,
+ 310:       bookingMetadata(customer, service.name),
+ 311:       preGeneratedBookingId,
+ 312:       fullCreditCreditOptions,
+ 313:     );
+ 314: 
+ 315:     // Apply credit synchronously for the fully-credit-paid path (no payment to wait for)
+ 316:     const appliedCreditAmount = await attemptCreditApplication(
+ 317:       customer.customerId,
+ 318:       booking.id,
+ 319:       pendingCreditAmount,
+ 320:       idempotencyKey,
+ 321:     );
+ 322: 
+ 323:     // P1-1: Verify the credit was actually applied before marking PAID.
+ 324:     //
+ 325:     // attemptCreditApplication returns 0 (or a partial amount) when:
+ 326:     //   - A 412 ETag conflict (race with another concurrent apply) exhausted all retries.
+ 327:     //   - An unexpected Cosmos error was swallowed by the non-blocking path.
+ 328:     //
+ 329:     // If we mark PAID without the credit being applied, the customer gets a free
+ 330:     // or underpaid booking (the Razorpay order was skipped entirely).
+ 331:     //
+ 332:     // Safe fallback: reject with 409 so the customer retries. We cannot safely
+ 333:     // fall back to Razorpay here because the booking doc was already created and
+ 334:     // the Razorpay order amount would need to be recomputed â€” doing so in a partially
+ 335:     // applied state risks double-charging or missed credit.
+ 336:     if (appliedCreditAmount < pendingCreditAmount) {
+ 337:       console.warn('[createBooking] full-credit path: applied amount < expected; rejecting with 409', {
+ 338:         customerId: customer.customerId,
+ 339:         bookingId: booking.id,
+ 340:         expected: pendingCreditAmount,
+ 341:         applied: appliedCreditAmount,
+ 342:       });
+ 343:       Sentry.captureException(
+ 344:         new Error(`CREDIT_RACE: applied ${appliedCreditAmount} < expected ${pendingCreditAmount}`),
+ 345:       );
+ 346:       // Booking is in PENDING_PAYMENT state and no Razorpay order was created â€” safe to
+ 347:       // leave it; it will expire naturally (stale-booking cleanup handles it).
+ 348:       return {
+ 349:         status: 409,
+ 350:         jsonBody: {
+ 351:           code: 'CREDIT_RACE',
+ 352:           message: 'Credit application conflict â€” please retry. Your wallet balance is unchanged.',
+ 353:         },
+ 354:       };
+ 355:     }
+ 356: 
+ 357:     // Mark PAID immediately (no Razorpay payment involved)
+ 358:     const paid = await bookingRepo.markPaid(booking.id, 'credit_full_payment');
+ 359:     if (!paid) return { status: 500, jsonBody: { code: 'BOOKING_CONFIRMATION_FAILED' } };
+ 360: 
+ 361:     // E16-S02: Commit hold â€” converts 30 s soft hold to permanent slot record.
+ 362:     slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+ 363:       Sentry.captureException(err);
+ 364:       console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+ 365:     });
+ 366: 
+ 367:     try {
+ 368:       posthog.capture({
+ 369:         distinctId: customer.customerId,
+ 370:         event: 'booking-created',
+ 371:         properties: {
+ 372:           bookingId: booking.id,
+ 373:           serviceId: parsed.data.serviceId,
+ 374:           paymentMethod: 'CREDIT_FULL',
+ 375:           appliedCreditAmount,
+ 376:         },
+ 377:       });
+ 378:     } catch { /* never break the main path */ }
+ 379: 
+ 380:     dispatcherService.triggerDispatch(booking.id).catch((err: unknown) => {
+ 381:       Sentry.captureException(err);
+ 382:       console.error('[createBooking] credit-full dispatch failed', { bookingId: booking.id, err });
+ 383:     });
+ 384: 
+ 385:     return {
+ 386:       status: 201,
+ 387:       jsonBody: {
+ 388:         bookingId: booking.id,
+ 389:         razorpayOrderId: fullCreditOrderId,
+ 390:         amount: service.basePrice,
+ 391:         requiresPayment: false,
+ 392:         paymentMethod: 'CREDIT_FULL',
+ 393:         appliedCreditAmount,
+ 394:       },
+ 395:     };
+ 396:   }
+ 397: 
+ 398:   // Partial or no credit â€” create Razorpay order for the payable portion.
+ 399:   //
+ 400:   // P1-2: Reserve the credit BEFORE creating the discounted Razorpay order.
+ 401:   //
+ 402:   // Problem without reservation: `pendingCreditAmount` is only a balance peek. If:
+ 403:   //   (a) The same idempotency key is replayed (client retry), a second discounted
+ 404:   //       Razorpay order is created, potentially granting the discount twice.
+ 405:   //   (b) The wallet balance is spent elsewhere between here and payment.captured,
+ 406:   //       the webhook tries to apply a credit that no longer exists â€” the Razorpay
+ 407:   //       payment collected less than basePrice and the booking is undercollected.
+ 408:   //
+ 409:   // Fix: write a RESERVED idempotency doc with IfNoneMatch: * before creating the
+ 410:   // Razorpay order. This guarantees:
+ 411:   //   - Idempotency-key replay on Razorpay order creation returns 'already_reserved'
+ 412:   //     (same booking) â†’ skip Razorpay creation and return the same pending credit amount.
+ 413:   //   - The wallet balance is not double-spent (the reservation does not debit the wallet;
+ 414:   //     the actual debit in applyCredit will see the RESERVED status and proceed to debit).
+ 415:   //   - On abandonment (no payment.captured within TTL): the reservation auto-expires, leaving
+ 416:   //     the wallet balance intact for the next booking.
+ 417:   if (pendingCreditAmount > 0) {
+ 418:     try {
+ 419:       const reserveResult = await customerCreditLedgerRepo.reserveCredit(
+ 420:         customer.customerId,
+ 421:         preGeneratedBookingId,
+ 422:         pendingCreditAmount,
+ 423:         idempotencyKey,
+ 424:       );
+ 425:       if (reserveResult === 'already_reserved') {
+ 426:         // Idempotent replay: same key, same booking â€” the Razorpay order was already created
+ 427:         // in a prior attempt (but the response may not have reached the client). Return the
+ 428:         // same pending credit info so the client can resume payment.
+ 429:         console.info('[createBooking] credit reservation already exists â€” idempotent replay', {
+ 430:           customerId: customer.customerId,
+ 431:           bookingId: preGeneratedBookingId,
+ 432:         });
+ 433:         // Fall through to create the Razorpay order (or it may already exist; Razorpay is
+ 434:         // idempotent on order ID because the receipt is unique per attempt â€” acceptable).
+ 435:       }
+ 436:     } catch (reserveErr: unknown) {
+ 437:       Sentry.captureException(reserveErr);
+ 438:       console.error('[createBooking] credit reservation failed â€” falling back to no-credit Razorpay', {
+ 439:         customerId: customer.customerId,
+ 440:         err: reserveErr,
+ 441:       });
+ 442:       // Non-fatal: fall back to full-price Razorpay (safer than blocking the booking).
+ 443:       // pendingCreditAmount is reset to 0 so no discount is applied.
+ 444:       // The unreserved credit stays in the wallet for the next booking.
+ 445:       // NOTE: if this was a 409 IDEMPOTENCY_KEY_ALREADY_USED for a different booking,
+ 446:       // that is an abuse signal â€” Sentry captures it above.
+ 447:       // For non-409 errors (Cosmos failures, timeouts, etc.), the reservation didn't
+ 448:       // happen â€” credit stays intact in the wallet for the next booking attempt.
+ 449:       // We fall through to create a full-price Razorpay order (no discount) which is safe.
+ 450:     }
+ 451:   }
+ 452: 
+ 453:   let order: Awaited<ReturnType<typeof createRazorpayOrder>>;
+ 454:   try {
+ 455:     order = await createRazorpayOrder({
+ 456:       amount: payableAmount > 0 ? payableAmount : service.basePrice,
+ 457:       currency: 'INR',
+ 458:       receipt: makeRazorpayReceipt(customer.customerId),
+ 459:       notes: { bookingId: preGeneratedBookingId },
+ 460:     });
+ 461:   } catch (err) {
+ 462:     Sentry.captureException(err);
+ 463:     console.error('[createBooking] Razorpay order creation failed', {
+ 464:       customerId: customer.customerId,
+ 465:       serviceId: parsed.data.serviceId,
+ 466:       err,
+ 467:     });
+ 468:     return {
+ 469:       status: 502,
+ 470:       jsonBody: {
+ 471:         code: 'PAYMENT_ORDER_FAILED',
+ 472:         message: 'Could not start payment. Please try again.',
+ 473:       },
+ 474:     };
+ 475:   }
+ 476: 
+ 477:   // P1-6: Store the intended credit amount on the booking doc.
+ 478:   // The webhook (payment.captured) will call applyCredit to debit the ledger.
+ 479:   // If the customer abandons payment, no credit is debited (it stays intact).
+ 480:   const razorpayCreditOptions: BookingCreateCreditOptions | undefined = pendingCreditAmount > 0
+ 481:     ? { pendingCreditAmountInPaise: pendingCreditAmount, pendingCreditIdempotencyKey: idempotencyKey }
+ 482:     : undefined;
+ 483: 
+ 484:   const booking = await bookingRepo.createPending(
+ 485:     parsed.data,
+ 486:     customer.customerId,
+ 487:     order.id,
+ 488:     service.basePrice,
+ 489:     bookingMetadata(customer, service.name),
+ 490:     preGeneratedBookingId,
+ 491:     razorpayCreditOptions,
+ 492:   );
+ 493: 
+ 494:   // E16-S02: Commit hold â€” converts 30 s soft hold to permanent slot record.
+ 495:   slotHoldsRepo.commitHold(holdId, holdPk, booking.id).catch((err: unknown) => {
+ 496:     Sentry.captureException(err);
+ 497:     console.warn('[createBooking] commitHold failed (non-fatal)', { holdId, bookingId: booking.id, err });
+ 498:   });
+ 499: 
+ 500:   try {
+ 501:     posthog.capture({
+ 502:       distinctId: customer.customerId,
+ 503:       event: 'booking-created',
+ 504:       properties: {
+ 505:         bookingId: booking.id,
+ 506:         serviceId: parsed.data.serviceId,
+ 507:         paymentMethod: 'RAZORPAY',
+ 508:         // appliedCreditAmount reported as 0 here â€” actual debit happens post-payment
+ 509:         appliedCreditAmount: 0,
+ 510:         pendingCreditAmount,
+ 511:       },
+ 512:     });
+ 513:   } catch { /* never break the main path */ }
+ 514:   return {
+ 515:     status: 201,
+ 516:     jsonBody: {
+ 517:       bookingId: booking.id,
+ 518:       razorpayOrderId: order.id,
+ 519:       amount: order.amount,
+ 520:       requiresPayment: true,
+ 521:       paymentMethod: 'RAZORPAY',
+ 522:       // Report pending credit to client so the UI can show "â‚¹X will be applied after payment"
+ 523:       appliedCreditAmount: 0,
+ 524:       pendingCreditAmount,
+ 525:     },
+ 526:   };
+ 527: };
+ 528: 
+ 529: const confirmHandler: CustomerHttpHandler = async (req, _ctx, customer) => {
+ 530:   const id = (req as unknown as { params: { id: string } }).params.id;
+ 531:   const body = await req.json().catch(() => null);
+ 532:   const parsed = ConfirmBookingRequestSchema.safeParse(body);
+ 533:   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+ 534: 
+ 535:   const booking = await bookingRepo.getById(id);
+ 536:   if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+ 537:   if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+ 538: 
+ 539:   if (!verifyPaymentSignature({
+ 540:     razorpayOrderId: parsed.data.razorpayOrderId,
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/functions/bookings.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -Skip 540 -First 240' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 652ms:
+ 541:     razorpayPaymentId: parsed.data.razorpayPaymentId,
+ 542:     razorpaySignature: parsed.data.razorpaySignature,
+ 543:   })) return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+ 544: 
+ 545:   const confirmed = await bookingRepo.confirmPayment(id, parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
+ 546:   if (!confirmed) return { status: 409, jsonBody: { code: 'BOOKING_ALREADY_PROCESSED' } };
+ 547: 
+ 548:   // Only audit when this call actually performed the transition. If status is PAID the webhook
+ 549:   // already processed the booking â€” this is an idempotent confirm, not a new event.
+ 550:   if (confirmed.status === 'SEARCHING') {
+ 551:     const _ts = new Date().toISOString();
+ 552:     void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'CUSTOMER_CONFIRMED_PAYMENT', resourceType: 'booking', resourceId: confirmed.id, payload: { bookingId: confirmed.id, paymentId: parsed.data.razorpayPaymentId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+ 553:   }
+ 554: 
+ 555:   return { status: 200, jsonBody: { bookingId: confirmed.id, status: confirmed.status } };
+ 556: };
+ 557: 
+ 558: export const createBookingHandler: HttpHandler = requireCustomer(createHandler);
+ 559: export const confirmBookingHandler: HttpHandler = requireCustomer(confirmHandler);
+ 560: 
+ 561: const getBookingInner: CustomerHttpHandler = async (req, _ctx, customer) => {
+ 562:   const id = (req as unknown as { params: { id: string } }).params.id;
+ 563:   const booking = await bookingRepo.getById(id);
+ 564:   if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+ 565:   if (booking.customerId !== customer.customerId) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+ 566:   return {
+ 567:     status: 200,
+ 568:     jsonBody: {
+ 569:       bookingId: booking.id, status: booking.status, amount: booking.amount,
+ 570:       finalAmount: booking.finalAmount ?? null,
+ 571:       pendingAddOns: booking.pendingAddOns ?? [],
+ 572:       approvedAddOns: booking.approvedAddOns ?? [],
+ 573:     },
+ 574:   };
+ 575: };
+ 576: export const getBookingHandler: HttpHandler = requireCustomer(getBookingInner);
+ 577: 
+ 578: const getMyBookingsInner: CustomerHttpHandler = async (_req, ctx, customer) => {
+ 579:   try {
+ 580:     const bookings = await bookingRepo.getByCustomerId(customer.customerId);
+ 581:     const serviceNames = new Map<string, string>();
+ 582: 
+ 583:     await Promise.all(
+ 584:       [...new Set(bookings.map((booking) => booking.serviceId))].map(async (serviceId) => {
+ 585:         const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
+ 586:         serviceNames.set(serviceId, service?.name ?? serviceId);
+ 587:       }),
+ 588:     );
+ 589: 
+ 590:     return {
+ 591:       status: 200,
+ 592:       jsonBody: {
+ 593:         bookings: bookings.map((booking) => ({
+ 594:           bookingId: booking.id,
+ 595:           serviceId: booking.serviceId,
+ 596:           serviceName: serviceNames.get(booking.serviceId) ?? booking.serviceId,
+ 597:           addressText: normalizeAddressText(booking.addressText),
+ 598:           addressLatLng: booking.addressLatLng,
+ 599:           status: booking.status,
+ 600:           slotDate: booking.slotDate,
+ 601:           slotWindow: booking.slotWindow,
+ 602:           amount: booking.finalAmount ?? booking.amount,
+ 603:           paymentMethod: booking.paymentMethod ?? 'RAZORPAY',
+ 604:           createdAt: booking.createdAt,
+ 605:         })),
+ 606:       },
+ 607:     };
+ 608:   } catch (err: unknown) {
+ 609:     Sentry.captureException(err);
+ 610:     ctx.error('getMyBookings failed', err);
+ 611:     return { status: 500, jsonBody: { code: 'INTERNAL_ERROR' } };
+ 612:   }
+ 613: };
+ 614: export const getMyBookingsHandler: HttpHandler = requireCustomer(getMyBookingsInner);
+ 615: 
+ 616: export const requestAddonHandler: HttpHandler = async (req, _ctx) => {
+ 617:   let uid: string;
+ 618:   try { ({ uid } = await verifyTechnicianToken(req)); }
+ 619:   catch { return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } }; }
+ 620:   const id = (req as unknown as { params: { id: string } }).params.id;
+ 621:   const booking = await bookingRepo.getById(id);
+ 622:   if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
+ 623:   if (booking.technicianId !== uid) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
+ 624:   const body = await req.json().catch(() => null);
+ 625:   const parsed = RequestAddOnBodySchema.safeParse(body);
+ 626:   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+ 627:   const updated = await bookingRepo.requestAddOn(id, parsed.data);
+ 628:   if (!updated) return { status: 409, jsonBody: { code: 'BOOKING_NOT_IN_PROGRESS' } };
+ 629: 
+ 630:   try {
+ 631:     await sendPriceApprovalPush(booking.customerId, id);
+ 632:   } catch (err) {
+ 633:     console.error('[requestAddon] FCM push failed â€” booking is AWAITING_PRICE_APPROVAL but customer was not notified', { bookingId: id, err });
+ 634:   }
+ 635: 
+ 636:   return { status: 200, jsonBody: { bookingId: updated.id, status: updated.status } };
+ 637: };
+ 638: 
+ 639: const approveFinalPriceInner: CustomerHttpHandler = async (req, _ctx, customer) => {
+ 640:   const id = (req as unknown as { params: { id: string } }).params.id;
+ 641:   const body = await req.json().catch(() => null);
+ 642:   const parsed = ApproveAddOnsBodySchema.safeParse(body);
+ 643:   if (!parsed.success) return { status: 422, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+ 644:   const updated = await bookingRepo.applyAddOnDecisions(id, customer.customerId, parsed.data.decisions);
+ 645:   if (!updated) return { status: 409, jsonBody: { code: 'BOOKING_NOT_AWAITING_APPROVAL' } };
+ 646:   return { status: 200, jsonBody: { bookingId: updated.id, status: updated.status, finalAmount: updated.finalAmount } };
+ 647: };
+ 648: export const approveFinalPriceHandler: HttpHandler = requireCustomer(approveFinalPriceInner);
+ 649: 
+ 650: const createBookingRateLimiter = withRateLimit({
+ 651:   buckets: { ip: { capacity: 20, refillPerSec: 20 / 60 } },
+ 652: });
+ 653: 
+ 654: app.http('createBooking', { route: 'v1/bookings', methods: ['POST'], handler: createBookingRateLimiter(createBookingHandler) });
+ 655: app.http('confirmBooking', { route: 'v1/bookings/{id}/confirm', methods: ['POST'], handler: requireIntegrity(confirmBookingHandler) });
+ 656: app.http('getMyBookings', { route: 'v1/bookings', methods: ['GET'], handler: getMyBookingsHandler });
+ 657: app.http('getBooking', { route: 'v1/bookings/{id}', methods: ['GET'], handler: getBookingHandler });
+ 658: app.http('requestAddon', { route: 'v1/bookings/{id}/request-addon', methods: ['POST'], handler: requestAddonHandler });
+ 659: app.http('approveFinalPrice', { route: 'v1/bookings/{id}/approve-final-price', methods: ['POST'], handler: approveFinalPriceHandler });
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$files=@('"'api/src/schemas/booking.ts','api/src/cosmos/booking-repository.ts','api/src/functions/razorpay-webhook.ts','api/src/functions/bookings.ts'); foreach("'$p in $files){ Write-Output "--- $p"; if(Test-Path $p){ Select-String -Path $p -Pattern "PENDING_PAYMENT|markPaid|confirmPayment|UNFULFILLED|CUSTOMER_CANCELLED|cancel|expire|cleanup|createPending" -Context 2,3 } }' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 594ms:
+--- api/src/schemas/booking.ts
+
+  api\src\schemas\booking.ts:3:
+  api\src\schemas\booking.ts:4:const BOOKING_STATUSES = [
+> api\src\schemas\booking.ts:5:  'PENDING_PAYMENT', 'SEARCHING', 'ASSIGNED', 'EN_ROUTE',
+  api\src\schemas\booking.ts:6:  'REACHED', 'IN_PROGRESS', 'AWAITING_PRICE_APPROVAL', 'COMPLETED', 'PAID', 'CLOSED',
+> api\src\schemas\booking.ts:7:  'UNFULFILLED', 'CUSTOMER_CANCELLED', 'NO_SHOW_REDISPATCH',
+  api\src\schemas\booking.ts:8:] as const;
+  api\src\schemas\booking.ts:9:
+  api\src\schemas\booking.ts:10:const PAYMENT_METHODS = ['RAZORPAY', 'CASH_ON_SERVICE'] as const;
+  api\src\schemas\booking.ts:61:   * ISO timestamp written atomically when the booking transitions to 
+AWAITING_PRICE_APPROVAL
+  api\src\schemas\booking.ts:62:   * (i.e. when the technician requests an add-on). Used by the bookings change-feed 
+projector
+> api\src\schemas\booking.ts:63:   * to anchor the ADDON_APPROVAL_REQUESTED expiresAt from the actual request time, 
+not from
+  api\src\schemas\booking.ts:64:   * the booking's original createdAt (which may be >24h in the past for advance 
+bookings).
+  api\src\schemas\booking.ts:65:   */
+  api\src\schemas\booking.ts:66:  pendingAddOnsUpdatedAt: z.string().optional(),
+--- api/src/cosmos/booking-repository.ts
+  api\src\cosmos\booking-repository.ts:26:
+  api\src\cosmos\booking-repository.ts:27:export const bookingRepo = {
+> api\src\cosmos\booking-repository.ts:28:  async createPending(
+  api\src\cosmos\booking-repository.ts:29:    req: CreateBookingRequest,
+  api\src\cosmos\booking-repository.ts:30:    customerId: string,
+  api\src\cosmos\booking-repository.ts:31:    paymentOrderId: string,
+  api\src\cosmos\booking-repository.ts:43:      ...(metadata.customerEmail ? { customerEmail: metadata.customerEmail } 
+: {}),
+  api\src\cosmos\booking-repository.ts:44:      ...(metadata.serviceName ? { serviceName: metadata.serviceName } : {}),
+> api\src\cosmos\booking-repository.ts:45:      status: 'PENDING_PAYMENT', paymentOrderId,
+  api\src\cosmos\booking-repository.ts:46:      paymentMethod,
+  api\src\cosmos\booking-repository.ts:47:      ...(paymentMethod === 'CASH_ON_SERVICE' ? { cashCollectionStatus: 
+'PENDING' as const } : {}),
+  api\src\cosmos\booking-repository.ts:48:      paymentId: null, paymentSignature: null,
+  api\src\cosmos\booking-repository.ts:65:  },
+  api\src\cosmos\booking-repository.ts:66:
+> api\src\cosmos\booking-repository.ts:67:  async confirmPayment(
+  api\src\cosmos\booking-repository.ts:68:    id: string,
+  api\src\cosmos\booking-repository.ts:69:    paymentId: string,
+  api\src\cosmos\booking-repository.ts:70:    paymentSignature: string,
+  api\src\cosmos\booking-repository.ts:73:    if (!existing) return null;
+  api\src\cosmos\booking-repository.ts:74:    if (existing.status === 'PAID') return existing; // webhook already 
+processed — idempotent success
+> api\src\cosmos\booking-repository.ts:75:    if (existing.status !== 'PENDING_PAYMENT') return null;
+  api\src\cosmos\booking-repository.ts:76:    const updated: BookingDoc = { ...existing, status: 'SEARCHING', 
+paymentId, paymentSignature };
+  api\src\cosmos\booking-repository.ts:77:    const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+  api\src\cosmos\booking-repository.ts:78:    if (useEtag) {
+  api\src\cosmos\booking-repository.ts:103:  },
+  api\src\cosmos\booking-repository.ts:104:
+> api\src\cosmos\booking-repository.ts:105:  async markPaid(id: string, paymentId: string): Promise<BookingDoc | null> 
+{
+  api\src\cosmos\booking-repository.ts:106:    const { resource: existing, etag } = await 
+getBookingsContainer().item(id, id).read<BookingDoc>();
+> api\src\cosmos\booking-repository.ts:107:    if (!existing || (existing.status !== 'SEARCHING' && existing.status 
+!== 'PENDING_PAYMENT')) return null;
+  api\src\cosmos\booking-repository.ts:108:    const updated: BookingDoc = { ...existing, status: 'PAID', paymentId };
+  api\src\cosmos\booking-repository.ts:109:    const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+  api\src\cosmos\booking-repository.ts:110:    if (useEtag) {
+  api\src\cosmos\booking-repository.ts:136:    const { resources } = await 
+getBookingsContainer().items.query<BookingDoc>({
+  api\src\cosmos\booking-repository.ts:137:      query: `SELECT * FROM c
+> api\src\cosmos\booking-repository.ts:138:              WHERE c.status IN ('PAID', 'UNFULFILLED')
+  api\src\cosmos\booking-repository.ts:139:                AND (NOT IS_DEFINED(c.technicianId) OR 
+IS_NULL(c.technicianId))`,
+  api\src\cosmos\booking-repository.ts:140:      parameters: [],
+  api\src\cosmos\booking-repository.ts:141:    }).fetchAll();
+  api\src\cosmos\booking-repository.ts:264:  },
+  api\src\cosmos\booking-repository.ts:265:
+> api\src\cosmos\booking-repository.ts:266:  // E16-S02: Returns slotWindow strings for all active 
+(non-cancelled/unfulfilled) bookings
+  api\src\cosmos\booking-repository.ts:267:  // for a given service on a given date. Used by the availability handler 
+to mark slots
+  api\src\cosmos\booking-repository.ts:268:  // as hard-booked. Cross-partition scan — acceptable at pilot scale 
+(≤5,000 bookings/mo).
+  api\src\cosmos\booking-repository.ts:269:  async getBookedWindowsByServiceDate(serviceId: string, date: string): 
+Promise<string[]> {
+  api\src\cosmos\booking-repository.ts:273:                WHERE c.serviceId = @serviceId
+  api\src\cosmos\booking-repository.ts:274:                  AND c.slotDate = @date
+> api\src\cosmos\booking-repository.ts:275:                  AND c.status NOT IN ('CUSTOMER_CANCELLED', 
+'UNFULFILLED')`,
+  api\src\cosmos\booking-repository.ts:276:        parameters: [
+  api\src\cosmos\booking-repository.ts:277:          { name: '@serviceId', value: serviceId },
+  api\src\cosmos\booking-repository.ts:278:          { name: '@date', value: date },
+--- api/src/functions/razorpay-webhook.ts
+--- api/src/functions/bookings.ts
+  api\src\functions\bookings.ts:177:  if (parsed.data.paymentMethod === 'CASH_ON_SERVICE') {
+  api\src\functions\bookings.ts:178:    const cashOrderId = `cash_${randomUUID()}`;
+> api\src\functions\bookings.ts:179:    const booking = await bookingRepo.createPending(
+  api\src\functions\bookings.ts:180:      parsed.data,
+  api\src\functions\bookings.ts:181:      customer.customerId,
+  api\src\functions\bookings.ts:182:      cashOrderId,
+  api\src\functions\bookings.ts:184:      bookingMetadata(customer, service.name),
+  api\src\functions\bookings.ts:185:    );
+> api\src\functions\bookings.ts:186:    const paid = await bookingRepo.markPaid(booking.id, 'cash_on_service_pending');
+  api\src\functions\bookings.ts:187:    if (!paid) return { status: 500, jsonBody: { code: 
+'BOOKING_CONFIRMATION_FAILED' } };
+  api\src\functions\bookings.ts:188:
+  api\src\functions\bookings.ts:189:    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
+  api\src\functions\bookings.ts:239:    const manualOrderId = `manual_${randomUUID()}`;
+  api\src\functions\bookings.ts:240:    const manualRequest = { ...parsed.data, paymentMethod: 'CASH_ON_SERVICE' as 
+const };
+> api\src\functions\bookings.ts:241:    const booking = await bookingRepo.createPending(
+  api\src\functions\bookings.ts:242:      manualRequest,
+  api\src\functions\bookings.ts:243:      customer.customerId,
+  api\src\functions\bookings.ts:244:      manualOrderId,
+  api\src\functions\bookings.ts:246:      bookingMetadata(customer, service.name),
+  api\src\functions\bookings.ts:247:    );
+> api\src\functions\bookings.ts:248:    const paid = await bookingRepo.markPaid(booking.id, 
+'manual_payment_not_configured');
+  api\src\functions\bookings.ts:249:    if (!paid) return { status: 500, jsonBody: { code: 
+'BOOKING_CONFIRMATION_FAILED' } };
+  api\src\functions\bookings.ts:250:
+  api\src\functions\bookings.ts:251:    // E16-S02: Commit hold (non-fatal)
+  api\src\functions\bookings.ts:303:      pendingCreditIdempotencyKey: idempotencyKey,
+  api\src\functions\bookings.ts:304:    };
+> api\src\functions\bookings.ts:305:    const booking = await bookingRepo.createPending(
+  api\src\functions\bookings.ts:306:      parsed.data,
+  api\src\functions\bookings.ts:307:      customer.customerId,
+  api\src\functions\bookings.ts:308:      fullCreditOrderId,
+  api\src\functions\bookings.ts:344:        new Error(`CREDIT_RACE: applied ${appliedCreditAmount} < expected 
+${pendingCreditAmount}`),
+  api\src\functions\bookings.ts:345:      );
+> api\src\functions\bookings.ts:346:      // Booking is in PENDING_PAYMENT state and no Razorpay order was created — 
+safe to
+> api\src\functions\bookings.ts:347:      // leave it; it will expire naturally (stale-booking cleanup handles it).
+  api\src\functions\bookings.ts:348:      return {
+  api\src\functions\bookings.ts:349:        status: 409,
+  api\src\functions\bookings.ts:350:        jsonBody: {
+  api\src\functions\bookings.ts:356:
+  api\src\functions\bookings.ts:357:    // Mark PAID immediately (no Razorpay payment involved)
+> api\src\functions\bookings.ts:358:    const paid = await bookingRepo.markPaid(booking.id, 'credit_full_payment');
+  api\src\functions\bookings.ts:359:    if (!paid) return { status: 500, jsonBody: { code: 
+'BOOKING_CONFIRMATION_FAILED' } };
+  api\src\functions\bookings.ts:360:
+  api\src\functions\bookings.ts:361:    // E16-S02: Commit hold — converts 30 s soft hold to permanent slot record.
+  api\src\functions\bookings.ts:413:  //   - The wallet balance is not double-spent (the reservation does not debit 
+the wallet;
+  api\src\functions\bookings.ts:414:  //     the actual debit in applyCredit will see the RESERVED status and proceed 
+to debit).
+> api\src\functions\bookings.ts:415:  //   - On abandonment (no payment.captured within TTL): the reservation 
+auto-expires, leaving
+  api\src\functions\bookings.ts:416:  //     the wallet balance intact for the next booking.
+  api\src\functions\bookings.ts:417:  if (pendingCreditAmount > 0) {
+  api\src\functions\bookings.ts:418:    try {
+  api\src\functions\bookings.ts:482:    : undefined;
+  api\src\functions\bookings.ts:483:
+> api\src\functions\bookings.ts:484:  const booking = await bookingRepo.createPending(
+  api\src\functions\bookings.ts:485:    parsed.data,
+  api\src\functions\bookings.ts:486:    customer.customerId,
+  api\src\functions\bookings.ts:487:    order.id,
+  api\src\functions\bookings.ts:543:  })) return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+  api\src\functions\bookings.ts:544:
+> api\src\functions\bookings.ts:545:  const confirmed = await bookingRepo.confirmPayment(id, 
+parsed.data.razorpayPaymentId, parsed.data.razorpaySignature);
+  api\src\functions\bookings.ts:546:  if (!confirmed) return { status: 409, jsonBody: { code: 
+'BOOKING_ALREADY_PROCESSED' } };
+  api\src\functions\bookings.ts:547:
+  api\src\functions\bookings.ts:548:  // Only audit when this call actually performed the transition. If status is 
+PAID the webhook
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Get-ChildItem -Path api/src -Recurse -Filter '*stale*','*cleanup*' | Select-Object FullName; Select-String -Path api/src/**/*.ts -Pattern \"stale|cleanup|PENDING_PAYMENT|bookingRepo.*cancel|CUSTOMER_CANCELLED|expire\" -CaseSensitive:"'$false | Select-Object -First 200' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 768ms:
+
+api\src\cosmos\booking-repository.ts:45:      status: 'PENDING_PAYMENT', paymentOrderId,
+api\src\cosmos\booking-repository.ts:75:    if (existing.status !== 'PENDING_PAYMENT') return null;
+api\src\cosmos\booking-repository.ts:107:    if (!existing || (existing.status !== 'SEARCHING' && existing.status !== 
+'PENDING_PAYMENT')) return null;
+api\src\cosmos\booking-repository.ts:127:  async getStaleSearching(olderThanIso: string): Promise<BookingDoc[]> {
+api\src\cosmos\booking-repository.ts:275:                  AND c.status NOT IN ('CUSTOMER_CANCELLED', 'UNFULFILLED')`,
+api\src\cosmos\customer-credit-ledger-repository.ts:297:   * On abandonment (no payment): TTL (24h) auto-expires the 
+reservation — the
+api\src\cosmos\dispatch-attempt-repository.ts:40:      expiresAt: resource.expiresAt,
+api\src\cosmos\dispatch-attempt-repository.ts:62:    if (new Date(resource.expiresAt) <= new Date()) return null;
+api\src\cosmos\dispatch-attempt-repository.ts:69:      expiresAt: resource.expiresAt,
+api\src\cosmos\dispatch-attempt-repository.ts:70:      status: 'EXPIRED',
+api\src\cosmos\pending-action-repository.ts:24: * Query ACTIVE pending actions for a user scoped by role, ordered by 
+priority asc, expiresAt asc.
+api\src\cosmos\pending-action-repository.ts:42:                AND c.expiresAt > @now`,
+api\src\cosmos\pending-action-repository.ts:51:  // Sort by priority asc then expiresAt asc in-memory; Cosmos 
+Serverless sorts
+api\src\cosmos\pending-action-repository.ts:56:    return a.expiresAt.localeCompare(b.expiresAt);
+api\src\cosmos\slot-holds-repository.ts:46:   * If the hold has already expired (404), logs a warning and returns 
+silently —
+api\src\cosmos\slot-holds-repository.ts:58:        console.warn('[slotHoldsRepo] commitHold: hold already expired 
+(non-fatal)', { holdId, bookingId });
+api\src\cosmos\slot-holds-repository.ts:67:   * Cosmos TTL means expired docs are excluded automatically by the engine.
+api\src\firebase\admin.ts:13:    expires: Date.now() + 15 * 60 * 1000, // 15 min
+api\src\functions\bookings.ts:346:      // Booking is in PENDING_PAYMENT state and no Razorpay order was created — 
+safe to
+api\src\functions\bookings.ts:347:      // leave it; it will expire naturally (stale-booking cleanup handles it).
+api\src\functions\bookings.ts:415:  //   - On abandonment (no payment.captured within TTL): the reservation 
+auto-expires, leaving
+api\src\functions\catalogue-public.ts:13:  'Cache-Control': 'public, max-age=300, stale-while-revalidate=60',
+api\src\functions\job-offers.ts:31:  if (attempt.status !== 'PENDING' || new Date(attempt.expiresAt) <= new Date()) {
+api\src\functions\job-offers.ts:32:    return { status: 410, jsonBody: { code: 'OFFER_EXPIRED' } };
+api\src\functions\job-offers.ts:100:async function expireStaleOffers(_timer: Timer, _ctx: InvocationContext): 
+Promise<void> {
+api\src\functions\job-offers.ts:104:      query: `SELECT * FROM c WHERE c.status = 'PENDING' AND c.expiresAt < @now`,
+api\src\functions\job-offers.ts:113:          { ...attempt, status: 'EXPIRED' },
+api\src\functions\job-offers.ts:116:        await bookingEventRepo.append({ event: 'OFFER_EXPIRED', bookingId: 
+attempt.bookingId });
+api\src\functions\job-offers.ts:139:app.timer('expireStaleOffers', {
+api\src\functions\job-offers.ts:141:  handler: expireStaleOffers,
+api\src\functions\pending-actions.ts:6: *   Returns: ACTIVE actions with expiresAt > now, sorted by priority asc
+api\src\functions\pending-actions.ts:10: *   Returns: ACTIVE actions with expiresAt > now, sorted by priority asc
+api\src\functions\rating-escalate.ts:60:  const expiresAt = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+api\src\functions\rating-escalate.ts:80:    slaDeadlineAt: expiresAt.toISOString(),
+api\src\functions\rating-escalate.ts:81:    expiresAt: expiresAt.toISOString(),
+api\src\functions\rating-escalate.ts:108:  return { status: 201, jsonBody: { complaintId: doc.id, expiresAt: 
+expiresAt.toISOString() } };
+api\src\functions\ratings.ts:46:  // the timer expires). The shield does NOT block submission here; enforcement is 
+client-side.
+api\src\functions\shield-report.ts:16:// (PENDING_PAYMENT, SEARCHING) and terminal-cancelled statuses (UNFULFILLED,
+api\src\functions\shield-report.ts:17:// CUSTOMER_CANCELLED, NO_SHOW_REDISPATCH) since those have no real tech 
+assignment.
+api\src\functions\trigger-erasure-deadline.ts:34:  for (const stale of overdue) {
+api\src\functions\trigger-erasure-deadline.ts:36:    const fetched = await getErasureRequestById(stale.id);
+api\src\functions\trigger-no-show-detector.ts:45:    // Guard against stale ASSIGNED snapshot: re-read the booking 
+immediately before the
+api\src\functions\trigger-projector-bookings.ts:33: * expiresAt value, so isSemanticNoOp() correctly identifies them 
+as no-ops
+api\src\functions\trigger-projector-bookings.ts:60:    // expiresAt is derived from booking.pendingAddOnsUpdatedAt 
+(the timestamp written atomically
+api\src\functions\trigger-projector-bookings.ts:63:    //      the expiry is correctly anchored to the request time — 
+not the stale booking.createdAt.
+api\src\functions\trigger-projector-bookings.ts:64:    //   2. Replayed change-feed events produce the same expiresAt 
+value (pendingAddOnsUpdatedAt is
+api\src\functions\trigger-projector-bookings.ts:76:      expiresAt: stableExpiryFrom(addonRequestedAt, 
+ADDON_EXPIRY_MS),
+api\src\functions\trigger-projector-bookings.ts:94:    // expiresAt derived from booking.completedAt (stable) so 
+replays are idempotent.
+api\src\functions\trigger-projector-bookings.ts:102:      expiresAt: stableExpiryFrom(doc.completedAt ?? 
+doc.createdAt, RATING_PROMPT_EXPIRY_MS),
+api\src\functions\trigger-projector-complaints.ts:27: * Same source state → same expiresAt → isSemanticNoOp correctly 
+identifies replays.
+api\src\functions\trigger-projector-complaints.ts:65:    // expiresAt derived from complaint.createdAt so replays 
+produce the same value
+api\src\functions\trigger-projector-complaints.ts:73:      expiresAt: stableExpiryFrom(doc.createdAt, 
+COMPLAINT_UPDATE_EXPIRY_MS),
+api\src\functions\trigger-projector-dispatch-attempts.ts:7: * Expires: JOB_OFFER actions when the attempt status 
+becomes EXPIRED or ACCEPTED.
+api\src\functions\trigger-projector-dispatch-attempts.ts:17:  expireAction,
+api\src\functions\trigger-projector-dispatch-attempts.ts:31:  const { id: attemptId, technicianIds, status, expiresAt, 
+bookingId } = doc;
+api\src\functions\trigger-projector-dispatch-attempts.ts:38:  if (status === 'PENDING' && expiresAt) {
+api\src\functions\trigger-projector-dispatch-attempts.ts:49:          expiresAt, // inherit from dispatch attempt
+api\src\functions\trigger-projector-dispatch-attempts.ts:63:  } else if (status === 'EXPIRED' || status === 
+'ACCEPTED') {
+api\src\functions\trigger-projector-dispatch-attempts.ts:64:    // Expire JOB_OFFER for all technicians in this 
+attempt.
+api\src\functions\trigger-projector-dispatch-attempts.ts:65:    // Retryable Cosmos errors (429, 503 etc.) from 
+expireAction are rethrown so the
+api\src\functions\trigger-projector-dispatch-attempts.ts:67:    // advance — preventing a stale JOB_OFFER from staying 
+ACTIVE indefinitely.
+api\src\functions\trigger-projector-dispatch-attempts.ts:68:    // Non-retryable errors (404, 409) are swallowed 
+(action may already be expired).
+api\src\functions\trigger-projector-dispatch-attempts.ts:73:          await expireAction(actionId, technicianId);
+api\src\functions\trigger-projector-dispatch-attempts.ts:79:          ctx?.warn(`[trigger-projector-dispatch-attempts] 
+Could not expire JOB_OFFER for tech ${technicianId}: ${String(err)}`);
+api\src\functions\trigger-projector-kyc.ts:41: * replays produce the same expiresAt and are correctly identified as 
+no-ops.
+api\src\functions\trigger-projector-kyc.ts:75:    // expiresAt derived from the KYC sub-doc's updatedAt (stable source 
+timestamp).
+api\src\functions\trigger-projector-kyc.ts:76:    // Same kycStatus + same updatedAt → same expiresAt → replay is a 
+no-op.
+api\src\functions\trigger-projector-kyc.ts:83:      expiresAt: stableExpiryFrom(doc.kyc?.updatedAt, 
+KYC_RESUME_EXPIRY_MS),
+api\src\functions\trigger-projector-ratings.ts:26: * customerSubmittedAt is stable: same rating replay → same 
+expiresAt → no-op.
+api\src\functions\trigger-projector-ratings.ts:47:  // expiresAt derived from customerSubmittedAt (stable source 
+timestamp) so replays
+api\src\functions\trigger-projector-ratings.ts:56:    expiresAt: stableExpiryFrom(customerSubmittedAt, 
+RATING_RECEIVED_EXPIRY_MS),
+api\src\functions\trigger-reconcile-payouts.ts:30:  const [pendingStale, failedEntries] = await Promise.all([
+api\src\functions\trigger-reconcile-payouts.ts:36:    `reconcilePayouts: ${pendingStale.length} stale-pending, 
+${failedEntries.length} failed entries`,
+api\src\functions\trigger-reconcile-payouts.ts:42:  for (const entry of pendingStale) {
+api\src\functions\trigger-reconcile-payouts.ts:87:    await sendOwnerRouteAlert({ stalePending: retryFailed, failed: 
+failedEntries.length });
+api\src\functions\trigger-reconcile-payouts.ts:89:      stalePending: retryFailed,
+api\src\functions\webhooks.ts:159:export async function reconcileStaleBookingsHandler(
+api\src\functions\webhooks.ts:164:  const stale = await bookingRepo.getStaleSearching(cutoff);
+api\src\functions\webhooks.ts:165:  for (const booking of stale) {
+api\src\functions\webhooks.ts:166:    context.log(`STALE_BOOKING bookingId=${booking.id} 
+createdAt=${booking.createdAt}`);
+api\src\functions\webhooks.ts:176:app.timer('reconcileStaleBookings', {
+api\src\functions\webhooks.ts:178:  handler: reconcileStaleBookingsHandler,
+api\src\middleware\requireAdmin.ts:24:      if (!session) return { status: 401, jsonBody: { code: 'SESSION_EXPIRED' } 
+};
+api\src\openapi\registry.ts:56:  sessionExpiresAt: z.number().openapi({ example: 1700000000000 }),
+api\src\schemas\booking.ts:5:  'PENDING_PAYMENT', 'SEARCHING', 'ASSIGNED', 'EN_ROUTE',
+api\src\schemas\booking.ts:7:  'UNFULFILLED', 'CUSTOMER_CANCELLED', 'NO_SHOW_REDISPATCH',
+api\src\schemas\booking.ts:63:   * to anchor the ADDON_APPROVAL_REQUESTED expiresAt from the actual request time, not 
+from
+api\src\schemas\complaint.ts:55:  expiresAt: z.string().optional(),
+api\src\schemas\complaint.ts:97:  expiresAt: z.string(),
+api\src\schemas\dispatch-attempt.ts:3:export const DispatchAttemptStatusSchema = z.enum(['PENDING', 'ACCEPTED', 
+'EXPIRED']);
+api\src\schemas\dispatch-attempt.ts:10:  expiresAt: z.string().datetime(),
+api\src\schemas\order.ts:7:  'PENDING_PAYMENT', 'SEARCHING', 'ASSIGNED', 'EN_ROUTE', 'REACHED',
+api\src\schemas\order.ts:9:  'UNFULFILLED', 'CUSTOMER_CANCELLED', 'NO_SHOW_REDISPATCH',
+api\src\schemas\pendingActions.ts:5: * Composite index: (userId, status, expiresAt)
+api\src\schemas\pendingActions.ts:28:  'EXPIRED',
+api\src\schemas\pendingActions.ts:45:  expiresAt: z.string().datetime(),
+api\src\schemas\report.ts:6:  warrantyExpiresAt: string;
+api\src\schemas\wallet.ts:90: *   On abandonment → TTL (24h) auto-expires the reservation.
+api\src\services\adminSession.service.ts:11:  hardExpiresAt: string;
+api\src\services\adminSession.service.ts:45:    hardExpiresAt: new Date(now.getTime() + HARD_EXPIRY_MS).toISOString(),
+api\src\services\adminSession.service.ts:69:  if (new Date(resource.hardExpiresAt) <= now) return null;
+api\src\services\adminSession.service.ts:98:  if (new Date(resource.hardExpiresAt) <= now) return null;
+api\src\services\dispatcher.service.ts:88:  const expiresAt = new Date(sentAt.getTime() + OFFER_WINDOW_MS);
+api\src\services\dispatcher.service.ts:95:    expiresAt: expiresAt.toISOString(),
+api\src\services\dispatcher.service.ts:100:  // Transition to SEARCHING so the stale-booking reconciler can find stuck 
+dispatches
+api\src\services\dispatcher.service.ts:128:          expiresAt: expiresAt.toISOString(),
+api\src\services\dispatcher.service.ts:180:   * Continue nearest-first dispatch after a live offer is declined or 
+expires.
+api\src\services\erasureCascade.service.ts:63:    // Customer FCM is topic-based (`customer_<uid>`); no per-doc 
+cleanup needed.
+api\src\services\fcm.service.ts:77:  stalePending: number;
+api\src\services\fcm.service.ts:84:      stalePending: String(payload.stalePending),
+api\src\services\pdf-generator.service.ts:38:    doc.fontSize(11).font('Helvetica').text(`Valid until: 
+${fmtDate(report.warrantyExpiresAt)}`).moveDown();
+api\src\services\pending-action-projector.ts:33:  expiresAt: string;
+api\src\services\pending-action-projector.ts:70:  if (existing.expiresAt !== input.expiresAt) return false;
+api\src\services\pending-action-projector.ts:101:        expiresAt: input.expiresAt,
+api\src\services\pending-action-projector.ts:120:      _log('pending_action_stale_drop', {
+api\src\services\pending-action-projector.ts:133:      // If the action was previously RESOLVED or EXPIRED (e.g., 
+second add-on
+api\src\services\pending-action-projector.ts:140:      expiresAt: input.expiresAt,
+api\src\services\pending-action-projector.ts:183: * Mark a pending action as EXPIRED (e.g., dispatch_attempts TTL 
+elapsed).
+api\src\services\pending-action-projector.ts:186:export async function expireAction(
+api\src\services\pending-action-projector.ts:190:  return _transitionStatus(id, userId, 'EXPIRED');
+api\src\services\pending-action-projector.ts:248:  targetStatus: 'RESOLVED' | 'EXPIRED',
+api\src\services\report-data.service.ts:17:  const warrantyExpiresAt = new Date(
+api\src\services\report-data.service.ts:34:    warrantyExpiresAt,
+api\src\services\truecaller.service.ts:35: * 3. Truecaller API (only on cache miss or stale entry)
+
+
+Get-ChildItem : Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'Filter'. Specified 
+method is not supported.
+At line:2 char:46
++ ... hildItem -Path api/src -Recurse -Filter '*stale*','*cleanup*' | Selec ...
++                                             ~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : InvalidArgument: (:) [Get-ChildItem], ParameterBindingException
+    + FullyQualifiedErrorId : CannotConvertArgument,Microsoft.PowerShell.Commands.GetChildItemCommand
+ 
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/functions/webhooks.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 230; $p='"'api/src/cosmos/booking-repository.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 160' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 574ms:
+   1: import { randomUUID } from 'node:crypto';
+   2: import type { HttpHandler, Timer } from '@azure/functions';
+   3: import { type InvocationContext, app } from '@azure/functions';
+   4: import * as Sentry from '@sentry/node';
+   5: import { RazorpayWebhookPayloadSchema } from '../schemas/webhook.js';
+   6: import { bookingRepo } from '../cosmos/booking-repository.js';
+   7: import { customerCreditLedgerRepo } from '../cosmos/customer-credit-ledger-repository.js';
+   8: import { dispatcherService } from '../services/dispatcher.service.js';
+   9: import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
+  10: import { getWebhookEventsContainer } from '../cosmos/client.js';
+  11: import { equalsHexHmac } from '../shared/timing-safe.js';
+  12: import { posthog } from '../observability/posthog.js';
+  13: 
+  14: export const razorpayWebhookHandler: HttpHandler = async (req, _ctx) => {
+  15:   const secret = process.env['RAZORPAY_WEBHOOK_SECRET'];
+  16:   if (!secret) return { status: 500, jsonBody: { code: 'CONFIGURATION_ERROR' } };
+  17: 
+  18:   const signature = req.headers.get('x-razorpay-signature') ?? '';
+  19:   const rawBody = await req.text();
+  20: 
+  21:   if (!equalsHexHmac(secret, rawBody, signature)) {
+  22:     return { status: 400, jsonBody: { code: 'SIGNATURE_INVALID' } };
+  23:   }
+  24: 
+  25:   let parsed;
+  26:   try {
+  27:     const json: unknown = JSON.parse(rawBody);
+  28:     const result = RazorpayWebhookPayloadSchema.safeParse(json);
+  29:     if (!result.success) {
+  30:       return { status: 400, jsonBody: { code: 'VALIDATION_ERROR', issues: result.error.issues } };
+  31:     }
+  32:     parsed = result.data;
+  33:   } catch {
+  34:     return { status: 400, jsonBody: { code: 'PARSE_ERROR' } };
+  35:   }
+  36: 
+  37:   if (parsed.event !== 'payment.captured') {
+  38:     return { status: 200, jsonBody: { received: true } };
+  39:   }
+  40: 
+  41:   const orderId = parsed.payload.payment.entity.order_id;
+  42:   const paymentId = parsed.payload.payment.entity.id;
+  43: 
+  44:   // Fast path: use bookingId embedded in Razorpay order notes for a cheap point-read.
+  45:   // Falls back to cross-partition scan for bookings created before this change.
+  46:   // [ ] Razorpay-live-gate: verify notes.bookingId survives order â†’ payment â†’ webhook round-trip
+  47:   const bookingIdFromNotes = parsed.payload.payment.entity.notes?.['bookingId'];
+  48:   let booking = null;
+  49:   if (bookingIdFromNotes) {
+  50:     booking = await bookingRepo.getById(bookingIdFromNotes);
+  51:   }
+  52:   if (!booking) {
+  53:     booking = await bookingRepo.getByPaymentOrderId(orderId);
+  54:   }
+  55: 
+  56:   if (!booking) {
+  57:     return { status: 200, jsonBody: { received: true } };
+  58:   }
+  59: 
+  60:   if (booking.status === 'PAID') {
+  61:     return { status: 200, jsonBody: { received: true } };
+  62:   }
+  63: 
+  64:   const updated = await bookingRepo.markPaid(booking.id, paymentId);
+  65:   if (!updated) {
+  66:     return { status: 200, jsonBody: { received: true } };
+  67:   }
+  68: 
+  69:   // E13-S01 (P1-6): Apply deferred wallet credit AFTER payment confirmation.
+  70:   // The credit amount was stored on the booking doc at creation time to avoid the
+  71:   // "debit-before-payment" bug. Now that payment is confirmed, debit the ledger.
+  72:   // Non-fatal: if credit application fails, the booking is already PAID â€” log and continue.
+  73:   if (
+  74:     booking.pendingCreditAmountInPaise &&
+  75:     booking.pendingCreditAmountInPaise > 0 &&
+  76:     booking.pendingCreditIdempotencyKey
+  77:   ) {
+  78:     try {
+  79:       await customerCreditLedgerRepo.applyCredit(
+  80:         booking.customerId,
+  81:         booking.id,
+  82:         booking.pendingCreditAmountInPaise,
+  83:         booking.pendingCreditIdempotencyKey,
+  84:       );
+  85:       const _creditTs = new Date().toISOString();
+  86:       void appendAuditEntry({
+  87:         id: randomUUID(),
+  88:         adminId: 'system',
+  89:         role: 'system',
+  90:         action: 'WALLET_CREDIT_APPLIED_ON_PAYMENT',
+  91:         resourceType: 'booking',
+  92:         resourceId: booking.id,
+  93:         payload: {
+  94:           bookingId: booking.id,
+  95:           creditAmountInPaise: booking.pendingCreditAmountInPaise,
+  96:           idempotencyKey: booking.pendingCreditIdempotencyKey,
+  97:         },
+  98:         timestamp: _creditTs,
+  99:         partitionKey: _creditTs.slice(0, 7),
+ 100:       }).catch(Sentry.captureException);
+ 101:     } catch (creditErr: unknown) {
+ 102:       // Credit application failure is non-fatal â€” booking is already PAID.
+ 103:       // The pending credit fields remain on the booking doc for manual reconciliation.
+ 104:       Sentry.captureException(creditErr);
+ 105:       console.error('[razorpayWebhook] deferred credit application failed', {
+ 106:         bookingId: booking.id,
+ 107:         pendingCreditAmountInPaise: booking.pendingCreditAmountInPaise,
+ 108:         idempotencyKey: booking.pendingCreditIdempotencyKey,
+ 109:         err: creditErr,
+ 110:       });
+ 111:     }
+ 112:   }
+ 113: 
+ 114:   try {
+ 115:     posthog.capture({
+ 116:       distinctId: booking.customerId,
+ 117:       event: 'booking-paid',
+ 118:       properties: {
+ 119:         bookingId: booking.id,
+ 120:         paymentId,
+ 121:         orderId,
+ 122:         creditAppliedInPaise: booking.pendingCreditAmountInPaise ?? 0,
+ 123:       },
+ 124:     });
+ 125:   } catch { /* never break the webhook ack */ }
+ 126: 
+ 127:   // Event-ID replay defense written AFTER successful markPaid so a transient
+ 128:   // Cosmos failure before this point does not permanently suppress Razorpay retries.
+ 129:   // Best-effort: non-409 Cosmos errors are logged but never block the webhook ack.
+ 130:   const eventId = req.headers.get('razorpay-event-id');
+ 131:   if (eventId) {
+ 132:     try {
+ 133:       await getWebhookEventsContainer().items.create({
+ 134:         id: eventId,
+ 135:         bookingId: booking.id,
+ 136:         processedAt: new Date().toISOString(),
+ 137:       });
+ 138:     } catch (err: unknown) {
+ 139:       if (
+ 140:         typeof err === 'object' && err !== null && 'code' in err &&
+ 141:         (err as { code: number }).code === 409
+ 142:       ) {
+ 143:         return { status: 200, jsonBody: { received: true, deduplicated: true } };
+ 144:       }
+ 145:       Sentry.captureException(err);
+ 146:     }
+ 147:   }
+ 148: 
+ 149:   const _ts = new Date().toISOString();
+ 150:   void appendAuditEntry({ id: randomUUID(), adminId: 'system', role: 'system', action: 'PAYMENT_CAPTURED', resourceType: 'booking', resourceId: booking.id, payload: { bookingId: booking.id, paymentId, orderId }, timestamp: _ts, partitionKey: _ts.slice(0, 7) }).catch(Sentry.captureException);
+ 151: 
+ 152:   dispatcherService.triggerDispatch(booking.id).catch(() => {
+ 153:     // fire-and-forget â€” dispatch failure does not fail the webhook ack
+ 154:   });
+ 155: 
+ 156:   return { status: 200, jsonBody: { received: true } };
+ 157: };
+ 158: 
+ 159: export async function reconcileStaleBookingsHandler(
+ 160:   _myTimer: Timer,
+ 161:   context: InvocationContext,
+ 162: ): Promise<void> {
+ 163:   const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+ 164:   const stale = await bookingRepo.getStaleSearching(cutoff);
+ 165:   for (const booking of stale) {
+ 166:     context.log(`STALE_BOOKING bookingId=${booking.id} createdAt=${booking.createdAt}`);
+ 167:   }
+ 168: }
+ 169: 
+ 170: app.http('razorpayWebhook', {
+ 171:   route: 'v1/webhooks/razorpay',
+ 172:   methods: ['POST'],
+ 173:   handler: razorpayWebhookHandler,
+ 174: });
+ 175: 
+ 176: app.timer('reconcileStaleBookings', {
+ 177:   schedule: '0 0 2 * * *',
+ 178:   handler: reconcileStaleBookingsHandler,
+ 179: });
+   1: import { randomUUID } from 'node:crypto';
+   2: import { getBookingsContainer } from './client.js';
+   3: import type { BookingDoc, CreateBookingRequest } from '../schemas/booking.js';
+   4: import type { PendingAddOn, AddOnDecision } from '../schemas/addon-approval.js';
+   5: import { normalizeAddressText } from '../shared/address-text.js';
+   6: 
+   7: function now() { return new Date().toISOString(); }
+   8: 
+   9: export interface BookingCreateMetadata {
+  10:   customerName?: string;
+  11:   customerPhone?: string;
+  12:   customerEmail?: string;
+  13:   serviceName?: string;
+  14: }
+  15: 
+  16: export interface BookingCreateCreditOptions {
+  17:   /**
+  18:    * E13-S01 (P1-6): When set, the wallet credit debit is DEFERRED to the Razorpay webhook.
+  19:    * Stored on the booking doc so the webhook can apply the credit after payment.captured.
+  20:    * Not applicable to CASH_ON_SERVICE bookings (those apply credit synchronously).
+  21:    */
+  22:   pendingCreditAmountInPaise?: number;
+  23:   /** Idempotency key for the deferred credit debit (required when pendingCreditAmountInPaise > 0). */
+  24:   pendingCreditIdempotencyKey?: string;
+  25: }
+  26: 
+  27: export const bookingRepo = {
+  28:   async createPending(
+  29:     req: CreateBookingRequest,
+  30:     customerId: string,
+  31:     paymentOrderId: string,
+  32:     amount: number,
+  33:     metadata: BookingCreateMetadata = {},
+  34:     bookingId?: string,
+  35:     creditOptions?: BookingCreateCreditOptions,
+  36:   ): Promise<BookingDoc> {
+  37:     const paymentMethod = req.paymentMethod ?? 'RAZORPAY';
+  38:     const doc: BookingDoc = {
+  39:       id: bookingId ?? randomUUID(), customerId, ...req,
+  40:       addressText: normalizeAddressText(req.addressText),
+  41:       ...(metadata.customerName ? { customerName: metadata.customerName } : {}),
+  42:       ...(metadata.customerPhone ? { customerPhone: metadata.customerPhone } : {}),
+  43:       ...(metadata.customerEmail ? { customerEmail: metadata.customerEmail } : {}),
+  44:       ...(metadata.serviceName ? { serviceName: metadata.serviceName } : {}),
+  45:       status: 'PENDING_PAYMENT', paymentOrderId,
+  46:       paymentMethod,
+  47:       ...(paymentMethod === 'CASH_ON_SERVICE' ? { cashCollectionStatus: 'PENDING' as const } : {}),
+  48:       paymentId: null, paymentSignature: null,
+  49:       amount, createdAt: now(),
+  50:       // E13-S01 (P1-6): Store pending credit info for deferred debit in webhook
+  51:       ...(creditOptions?.pendingCreditAmountInPaise && creditOptions.pendingCreditAmountInPaise > 0
+  52:         ? {
+  53:             pendingCreditAmountInPaise: creditOptions.pendingCreditAmountInPaise,
+  54:             pendingCreditIdempotencyKey: creditOptions.pendingCreditIdempotencyKey,
+  55:           }
+  56:         : {}),
+  57:     };
+  58:     const { resource } = await getBookingsContainer().items.create<BookingDoc>(doc);
+  59:     return resource!;
+  60:   },
+  61: 
+  62:   async getById(id: string): Promise<BookingDoc | null> {
+  63:     const { resource } = await getBookingsContainer().item(id, id).read<BookingDoc>();
+  64:     return resource ?? null;
+  65:   },
+  66: 
+  67:   async confirmPayment(
+  68:     id: string,
+  69:     paymentId: string,
+  70:     paymentSignature: string,
+  71:   ): Promise<BookingDoc | null> {
+  72:     const { resource: existing, etag } = await getBookingsContainer().item(id, id).read<BookingDoc>();
+  73:     if (!existing) return null;
+  74:     if (existing.status === 'PAID') return existing; // webhook already processed â€” idempotent success
+  75:     if (existing.status !== 'PENDING_PAYMENT') return null;
+  76:     const updated: BookingDoc = { ...existing, status: 'SEARCHING', paymentId, paymentSignature };
+  77:     const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+  78:     if (useEtag) {
+  79:       try {
+  80:         const { resource } = await getBookingsContainer()
+  81:           .item(id, id)
+  82:           .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+  83:         return resource ?? null;
+  84:       } catch (e: unknown) {
+  85:         if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: number }).code === 412) {
+  86:           return null; // lost ETag race â€” idempotent by design
+  87:         }
+  88:         throw e;
+  89:       }
+  90:     }
+  91:     const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+  92:     return resource!;
+  93:   },
+  94: 
+  95:   async getByPaymentOrderId(orderId: string): Promise<BookingDoc | null> {
+  96:     const { resources } = await getBookingsContainer()
+  97:       .items.query<BookingDoc>({
+  98:         query: 'SELECT * FROM c WHERE c.paymentOrderId = @orderId',
+  99:         parameters: [{ name: '@orderId', value: orderId }],
+ 100:       })
+ 101:       .fetchAll();
+ 102:     return resources[0] ?? null;
+ 103:   },
+ 104: 
+ 105:   async markPaid(id: string, paymentId: string): Promise<BookingDoc | null> {
+ 106:     const { resource: existing, etag } = await getBookingsContainer().item(id, id).read<BookingDoc>();
+ 107:     if (!existing || (existing.status !== 'SEARCHING' && existing.status !== 'PENDING_PAYMENT')) return null;
+ 108:     const updated: BookingDoc = { ...existing, status: 'PAID', paymentId };
+ 109:     const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+ 110:     if (useEtag) {
+ 111:       try {
+ 112:         const { resource } = await getBookingsContainer()
+ 113:           .item(id, id)
+ 114:           .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+ 115:         return resource ?? null;
+ 116:       } catch (e: unknown) {
+ 117:         if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: number }).code === 412) {
+ 118:           return null; // lost ETag race â€” idempotent by design
+ 119:         }
+ 120:         throw e;
+ 121:       }
+ 122:     }
+ 123:     const { resource } = await getBookingsContainer().item(id, id).replace<BookingDoc>(updated);
+ 124:     return resource!;
+ 125:   },
+ 126: 
+ 127:   async getStaleSearching(olderThanIso: string): Promise<BookingDoc[]> {
+ 128:     const { resources } = await getBookingsContainer().items.query<BookingDoc>({
+ 129:       query: "SELECT * FROM c WHERE c.status = 'SEARCHING' AND c.createdAt < @cutoff",
+ 130:       parameters: [{ name: '@cutoff', value: olderThanIso }],
+ 131:     }).fetchAll();
+ 132:     return resources;
+ 133:   },
+ 134: 
+ 135:   async getBookingsAwaitingDispatch(limit = 100): Promise<BookingDoc[]> {
+ 136:     const { resources } = await getBookingsContainer().items.query<BookingDoc>({
+ 137:       query: `SELECT * FROM c
+ 138:               WHERE c.status IN ('PAID', 'UNFULFILLED')
+ 139:                 AND (NOT IS_DEFINED(c.technicianId) OR IS_NULL(c.technicianId))`,
+ 140:       parameters: [],
+ 141:     }).fetchAll();
+ 142:     return resources.slice(0, limit);
+ 143:   },
+ 144: 
+ 145:   async getAssignedBookingsBefore(slotDateCutoff: string): Promise<BookingDoc[]> {
+ 146:     const { resources } = await getBookingsContainer()
+ 147:       .items.query<BookingDoc>({
+ 148:         query: "SELECT * FROM c WHERE (c.status IN ('ASSIGNED', 'NO_SHOW_REDISPATCH') OR (c.status = 'SEARCHING' AND IS_DEFINED(c.noShowTechnicianId))) AND c.slotDate <= @slotDate",
+ 149:         parameters: [{ name: '@slotDate', value: slotDateCutoff }],
+ 150:       })
+ 151:       .fetchAll();
+ 152:     return resources;
+ 153:   },
+ 154: 
+ 155:   async getByTechnicianId(technicianId: string): Promise<BookingDoc[]> {
+ 156:     const { resources } = await getBookingsContainer()
+ 157:       .items.query<BookingDoc>({
+ 158:         query: `SELECT * FROM c
+ 159:                 WHERE c.technicianId = @technicianId
+ 160:                   AND c.status IN (
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/schemas/booking.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 140' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 614ms:
+   1: import { z } from 'zod';
+   2: import { PendingAddOnSchema } from './addon-approval.js';
+   3: 
+   4: const BOOKING_STATUSES = [
+   5:   'PENDING_PAYMENT', 'SEARCHING', 'ASSIGNED', 'EN_ROUTE',
+   6:   'REACHED', 'IN_PROGRESS', 'AWAITING_PRICE_APPROVAL', 'COMPLETED', 'PAID', 'CLOSED',
+   7:   'UNFULFILLED', 'CUSTOMER_CANCELLED', 'NO_SHOW_REDISPATCH',
+   8: ] as const;
+   9: 
+  10: const PAYMENT_METHODS = ['RAZORPAY', 'CASH_ON_SERVICE'] as const;
+  11: const CASH_COLLECTION_STATUSES = ['PENDING', 'COLLECTED'] as const;
+  12: 
+  13: export const LatLngSchema = z.object({
+  14:   lat: z.number().min(-90).max(90),
+  15:   lng: z.number().min(-180).max(180),
+  16: });
+  17: export const PaymentMethodSchema = z.enum(PAYMENT_METHODS);
+  18: export const CashCollectionStatusSchema = z.enum(CASH_COLLECTION_STATUSES);
+  19: 
+  20: export const BookingDocSchema = z.object({
+  21:   id: z.string(),
+  22:   customerId: z.string(),
+  23:   customerName: z.string().optional(),
+  24:   customerPhone: z.string().optional(),
+  25:   customerEmail: z.string().optional(),
+  26:   serviceId: z.string(),
+  27:   serviceName: z.string().optional(),
+  28:   categoryId: z.string(),
+  29:   slotDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  30:   slotWindow: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  31:   addressText: z.string().min(1),
+  32:   addressLatLng: LatLngSchema,
+  33:   status: z.enum(BOOKING_STATUSES),
+  34:   paymentOrderId: z.string(),
+  35:   paymentMethod: PaymentMethodSchema.optional(),
+  36:   cashCollectionStatus: CashCollectionStatusSchema.optional(),
+  37:   paymentId: z.string().nullable(),
+  38:   paymentSignature: z.string().nullable(),
+  39:   amount: z.number().int().positive(),
+  40:   technicianId: z.string().optional(),
+  41:   createdAt: z.string(),
+  42:   completedAt: z.string().optional(),
+  43:   feesWaived: z.boolean().optional(),
+  44:   escalated: z.boolean().optional(),
+  45:   internalNotes: z.array(z.string()).optional(),
+  46:   photos: z.record(z.string(), z.array(z.string())).optional(),
+  47:   pendingAddOns: z.array(PendingAddOnSchema).optional(),
+  48:   approvedAddOns: z.array(PendingAddOnSchema).optional(),
+  49:   finalAmount: z.number().int().positive().optional(),
+  50:   /** ISO timestamp written atomically after redispatch offers are sent successfully. */
+  51:   noShowRedispatchAt: z.string().optional(),
+  52:   /** The technician who no-showed. Preserved separately so the exclusion filter works across timer recovery runs even after technicianId is cleared. */
+  53:   noShowTechnicianId: z.string().optional(),
+  54:   /** ISO timestamp written after the NO_SHOW_CREDIT_ISSUED FCM push is sent successfully. Prevents duplicate pushes across recovery runs. */
+  55:   noShowPushSentAt: z.string().optional(),
+  56:   /** ISO timestamp written when customer triggers Safety SOS. */
+  57:   sosActivatedAt: z.string().optional(),
+  58:   /** ISO timestamp written after sendOwnerSosAlert() succeeds. Absent = alert pending retry. */
+  59:   sosAlertSentAt: z.string().optional(),
+  60:   /**
+  61:    * ISO timestamp written atomically when the booking transitions to AWAITING_PRICE_APPROVAL
+  62:    * (i.e. when the technician requests an add-on). Used by the bookings change-feed projector
+  63:    * to anchor the ADDON_APPROVAL_REQUESTED expiresAt from the actual request time, not from
+  64:    * the booking's original createdAt (which may be >24h in the past for advance bookings).
+  65:    */
+  66:   pendingAddOnsUpdatedAt: z.string().optional(),
+  67:   /**
+  68:    * E13-S01 (P1-6): Wallet credit amount in paise that is PENDING debit for a Razorpay booking.
+  69:    * Written at booking creation time (before Razorpay order); deducted from the ledger only
+  70:    * after payment.captured is received from the Razorpay webhook. Absent = no credit pending.
+  71:    * Once the webhook debits the credit, this field should be removed (or left as a historical record).
+  72:    */
+  73:   pendingCreditAmountInPaise: z.number().int().nonnegative().optional(),
+  74:   /**
+  75:    * E13-S01 (P1-6): Idempotency key for the pending credit debit above.
+  76:    * Stored so the webhook can call applyCredit idempotently on re-delivery.
+  77:    */
+  78:   pendingCreditIdempotencyKey: z.string().optional(),
+  79: });
+  80: 
+  81: export const CreateBookingRequestSchema = z.object({
+  82:   serviceId: z.string().min(1),
+  83:   categoryId: z.string().min(1),
+  84:   slotDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  85:   slotWindow: z.string().regex(/^\d{2}:\d{2}-\d{2}:\d{2}$/),
+  86:   addressText: z.string().min(1),
+  87:   addressLatLng: LatLngSchema,
+  88:   paymentMethod: PaymentMethodSchema.default('RAZORPAY'),
+  89:   /**
+  90:    * E13-S01: If true, the server will attempt to apply the customer's wallet
+  91:    * credit balance against this booking's amount. The actual applied amount is
+  92:    * returned as `appliedCreditAmount` in the response (may be 0 if no balance).
+  93:    * Requires an `Idempotency-Key: <uuid>` header for replay protection.
+  94:    */
+  95:   applyCredit: z.boolean().optional().default(false),
+  96: });
+  97: 
+  98: export const ConfirmBookingRequestSchema = z.object({
+  99:   razorpayPaymentId: z.string().min(1),
+ 100:   razorpayOrderId: z.string().min(1),
+ 101:   razorpaySignature: z.string().min(1),
+ 102: });
+ 103: 
+ 104: export type BookingDoc = z.infer<typeof BookingDocSchema>;
+ 105: export type CreateBookingRequest = z.infer<typeof CreateBookingRequestSchema>;
+ 106: export type ConfirmBookingRequest = z.infer<typeof ConfirmBookingRequestSchema>;
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Select-String -Path api/openapi.json -Pattern "availability|servicesAvailability|v1/services" -Context 2,4 | Select-Object -First 80' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 1357ms:
+
+  api\openapi.json:1736:      }
+  api\openapi.json:1737:    },
+> api\openapi.json:1738:    "/v1/services/{id}": {
+  api\openapi.json:1739:      "get": {
+  api\openapi.json:1740:        "operationId": "getServiceById",
+  api\openapi.json:1741:        "tags": [
+  api\openapi.json:1742:          "catalogue"
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Select-String -Path api/src/openapi/registry.ts -Pattern "service|availability|booking" -Context 1,3 | Select-Object -First 120' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 636ms:
+
+  api\src\openapi\registry.ts:6:  DashboardSummaryResponseSchema,
+> api\src\openapi\registry.ts:7:  BookingEventSchema,
+> api\src\openapi\registry.ts:8:  BookingEventsResponseSchema,
+  api\src\openapi\registry.ts:9:  TechLocationSchema,
+  api\src\openapi\registry.ts:10:  TechLocationsResponseSchema,
+  api\src\openapi\registry.ts:11:} from '../schemas/dashboard.js';
+  api\src\openapi\registry.ts:12:import {
+> api\src\openapi\registry.ts:13:  ServiceCategorySchema,
+  api\src\openapi\registry.ts:14:  CreateCategoryBodySchema,
+  api\src\openapi\registry.ts:15:  UpdateCategoryBodySchema,
+> api\src\openapi\registry.ts:16:} from '../schemas/service-category.js';
+  api\src\openapi\registry.ts:17:import {
+> api\src\openapi\registry.ts:18:  ServiceDetailSchema,
+> api\src\openapi\registry.ts:19:  ServiceCardSchema,
+> api\src\openapi\registry.ts:20:  CreateServiceBodySchema,
+> api\src\openapi\registry.ts:21:  UpdateServiceBodySchema,
+> api\src\openapi\registry.ts:22:  ServiceSchema,
+> api\src\openapi\registry.ts:23:} from '../schemas/service.js';
+  api\src\openapi\registry.ts:24:import {
+  api\src\openapi\registry.ts:25:  ComplaintDocSchema,
+  api\src\openapi\registry.ts:26:  CreateComplaintBodySchema,
+  api\src\openapi\registry.ts:100:    200: {
+> api\src\openapi\registry.ts:101:      description: 'Service is live',
+  api\src\openapi\registry.ts:102:      content: {
+  api\src\openapi\registry.ts:103:        'application/json': { schema: HealthResponse },
+  api\src\openapi\registry.ts:104:      },
+  api\src\openapi\registry.ts:113:registry.register('DashboardSummaryResponse', DashboardSummaryResponseSchema);
+> api\src\openapi\registry.ts:114:registry.register('BookingEvent', BookingEventSchema);
+> api\src\openapi\registry.ts:115:registry.register('BookingEventsResponse', BookingEventsResponseSchema);
+  api\src\openapi\registry.ts:116:registry.register('TechLocation', TechLocationSchema);
+  api\src\openapi\registry.ts:117:registry.register('TechLocationsResponse', TechLocationsResponseSchema);
+  api\src\openapi\registry.ts:118:
+  api\src\openapi\registry.ts:139:  security: [{ cookieAuth: [] }],
+> api\src\openapi\registry.ts:140:  summary: 'Recent 50 booking events, newest first',
+  api\src\openapi\registry.ts:141:  responses: {
+> api\src\openapi\registry.ts:142:    200: { description: 'Booking events feed', content: { 'application/json': { 
+schema: BookingEventsResponseSchema } } },
+  api\src\openapi\registry.ts:143:    401: { description: 'Unauthenticated' },
+  api\src\openapi\registry.ts:144:    403: { description: 'Forbidden' },
+  api\src\openapi\registry.ts:145:    502: { description: 'Upstream Cosmos error' },
+  api\src\openapi\registry.ts:165:
+> api\src\openapi\registry.ts:166:const ServiceCardResponse = ServiceCardSchema.openapi('ServiceCard');
+> api\src\openapi\registry.ts:167:const ServiceDetailResponse = ServiceDetailSchema.openapi('ServiceDetail');
+> api\src\openapi\registry.ts:168:const CategoryWithServicesSchema = z.object({
+  api\src\openapi\registry.ts:169:  id: z.string(),
+  api\src\openapi\registry.ts:170:  name: z.string(),
+  api\src\openapi\registry.ts:171:  heroImageUrl: z.string(),
+  api\src\openapi\registry.ts:172:  sortOrder: z.number(),
+> api\src\openapi\registry.ts:173:  services: z.array(ServiceCardResponse),
+> api\src\openapi\registry.ts:174:}).openapi('CategoryWithServices');
+  api\src\openapi\registry.ts:175:
+> api\src\openapi\registry.ts:176:registry.register('ServiceCard', ServiceCardResponse);
+> api\src\openapi\registry.ts:177:registry.register('ServiceDetail', ServiceDetailResponse);
+> api\src\openapi\registry.ts:178:registry.register('CategoryWithServices', CategoryWithServicesSchema);
+  api\src\openapi\registry.ts:179:
+  api\src\openapi\registry.ts:180:registry.registerPath({
+  api\src\openapi\registry.ts:181:  method: 'get', path: '/v1/categories', operationId: 'getCategories',
+> api\src\openapi\registry.ts:182:  tags: ['catalogue'], summary: 'List active categories with nested services (home 
+screen)',
+  api\src\openapi\registry.ts:183:  responses: {
+> api\src\openapi\registry.ts:184:    200: { description: 'Active categories with card-shape services', content: { 
+'application/json': { schema: z.object({ categories: z.array(CategoryWithServicesSchema) }) } } },
+  api\src\openapi\registry.ts:185:  },
+  api\src\openapi\registry.ts:186:});
+  api\src\openapi\registry.ts:187:
+  api\src\openapi\registry.ts:188:registry.registerPath({
+> api\src\openapi\registry.ts:189:  method: 'get', path: '/v1/services/{id}', operationId: 'getServiceById',
+> api\src\openapi\registry.ts:190:  tags: ['catalogue'], summary: 'Full service detail',
+  api\src\openapi\registry.ts:191:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+  api\src\openapi\registry.ts:192:  responses: {
+> api\src\openapi\registry.ts:193:    200: { description: 'Service detail', content: { 'application/json': { schema: 
+ServiceDetailResponse } } },
+> api\src\openapi\registry.ts:194:    404: { description: 'Service not found' },
+  api\src\openapi\registry.ts:195:  },
+  api\src\openapi\registry.ts:196:});
+  api\src\openapi\registry.ts:197:
+  api\src\openapi\registry.ts:199:
+> api\src\openapi\registry.ts:200:const AdminServiceCategory = ServiceCategorySchema.openapi('AdminServiceCategory');
+> api\src\openapi\registry.ts:201:const AdminService = ServiceSchema.openapi('AdminService');
+> api\src\openapi\registry.ts:202:registry.register('AdminServiceCategory', AdminServiceCategory);
+> api\src\openapi\registry.ts:203:registry.register('AdminService', AdminService);
+  api\src\openapi\registry.ts:204:
+  api\src\openapi\registry.ts:205:registry.registerPath({
+  api\src\openapi\registry.ts:206:  method: 'get', path: '/v1/admin/catalogue/categories', operationId: 
+'adminListCategories',
+> api\src\openapi\registry.ts:207:  tags: ['admin-catalogue'], summary: 'List service categories (admin, includes 
+inactive)',
+  api\src\openapi\registry.ts:208:  security: [{ cookieAuth: [] }],
+  api\src\openapi\registry.ts:209:  responses: {
+> api\src\openapi\registry.ts:210:    200: { description: 'Categories list', content: { 'application/json': { schema: 
+z.object({ categories: z.array(AdminServiceCategory) }) } } },
+  api\src\openapi\registry.ts:211:    401: { description: 'Unauthenticated' },
+  api\src\openapi\registry.ts:212:    403: { description: 'Forbidden' },
+  api\src\openapi\registry.ts:213:  },
+  api\src\openapi\registry.ts:217:  method: 'get', path: '/v1/admin/catalogue/categories/{id}', operationId: 
+'adminGetCategory',
+> api\src\openapi\registry.ts:218:  tags: ['admin-catalogue'], summary: 'Get a service category',
+  api\src\openapi\registry.ts:219:  security: [{ cookieAuth: [] }],
+  api\src\openapi\registry.ts:220:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+  api\src\openapi\registry.ts:221:  responses: {
+> api\src\openapi\registry.ts:222:    200: { description: 'Category', content: { 'application/json': { schema: 
+AdminServiceCategory } } },
+  api\src\openapi\registry.ts:223:    401: { description: 'Unauthenticated' },
+  api\src\openapi\registry.ts:224:    403: { description: 'Forbidden' },
+  api\src\openapi\registry.ts:225:    404: { description: 'Not found' },
+  api\src\openapi\registry.ts:230:  method: 'post', path: '/v1/admin/catalogue/categories', operationId: 
+'adminCreateCategory',
+> api\src\openapi\registry.ts:231:  tags: ['admin-catalogue'], summary: 'Create a service category',
+  api\src\openapi\registry.ts:232:  request: { body: { content: { 'application/json': { schema: 
+CreateCategoryBodySchema } } } },
+> api\src\openapi\registry.ts:233:  responses: { 201: { description: 'Created', content: { 'application/json': { 
+schema: AdminServiceCategory } } }, 400: { description: 'Validation error' }, 409: { description: 'Duplicate id' } },
+  api\src\openapi\registry.ts:234:});
+  api\src\openapi\registry.ts:235:
+  api\src\openapi\registry.ts:236:registry.registerPath({
+  api\src\openapi\registry.ts:237:  method: 'put', path: '/v1/admin/catalogue/categories/{id}', operationId: 
+'adminUpdateCategory',
+> api\src\openapi\registry.ts:238:  tags: ['admin-catalogue'], summary: 'Update a service category',
+  api\src\openapi\registry.ts:239:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+  api\src\openapi\registry.ts:240:  request: { body: { content: { 'application/json': { schema: 
+UpdateCategoryBodySchema } } } },
+> api\src\openapi\registry.ts:241:  responses: { 200: { description: 'Updated', content: { 'application/json': { 
+schema: AdminServiceCategory } } }, 404: { description: 'Not found' } },
+  api\src\openapi\registry.ts:242:});
+  api\src\openapi\registry.ts:243:
+  api\src\openapi\registry.ts:244:registry.registerPath({
+  api\src\openapi\registry.ts:247:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+> api\src\openapi\registry.ts:248:  responses: { 200: { description: 'Toggled', content: { 'application/json': { 
+schema: AdminServiceCategory } } }, 404: { description: 'Not found' } },
+  api\src\openapi\registry.ts:249:});
+  api\src\openapi\registry.ts:250:
+  api\src\openapi\registry.ts:251:registry.registerPath({
+> api\src\openapi\registry.ts:252:  method: 'get', path: '/v1/admin/catalogue/services', operationId: 
+'adminListServices',
+> api\src\openapi\registry.ts:253:  tags: ['admin-catalogue'], summary: 'List services (admin, includes inactive)',
+  api\src\openapi\registry.ts:254:  parameters: [{ name: 'categoryId', in: 'query', required: false, schema: { type: 
+'string' } }],
+> api\src\openapi\registry.ts:255:  responses: { 200: { description: 'Services list', content: { 'application/json': { 
+schema: z.object({ services: z.array(AdminService) }) } } } },
+  api\src\openapi\registry.ts:256:});
+  api\src\openapi\registry.ts:257:
+  api\src\openapi\registry.ts:258:registry.registerPath({
+> api\src\openapi\registry.ts:259:  method: 'get', path: '/v1/admin/catalogue/services/{id}', operationId: 
+'adminGetService',
+> api\src\openapi\registry.ts:260:  tags: ['admin-catalogue'], summary: 'Get a service',
+  api\src\openapi\registry.ts:261:  security: [{ cookieAuth: [] }],
+  api\src\openapi\registry.ts:262:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+  api\src\openapi\registry.ts:263:  responses: {
+> api\src\openapi\registry.ts:264:    200: { description: 'Service', content: { 'application/json': { schema: 
+AdminService } } },
+  api\src\openapi\registry.ts:265:    401: { description: 'Unauthenticated' },
+  api\src\openapi\registry.ts:266:    403: { description: 'Forbidden' },
+  api\src\openapi\registry.ts:267:    404: { description: 'Not found' },
+  api\src\openapi\registry.ts:271:registry.registerPath({
+> api\src\openapi\registry.ts:272:  method: 'post', path: '/v1/admin/catalogue/services', operationId: 
+'adminCreateService',
+> api\src\openapi\registry.ts:273:  tags: ['admin-catalogue'], summary: 'Create a service',
+> api\src\openapi\registry.ts:274:  request: { body: { content: { 'application/json': { schema: 
+CreateServiceBodySchema } } } },
+> api\src\openapi\registry.ts:275:  responses: { 201: { description: 'Created', content: { 'application/json': { 
+schema: AdminService } } }, 400: { description: 'Validation error' }, 409: { description: 'Duplicate id' } },
+  api\src\openapi\registry.ts:276:});
+  api\src\openapi\registry.ts:277:
+  api\src\openapi\registry.ts:278:registry.registerPath({
+> api\src\openapi\registry.ts:279:  method: 'put', path: '/v1/admin/catalogue/services/{id}', operationId: 
+'adminUpdateService',
+> api\src\openapi\registry.ts:280:  tags: ['admin-catalogue'], summary: 'Update a service',
+  api\src\openapi\registry.ts:281:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+> api\src\openapi\registry.ts:282:  request: { body: { content: { 'application/json': { schema: 
+UpdateServiceBodySchema } } } },
+> api\src\openapi\registry.ts:283:  responses: { 200: { description: 'Updated', content: { 'application/json': { 
+schema: AdminService } } }, 404: { description: 'Not found' } },
+  api\src\openapi\registry.ts:284:});
+  api\src\openapi\registry.ts:285:
+  api\src\openapi\registry.ts:286:registry.registerPath({
+> api\src\openapi\registry.ts:287:  method: 'patch', path: '/v1/admin/catalogue/services/{id}/toggle', operationId: 
+'adminToggleService',
+> api\src\openapi\registry.ts:288:  tags: ['admin-catalogue'], summary: 'Toggle service active state',
+  api\src\openapi\registry.ts:289:  parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } 
+}],
+> api\src\openapi\registry.ts:290:  responses: { 200: { description: 'Toggled', content: { 'application/json': { 
+schema: AdminService } } }, 404: { description: 'Not found' } },
+  api\src\openapi\registry.ts:291:});
+  api\src\openapi\registry.ts:292:
+  api\src\openapi\registry.ts:293:registry.registerPath({
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/package.json; Get-ChildItem api/src/functions | Select-Object Name' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 563ms:
+{
+  "name": "homeservices-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@9.15.4",
+  "main": "dist/functions/**/*.js",
+  "engines": {
+    "node": ">=22.0.0",
+    "pnpm": ">=9.0.0"
+  },
+  "scripts": {
+    "dev": "pnpm build && func start",
+    "dev:direct": "pnpm build && func start",
+    "dev:watch": "tsc --watch",
+    "build": "tsc",
+    "start": "func start",
+    "typecheck": "tsc --noEmit -p tsconfig.tests.json",
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "openapi:build": "tsx src/openapi/build.ts",
+    "openapi:lint": "spectral lint openapi.json --fail-severity error",
+    "seed:admin": "tsx scripts/seed-admin.ts",
+    "invite:admin": "tsx scripts/invite-admin.ts",
+    "seed:technicians": "npx tsx scripts/seed-technicians.ts",
+    "seed:catalogue": "tsx src/cosmos/seeds/catalogue.ts",
+    "seed:complaints": "tsx src/cosmos/seeds/complaints.ts",
+    "provision:indexes": "tsx scripts/provision-cosmos-indexes.ts"
+  },
+  "dependencies": {
+    "@azure/ai-form-recognizer": "^5.1.0",
+    "@azure/communication-email": "^1.1.0",
+    "@azure/cosmos": "^4.9.2",
+    "@azure/functions": "^4.5.0",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
+    "@growthbook/growthbook": "^1",
+    "@opentelemetry/resources": "^1",
+    "@opentelemetry/sdk-node": "^0.57",
+    "@sentry/node": "^8",
+    "@turf/boolean-point-in-polygon": "^7.3.5",
+    "@turf/helpers": "^7.3.5",
+    "fastify": "^5",
+    "firebase-admin": "^13.8.0",
+    "jose": "^6.2.2",
+    "otplib": "^13.4.0",
+    "pdfkit": "^0.18.0",
+    "posthog-node": "^4",
+    "qrcode": "^1.5.4",
+    "razorpay": "^2.9.6",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@apidevtools/swagger-parser": "^10.1.0",
+    "@asteasolutions/zod-to-openapi": "^7.3.0",
+    "@stoplight/spectral-cli": "^6.11.0",
+    "@types/geojson": "^7946.0.16",
+    "@types/node": "^22",
+    "@types/pdfkit": "^0.17.6",
+    "@types/qrcode": "^1.5.6",
+    "@vitest/coverage-v8": "^2",
+    "eslint": "^9",
+    "eslint-plugin-import": "^2",
+    "prettier": "^3",
+    "supertest": "^7",
+    "testcontainers": "^10",
+    "tsx": "^4",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8",
+    "vitest": "^2"
+  }
+}
+
+Name                                  
+----                                  
+admin                                 
+auth                                  
+complaints                            
+integrity                             
+kyc                                   
+active-job-photos.ts                  
+active-job.ts                         
+bookings.ts                           
+catalogue-admin.ts                    
+catalogue-public.ts                   
+earnings.ts                           
+health.ts                             
+job-offers.ts                         
+payout-cadence.ts                     
+pending-actions.ts                    
+rating-appeal.ts                      
+rating-escalate.ts                    
+ratings.ts                            
+services-availability.ts              
+shield-report.ts                      
+sos.ts                                
+tech-ratings.ts                       
+technician-bookings.ts                
+technician-dashboard.ts               
+technicians.ts                        
+trigger-booking-completed.ts          
+trigger-dispatch-retry.ts             
+trigger-erasure-deadline.ts           
+trigger-next-day-payout.ts            
+trigger-no-show-detector.ts           
+trigger-projector-bookings.ts         
+trigger-projector-complaints.ts       
+trigger-projector-dispatch-attempts.ts
+trigger-projector-kyc.ts              
+trigger-projector-ratings.ts          
+trigger-rating-prompt.ts              
+trigger-reconcile-payouts.ts          
+trigger-service-report.ts             
+users-data-export.ts                  
+users-erasure-request.ts              
+wallet.ts                             
+webhooks.ts                           
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Select-String -Path api/src/**/*.ts -Pattern \"statusCode\\?|\\.statusCode|code === 409|code === 412\" | Select-Object -First 200" in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 671ms:
+
+api\src\cosmos\booking-repository.ts:85:        if (typeof e === 'object' && e !== null && 'code' in e && (e as { 
+code: number }).code === 412) {
+api\src\cosmos\booking-repository.ts:117:        if (typeof e === 'object' && e !== null && 'code' in e && (e as { 
+code: number }).code === 412) {
+api\src\cosmos\booking-repository.ts:259:      if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: 
+number }).code === 412) {
+api\src\cosmos\customer-credit-ledger-repository.ts:333:      if ((err as { code?: number }).code === 409) {
+api\src\cosmos\customer-credit-ledger-repository.ts:410:      if ((idemErr as { code?: number }).code === 409) {
+api\src\cosmos\customer-credit-ledger-repository.ts:563:        if ((code === 412 || code === 409) && attempt < 
+MAX_CONCURRENCY_RETRIES - 1) {
+api\src\cosmos\customer-credit-repository.ts:11:      if ((err as { code?: number }).code === 409) return false;
+api\src\cosmos\dispatch-attempt-repository.ts:87:  return typeof err === 'object' && err !== null && (err as { code?: 
+unknown }).code === 412;
+api\src\cosmos\erasure-request-repository.ts:21:    (err as { statusCode: number }).statusCode === 409
+api\src\cosmos\pending-action-repository.ts:90:    (err as { code?: unknown }).code === 412
+api\src\cosmos\rate-limit-repository.ts:135:    (err as { code: number }).code === 412
+api\src\cosmos\slot-holds-repository.ts:37:      const code = (err as { statusCode?: number }).statusCode;
+api\src\cosmos\slot-holds-repository.ts:38:      if (code === 409 || code === 412) return 'CONFLICT';
+api\src\cosmos\slot-holds-repository.ts:56:      const code = (err as { statusCode?: number }).statusCode;
+api\src\cosmos\technician-repository.ts:335:      if ((err as { code?: number }).code === 412 && attempt < maxRetries 
+- 1) {
+api\src\cosmos\technician-repository.ts:363:      if ((err as { code?: number }).code === 412 && attempt < maxRetries 
+- 1) {
+api\src\cosmos\technician-repository.ts:406:      if ((err as { code?: number }).code === 412 && attempt < maxRetries 
+- 1) continue;
+api\src\cosmos\wallet-ledger-repository.ts:33:      if ((err as { code?: number }).code === 409) return false;
+api\src\functions\active-job-photos.ts:91:    if (typeof err === 'object' && err !== null && 'code' in err && (err as 
+{ code: number }).code === 412) {
+api\src\functions\bookings.ts:85:    if (code === 412) {
+api\src\functions\rating-appeal.ts:84:    if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: 
+number }).code === 409) {
+api\src\functions\rating-escalate.ts:94:      if (code === 409) return { status: 409, jsonBody: { code: 
+'SHIELD_ALREADY_ESCALATED' } };
+api\src\functions\shield-report.ts:86:    if (typeof err === 'object' && err !== null && 'code' in err && (err as { 
+code: number }).code === 409) {
+api\src\functions\webhooks.ts:141:        (err as { code: number }).code === 409
+api\src\services\formRecognizer.service.ts:29:    const statusCode = (err as { statusCode?: number }).statusCode;
+api\src\shared\cosmos-errors.ts:27:  const code = (err as { code?: unknown; statusCode?: unknown }).code
+api\src\shared\cosmos-errors.ts:28:    ?? (err as { code?: unknown; statusCode?: unknown }).statusCode;
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Select-String -Path api/node_modules/@azure/cosmos/dist/**/*.d.ts -Pattern "interface ErrorResponse|class ErrorResponse|statusCode|code" -ErrorAction SilentlyContinue | Select-Object -First 80' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 647ms:
+
+api\node_modules\@azure\cosmos\dist\browser\ChangeFeedIterator.d.ts:17:    private lastStatusCode;
+api\node_modules\@azure\cosmos\dist\browser\ChangeFeedResponse.d.ts:16:     * Gets the status code of the response 
+from Azure Cosmos DB
+api\node_modules\@azure\cosmos\dist\browser\ChangeFeedResponse.d.ts:18:    readonly statusCode: number;
+api\node_modules\@azure\cosmos\dist\browser\CosmosDiagnostics.d.ts:112:    statusCode?: number;
+api\node_modules\@azure\cosmos\dist\browser\CosmosDiagnostics.d.ts:113:    subStatusCode?: number;
+api\node_modules\@azure\cosmos\dist\browser\CosmosDiagnostics.d.ts:141:    statusCode: number;
+api\node_modules\@azure\cosmos\dist\browser\CosmosDiagnostics.d.ts:142:    substatusCode?: number;
+api\node_modules\@azure\cosmos\dist\browser\index.d.ts:2:export { StatusCodes, type StatusCodesType, type 
+PartitionKeyRangePropertiesNames, } from "./common/index.js";
+api\node_modules\@azure\cosmos\dist\browser\queryIterator.d.ts:34:     * use polyfils/etc. in order to use them in 
+your code.
+api\node_modules\@azure\cosmos\dist\commonjs\ChangeFeedIterator.d.ts:17:    private lastStatusCode;
+api\node_modules\@azure\cosmos\dist\commonjs\ChangeFeedResponse.d.ts:16:     * Gets the status code of the response 
+from Azure Cosmos DB
+api\node_modules\@azure\cosmos\dist\commonjs\ChangeFeedResponse.d.ts:18:    readonly statusCode: number;
+api\node_modules\@azure\cosmos\dist\commonjs\CosmosDiagnostics.d.ts:112:    statusCode?: number;
+api\node_modules\@azure\cosmos\dist\commonjs\CosmosDiagnostics.d.ts:113:    subStatusCode?: number;
+api\node_modules\@azure\cosmos\dist\commonjs\CosmosDiagnostics.d.ts:141:    statusCode: number;
+api\node_modules\@azure\cosmos\dist\commonjs\CosmosDiagnostics.d.ts:142:    substatusCode?: number;
+api\node_modules\@azure\cosmos\dist\commonjs\index.d.ts:2:export { StatusCodes, type StatusCodesType, type 
+PartitionKeyRangePropertiesNames, } from "./common/index.js";
+api\node_modules\@azure\cosmos\dist\commonjs\queryIterator.d.ts:34:     * use polyfils/etc. in order to use them in 
+your code.
+api\node_modules\@azure\cosmos\dist\esm\ChangeFeedIterator.d.ts:17:    private lastStatusCode;
+api\node_modules\@azure\cosmos\dist\esm\ChangeFeedResponse.d.ts:16:     * Gets the status code of the response from 
+Azure Cosmos DB
+api\node_modules\@azure\cosmos\dist\esm\ChangeFeedResponse.d.ts:18:    readonly statusCode: number;
+api\node_modules\@azure\cosmos\dist\esm\CosmosDiagnostics.d.ts:112:    statusCode?: number;
+api\node_modules\@azure\cosmos\dist\esm\CosmosDiagnostics.d.ts:113:    subStatusCode?: number;
+api\node_modules\@azure\cosmos\dist\esm\CosmosDiagnostics.d.ts:141:    statusCode: number;
+api\node_modules\@azure\cosmos\dist\esm\CosmosDiagnostics.d.ts:142:    substatusCode?: number;
+api\node_modules\@azure\cosmos\dist\esm\index.d.ts:2:export { StatusCodes, type StatusCodesType, type 
+PartitionKeyRangePropertiesNames, } from "./common/index.js";
+api\node_modules\@azure\cosmos\dist\esm\queryIterator.d.ts:34:     * use polyfils/etc. in order to use them in your 
+code.
+api\node_modules\@azure\cosmos\dist\react-native\ChangeFeedIterator.d.ts:17:    private lastStatusCode;
+api\node_modules\@azure\cosmos\dist\react-native\ChangeFeedResponse.d.ts:16:     * Gets the status code of the 
+response from Azure Cosmos DB
+api\node_modules\@azure\cosmos\dist\react-native\ChangeFeedResponse.d.ts:18:    readonly statusCode: number;
+api\node_modules\@azure\cosmos\dist\react-native\CosmosDiagnostics.d.ts:112:    statusCode?: number;
+api\node_modules\@azure\cosmos\dist\react-native\CosmosDiagnostics.d.ts:113:    subStatusCode?: number;
+api\node_modules\@azure\cosmos\dist\react-native\CosmosDiagnostics.d.ts:141:    statusCode: number;
+api\node_modules\@azure\cosmos\dist\react-native\CosmosDiagnostics.d.ts:142:    substatusCode?: number;
+api\node_modules\@azure\cosmos\dist\react-native\index.d.ts:2:export { StatusCodes, type StatusCodesType, type 
+PartitionKeyRangePropertiesNames, } from "./common/index.js";
+api\node_modules\@azure\cosmos\dist\react-native\queryIterator.d.ts:34:     * use polyfils/etc. in order to use them 
+in your code.
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command "Get-ChildItem api/node_modules/@azure/cosmos/dist/esm -Recurse -Filter \"*Error*\" | Select-Object FullName | Select-Object -First 20; Select-String -Path api/node_modules/@azure/cosmos/dist/esm/**/*.d.ts -Pattern \"ErrorResponse|CosmosClientOptions|code\\?:\" | Select-Object -First 100" in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 820ms:
+
+FullName                                                                                                      
+--------                                                                                                      
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\ErrorResponse.d.ts    
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\ErrorResponse.d.ts.map
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\ErrorResponse.js      
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\ErrorResponse.js.map  
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\TimeoutError.d.ts     
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\TimeoutError.d.ts.map 
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\TimeoutError.js       
+C:\Alok\Business Projects\Urbanclap-dup\api\node_modules\@azure\cosmos\dist\esm\request\TimeoutError.js.map   
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+                                                                                                              
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@azure/cosmos/dist/esm/request/ErrorResponse.d.ts; Get-Content api/node_modules/@azure/cosmos/dist/esm/request/ErrorResponse.js | Select-Object -First 80' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 766ms:
+import type { CosmosDiagnostics, CosmosHeaders } from "../index.js";
+export interface ErrorBody {
+    code: string;
+    message: string;
+    /**
+     * @hidden
+     */
+    additionalErrorInfo?: PartitionedQueryExecutionInfo;
+}
+/**
+ * @hidden
+ */
+export interface PartitionedQueryExecutionInfo {
+    partitionedQueryExecutionInfoVersion: number;
+    queryInfo?: QueryInfo;
+    /**
+     * Represents hybrid query information.
+     */
+    hybridSearchQueryInfo?: HybridSearchQueryInfo;
+    queryRanges: QueryRange[];
+}
+/**
+ * @hidden
+ */
+export interface QueryRange {
+    min: string;
+    max: string;
+    isMinInclusive: boolean;
+    isMaxInclusive: boolean;
+}
+/**
+ * @hidden
+ */
+export interface QueryInfo {
+    top?: any;
+    orderBy?: any[];
+    orderByExpressions?: any[];
+    offset?: number;
+    limit?: number;
+    aggregates?: AggregateType[];
+    groupByExpressions?: GroupByExpressions;
+    groupByAliasToAggregateType: GroupByAliasToAggregateType;
+    rewrittenQuery?: any;
+    distinctType: string;
+    hasSelectValue: boolean;
+    /**
+     * determines whether the query is of non streaming orderby type.
+     */
+    hasNonStreamingOrderBy: boolean;
+}
+/**
+ * @hidden
+ * Represents the hybrid search query information
+ */
+export interface HybridSearchQueryInfo {
+    /**
+     * The query to be used for fetching global statistics
+     */
+    globalStatisticsQuery: string;
+    /**
+     * Query information for the subsequent queries
+     */
+    componentQueryInfos: QueryInfo[];
+    /**
+     * The number of results in the final result set
+     */
+    take: number;
+    /**
+     * The number of results to skip in the final result set
+     */
+    skip: number;
+    /**
+     * Whether the query requires global statistics
+     */
+    requiresGlobalStatistics: boolean;
+    /**
+     * Represents the weights for each component in a hybrid search query.
+     */
+    componentWeights?: number[];
+}
+export type GroupByExpressions = string[];
+export type AggregateType = "Average" | "Count" | "Max" | "Min" | "Sum" | "MakeSet" | "MakeList" | "CountIf";
+export interface GroupByAliasToAggregateType {
+    [key: string]: AggregateType;
+}
+/**
+ * Represents an error response returned in operations.
+ */
+export declare class ErrorResponse extends Error {
+    /** status or error code returned */
+    code?: number | string;
+    /** substatus code returned */
+    substatus?: number;
+    /** body of the error response, typically including error details */
+    body?: ErrorBody;
+    /** HTTP headers */
+    headers?: CosmosHeaders;
+    /** unique identifier for the operation's activity */
+    activityId?: string;
+    /** delay (in milliseconds) before retrying the operation. */
+    retryAfterInMs?: number;
+    /** delay (in milliseconds) before retrying the operation. */
+    /** Note: Use retryAfterInMs instead */
+    retryAfterInMilliseconds?: number;
+    /** any additional property */
+    [key: string]: any;
+    /** Detailed diagnostic information associated with the error.*/
+    diagnostics?: CosmosDiagnostics;
+    /** The request charge of the operation, representing the resource cost incurred.*/
+    requestCharge?: number;
+}
+//# sourceMappingURL=ErrorResponse.d.ts.map
+/**
+ * Represents an error response returned in operations.
+ */
+export class ErrorResponse extends Error {
+    /** status or error code returned */
+    code;
+    /** substatus code returned */
+    substatus;
+    /** body of the error response, typically including error details */
+    body;
+    /** HTTP headers */
+    headers;
+    /** unique identifier for the operation's activity */
+    activityId;
+    /** delay (in milliseconds) before retrying the operation. */
+    retryAfterInMs;
+    /** delay (in milliseconds) before retrying the operation. */
+    /** Note: Use retryAfterInMs instead */
+    retryAfterInMilliseconds;
+    /** Detailed diagnostic information associated with the error.*/
+    diagnostics;
+    /** The request charge of the operation, representing the resource cost incurred.*/
+    requestCharge;
+}
+//# sourceMappingURL=ErrorResponse.js.map
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Select-String -Path api/node_modules/@azure/cosmos/dist/esm/**/*.js -Pattern "statusCode|new ErrorResponse|response.status" | Select-Object -First 120' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 2461ms:
+
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:4:import { StatusCodes } from "../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:48:            throw new ErrorResponse("Operation is not 
+defined");
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:51:            throw new ErrorResponse("Operation context is 
+not defined");
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:80:            const numThrottle = 
+response?.results?.some((result) => "code" in result && result.code === StatusCodes.TooManyRequests)
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:83:            const splitOrMerge = 
+response?.results?.some((result) => "code" in result && result.code === StatusCodes.Gone)
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:87:                await 
+this.limiter.pauseAndClear(StatusCodes.Gone, diagnosticNode);
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:111:                        const decryptionError = new 
+ErrorResponse(`Item ${operation.operationInput.operationType} operation was successful but response decryption failed: 
++ ${error.message}`);
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:112:                        decryptionError.code = 
+StatusCodes.ServiceUnavailable;
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:136:                    error: Object.assign(new 
+ErrorResponse(error.message), {
+api\node_modules\@azure\cosmos\dist\esm\bulk\Batcher.js:137:                        code: 
+StatusCodes.InternalServerError,
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:6:import { StatusCodes } from "../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:117:                error: Object.assign(new 
+ErrorResponse("Operation cannot be null or undefined."), {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:118:                    code: 
+StatusCodes.InternalServerError,
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:130:                    error: Object.assign(new 
+ErrorResponse(`Operation resource body must have an 'id' for ${operation.operationType} operations.`), { code: 
+StatusCodes.InternalServerError }),
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:139:                error: Object.assign(new 
+ErrorResponse(`PartitionKey is required for ${operation.operationType} operations.`), { code: 
+StatusCodes.InternalServerError }),
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:196:                error: Object.assign(new 
+ErrorResponse(operationError.message), {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:197:                    code: 
+StatusCodes.InternalServerError,
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:224:            throw new ErrorResponse("Bulk execution 
+cancelled due to a previous error.");
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkHelper.js:247:                throw new ErrorResponse("Failed to 
+fetch bulk response.");
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:4:import { StatusCodes, SubStatusCodes } from 
+"../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:6:import { isSuccessStatusCode } from "../utils/batch.js";
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:12:    statusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:13:    subStatusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:18:    constructor(statusCode, subStatusCode, headers, 
+operations) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:19:        this.statusCode = statusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:20:        this.subStatusCode = subStatusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:27:    static createEmptyResponse(operations, statusCode, 
+subStatusCode, headers) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:28:        const bulkResponse = new 
+BulkResponse(statusCode, subStatusCode, headers, operations);
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:29:        
+bulkResponse.createAndPopulateResults(operations, 0, new ErrorResponse());
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:41:            if 
+(isSuccessStatusCode(responseMessage.code)) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:42:                bulkResponse = new 
+BulkResponse(StatusCodes.InternalServerError, SubStatusCodes.Unknown, responseMessage.headers, operations);
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:44:            // When the overall response status code 
+is TooManyRequests, propagate the RetryAfter into the individual operations.
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:46:            if (responseMessage.code === 
+StatusCodes.TooManyRequests) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:59:                if 
+(isSuccessStatusCode(itemResponse?.statusCode)) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:61:                        statusCode: 
+itemResponse?.statusCode,
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:74:                    const error = new ErrorResponse();
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:75:                    error.code = 
+itemResponse?.statusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:76:                    error.substatus = 
+itemResponse?.subStatusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:88:        let statusCode = responseMessage.code;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:89:        let subStatusCode = responseMessage.substatus;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:90:        if (responseMessage.code === 
+StatusCodes.MultiStatus) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:93:                    result.statusCode !== 
+StatusCodes.FailedDependency &&
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:94:                    result.statusCode >= 
+StatusCodes.BadRequest) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:95:                    statusCode = typeof result.code 
+=== "number" ? result.code : Number(result.code);
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:96:                    subStatusCode = result.substatus;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:101:        const bulkResponse = new 
+BulkResponse(statusCode, subStatusCode, responseMessage.headers, operations);
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:107:            const errorResponse = new ErrorResponse();
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:109:            errorResponse.code = this.statusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\BulkResponse.js:110:            errorResponse.substatus = 
+this.subStatusCode;
+api\node_modules\@azure\cosmos\dist\esm\bulk\HelperPerPartition.js:4:import { StatusCodes } from 
+"../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\bulk\HelperPerPartition.js:67:                            code: 
+StatusCodes.InternalServerError,
+api\node_modules\@azure\cosmos\dist\esm\bulk\Limiter.js:3:import { StatusCodes } from "../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\bulk\Limiter.js:130:            if (customValue === StatusCodes.Gone) {
+api\node_modules\@azure\cosmos\dist\esm\bulk\Limiter.js:136:        if (customValue === StatusCodes.Gone) {
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:389:        throw new ErrorResponse("Supported versions of 
+client encryption policy are 1 and 2.");
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:395:            throw new ErrorResponse(`Duplicate path 
+found: ${includedPath.path} in client encryption policy.`);
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:401:            throw new ErrorResponse("Path needs to be 
+defined in ClientEncryptionIncludedPath.");
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:407:            throw new 
+ErrorResponse("ClientEncryptionKeyId needs to be defined as string type in ClientEncryptionIncludedPath.");
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:410:            throw new ErrorResponse("Path in 
+ClientEncryptionIncludedPath must start with '/'.");
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:414:            throw new ErrorResponse("Only top-level paths 
+are currently supported for encryption");
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:427:                throw new ErrorResponse("The '/id' 
+property must be encrypted using Deterministic encryption.");
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:433:                throw new ErrorResponse(`Path: 
+${encryptedPath.path} which is part of the partition key has to be encrypted with Deterministic type Encryption.`);
+api\node_modules\@azure\cosmos\dist\esm\common\helper.js:440:        throw new ErrorResponse("Encryption of partition 
+key or id is only supported with policy format version 2.");
+api\node_modules\@azure\cosmos\dist\esm\common\index.js:5:export * from "./statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\common\statusCodes.js:6:export const StatusCodes = {
+api\node_modules\@azure\cosmos\dist\esm\common\statusCodes.js:40:export const SubStatusCodes = {
+api\node_modules\@azure\cosmos\dist\esm\common\statusCodes.js:46:    // 410: StatusCodeType_Gone: substatus
+api\node_modules\@azure\cosmos\dist\esm\common\statusCodes.js:59://# sourceMappingURL=statusCodes.js.map
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\CosmosDiagnosticsContext.js:29:            statusCode: 
+gatewayStatistics.statusCode,
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\CosmosDiagnosticsContext.js:30:            substatusCode: 
+gatewayStatistics.subStatusCode,
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:80:            statusCode: 
+pipelineResponse.status,
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:81:            subStatusCode: substatus,
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:114:    
+recordFailedNetworkCall(startTimeUTCInMs, requestContext, retryAttemptNumber, statusCode, substatusCode, 
+responseHeaders) {
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:122:            statusCode,
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:123:            subStatusCode: 
+substatusCode,
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:231:                throw new 
+ErrorResponse("Invalid operation type for encryption diagnostics");
+api\node_modules\@azure\cosmos\dist\esm\diagnostics\DiagnosticNodeInternal.js:264:                throw new 
+ErrorResponse("Invalid operation type for encryption diagnostics");
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:3:import { Constants, ResourceType, 
+StatusCodes, createDeserializer, createSerializer, extractPath, } from "../common/index.js";
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:21:            throw new 
+ErrorResponse("Input body is null or undefined.");
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:34:                throw new 
+ErrorResponse("Invalid Encryption Setting for the Property: " + propertyName);
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:136:                throw new 
+ErrorResponse("The id should be of string type.");
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:165:                throw new 
+ErrorResponse("Invalid Encryption Setting for the Path: " + pathToEncrypt);
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:203:            throw new 
+ErrorResponse("returned null plain text");
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:222:                    throw new 
+ErrorResponse("Failed to fetch container definition");
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:246:            if (err.statusCode !== 
+StatusCodes.Forbidden)
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:255:                if (retryErr.statusCode 
+!== StatusCodes.Forbidden)
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:283:                throw new 
+ErrorResponse(`Failed to fetch client encryption key ${cekId}`);
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:285:            if (response.code === 
+StatusCodes.NotModified) {
+api\node_modules\@azure\cosmos\dist\esm\encryption\EncryptionProcessor.js:286:                throw new 
+ErrorResponse(`The Client Encryption Key with key id: ${cekId} on database: ${this.database.id} needs to be rewrapped 
+with a valid Key Encryption Key using rewrapClientEncryptionKey. The Key Encryption Key used to wrap the Client 
+Encryption Key has been revoked`);
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\documentProducer.js:1:import { Constants, getIdFromLink, 
+getPathFromLink, ResourceType, StatusCodes, SubStatusCodes, } from "../common/index.js";
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\documentProducer.js:117:        return (error.code === 
+StatusCodes.Gone &&
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\documentProducer.js:119:            error["substatus"] 
+=== SubStatusCodes.PartitionKeyRangeGone);
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\parallelQueryExecutionContextBase.js:5:import { 
+StatusCodes, SubStatusCodes } from "../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\parallelQueryExecutionContextBase.js:404:            
+throw new ErrorResponse(`Invalid continuation token format. Expected token with rangeMappings property. ` +
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\parallelQueryExecutionContextBase.js:545:        return 
+(error.code === StatusCodes.Gone &&
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\parallelQueryExecutionContextBase.js:547:            
+error["substatus"] === SubStatusCodes.PartitionKeyRangeGone);
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\pipelinedQueryExecutionContext.js:39:            throw 
+new ErrorResponse("Query execution requires valid query plan information. " +
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\pipelinedQueryExecutionContext.js:190:            throw 
+new ErrorResponse(`Executing a vector search query with TOP or OFFSET + LIMIT value ${vectorSearchBufferSize} larger 
+than the vectorSearchBufferSize ${maxBufferSize} ` +
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\pipelinedQueryExecutionContext.js:209:            throw 
+new ErrorResponse("Executing a non-streaming search query without TOP or LIMIT can consume a large number of RUs " +
+api\node_modules\@azure\cosmos\dist\esm\queryExecutionContext\QueryValidationHelper.js:18:        throw new 
+ErrorResponse(conflictingQueryType.errorMessage);
+api\node_modules\@azure\cosmos\dist\esm\request\request.js:183:            throw new ErrorResponse("Currently 
+`contentResponseOnWriteEnabled` option is only supported for batch and bulk operations.");
+api\node_modules\@azure\cosmos\dist\esm\request\RequestHandler.js:102:    const result = response.status === 204 || 
+response.status === 304 || response.bodyAsText === ""
+api\node_modules\@azure\cosmos\dist\esm\request\RequestHandler.js:110:    if (response.status >= 400) {
+api\node_modules\@azure\cosmos\dist\esm\request\RequestHandler.js:111:        const errorResponse = new 
+ErrorResponse(result.message);
+api\node_modules\@azure\cosmos\dist\esm\request\RequestHandler.js:112:        logger.warning(response.status +
+api\node_modules\@azure\cosmos\dist\esm\request\RequestHandler.js:119:        errorResponse.code = response.status;
+api\node_modules\@azure\cosmos\dist\esm\request\RequestHandler.js:141:        code: response.status,
+api\node_modules\@azure\cosmos\dist\esm\request\ResourceResponse.js:5:    statusCode;
+api\node_modules\@azure\cosmos\dist\esm\request\ResourceResponse.js:8:    constructor(resource, headers, statusCode, 
+diagnostics, substatus) {
+api\node_modules\@azure\cosmos\dist\esm\request\ResourceResponse.js:11:        this.statusCode = statusCode;
+api\node_modules\@azure\cosmos\dist\esm\request\StatusCodes.js:4://# sourceMappingURL=StatusCodes.js.map
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:4:import { StatusCodes, SubStatusCodes } 
+from "../common/statusCodes.js";
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:13:    
+SubstatusCodeBatchResponseSizeExceeded = 3402;
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:23:        if (err.code === 
+StatusCodes.Gone) {
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:28:            if (err.substatus === 
+SubStatusCodes.PartitionKeyRangeGone ||
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:29:                err.substatus === 
+SubStatusCodes.CompletingSplit ||
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:30:                err.substatus === 
+SubStatusCodes.CompletingPartitionMigration) {
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:33:            if (err.substatus === 
+SubStatusCodes.NameCacheIsStale) {
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:40:        if (err.code === 
+StatusCodes.RequestEntityTooLarge &&
+api\node_modules\@azure\cosmos\dist\esm\retry\bulkExecutionRetryPolicy.js:41:            err.substatus === 
+this.SubstatusCodeBatchResponseSizeExceeded) {
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Get-Content api/node_modules/@azure/cosmos/dist/esm/request/RequestHandler.js | Select-Object -Skip 100 -First 50' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 601ms:
+    }
+    const result = response.status === 204 || response.status === 304 || response.bodyAsText === ""
+        ? null
+        : JSON.parse(response.bodyAsText);
+    const responseHeaders = response.headers.toJSON();
+    const substatus = responseHeaders[Constants.HttpHeaders.SubStatus]
+        ? parseInt(responseHeaders[Constants.HttpHeaders.SubStatus], 10)
+        : undefined;
+    diagnosticNode.recordSuccessfulNetworkCall(startTimeUTCInMs, requestContext, response, substatus, url);
+    if (response.status >= 400) {
+        const errorResponse = new ErrorResponse(result.message);
+        logger.warning(response.status +
+            " " +
+            requestContext.endpoint +
+            " " +
+            requestContext.path +
+            " " +
+            result.message);
+        errorResponse.code = response.status;
+        errorResponse.body = result;
+        errorResponse.headers = responseHeaders;
+        if (Constants.HttpHeaders.ActivityId in responseHeaders) {
+            errorResponse.activityId = responseHeaders[Constants.HttpHeaders.ActivityId];
+        }
+        if (Constants.HttpHeaders.SubStatus in responseHeaders) {
+            errorResponse.substatus = substatus;
+        }
+        if (Constants.HttpHeaders.RetryAfterInMs in responseHeaders) {
+            errorResponse.retryAfterInMs = parseInt(responseHeaders[Constants.HttpHeaders.RetryAfterInMs], 10);
+            Object.defineProperty(errorResponse, "retryAfterInMilliseconds", {
+                get: () => {
+                    return errorResponse.retryAfterInMs;
+                },
+            });
+        }
+        throw errorResponse;
+    }
+    return {
+        headers: responseHeaders,
+        result,
+        code: response.status,
+        substatus,
+    };
+}
+/**
+ * @hidden
+ */
+async function request(requestContext, diagnosticNode) {
+    if (requestContext.body) {
+        requestContext.body = bodyFromData(requestContext.body);
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/tests/unit/cosmos/slot-holds-repository.test.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 220' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 654ms:
+   1: import { describe, it, expect, vi, beforeEach } from 'vitest';
+   2: 
+   3: // ---------------------------------------------------------------------------
+   4: // Mocks â€” must be declared before module import
+   5: // ---------------------------------------------------------------------------
+   6: 
+   7: const mockCreate = vi.fn();
+   8: const mockPatch = vi.fn();
+   9: const mockFetchAll = vi.fn();
+  10: const mockQuery = vi.fn(() => ({ fetchAll: mockFetchAll }));
+  11: const mockItem = vi.fn(() => ({ patch: mockPatch }));
+  12: 
+  13: vi.mock('../../../src/cosmos/client.js', () => ({
+  14:   getSlotHoldsContainer: vi.fn(() => ({
+  15:     items: { create: mockCreate, query: mockQuery },
+  16:     item: mockItem,
+  17:   })),
+  18: }));
+  19: 
+  20: import { slotHoldsRepo } from '../../../src/cosmos/slot-holds-repository.js';
+  21: 
+  22: // ---------------------------------------------------------------------------
+  23: // Helpers
+  24: // ---------------------------------------------------------------------------
+  25: 
+  26: const SVC = 'svc-ac';
+  27: const DATE = '2026-05-20';
+  28: const WINDOW = '10:00-11:00';
+  29: const CUST = 'cust-1';
+  30: const HOLD_ID = `${SVC}|${DATE}|${WINDOW}`;
+  31: const HOLD_PK = `${SVC}|${DATE}`;
+  32: 
+  33: const HOLD_DOC = {
+  34:   id: HOLD_ID,
+  35:   servicePartitionKey: HOLD_PK,
+  36:   serviceId: SVC,
+  37:   date: DATE,
+  38:   window: WINDOW,
+  39:   customerId: CUST,
+  40:   heldAt: '2026-05-20T04:30:00.000Z',
+  41: };
+  42: 
+  43: // ---------------------------------------------------------------------------
+  44: // createHold
+  45: // ---------------------------------------------------------------------------
+  46: 
+  47: describe('slotHoldsRepo.createHold', () => {
+  48:   beforeEach(() => vi.clearAllMocks());
+  49: 
+  50:   it('happy path: returns hold doc when Cosmos create succeeds', async () => {
+  51:     mockCreate.mockResolvedValue({ resource: HOLD_DOC });
+  52: 
+  53:     const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
+  54: 
+  55:     expect(result).not.toBe('CONFLICT');
+  56:     expect((result as typeof HOLD_DOC).id).toBe(HOLD_ID);
+  57:     expect(mockCreate).toHaveBeenCalledOnce();
+  58:   });
+  59: 
+  60:   it('returns CONFLICT when Cosmos responds 409 (slot already held)', async () => {
+  61:     mockCreate.mockRejectedValue({ statusCode: 409 });
+  62: 
+  63:     const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
+  64: 
+  65:     expect(result).toBe('CONFLICT');
+  66:   });
+  67: 
+  68:   it('returns CONFLICT when Cosmos responds 412 (etag mismatch â€” ADR-0017 pattern)', async () => {
+  69:     mockCreate.mockRejectedValue({ statusCode: 412 });
+  70: 
+  71:     const result = await slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST);
+  72: 
+  73:     expect(result).toBe('CONFLICT');
+  74:   });
+  75: 
+  76:   it('rethrows non-409/412 errors for Sentry to capture upstream', async () => {
+  77:     mockCreate.mockRejectedValue({ statusCode: 500, message: 'Internal error' });
+  78: 
+  79:     await expect(slotHoldsRepo.createHold(SVC, DATE, WINDOW, CUST)).rejects.toMatchObject({ statusCode: 500 });
+  80:   });
+  81: });
+  82: 
+  83: // ---------------------------------------------------------------------------
+  84: // commitHold
+  85: // ---------------------------------------------------------------------------
+  86: 
+  87: describe('slotHoldsRepo.commitHold', () => {
+  88:   beforeEach(() => vi.clearAllMocks());
+  89: 
+  90:   it('happy path: patches bookingId and ttl=-1', async () => {
+  91:     mockPatch.mockResolvedValue({ resource: { ...HOLD_DOC, bookingId: 'bk-1', ttl: -1 } });
+  92: 
+  93:     await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
+  94: 
+  95:     expect(mockItem).toHaveBeenCalledWith(HOLD_ID, HOLD_PK);
+  96:     expect(mockPatch).toHaveBeenCalledWith([
+  97:       { op: 'add', path: '/bookingId', value: 'bk-1' },
+  98:       { op: 'replace', path: '/ttl', value: -1 },
+  99:     ]);
+ 100:   });
+ 101: 
+ 102:   it('silently returns when hold has already expired (Cosmos 404)', async () => {
+ 103:     mockPatch.mockRejectedValue({ statusCode: 404 });
+ 104: 
+ 105:     // Should NOT throw â€” expired hold is non-fatal
+ 106:     await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).resolves.toBeUndefined();
+ 107:   });
+ 108: 
+ 109:   it('rethrows non-404 errors', async () => {
+ 110:     mockPatch.mockRejectedValue({ statusCode: 503 });
+ 111: 
+ 112:     await expect(slotHoldsRepo.commitHold(HOLD_ID, HOLD_PK, 'bk-1')).rejects.toMatchObject({ statusCode: 503 });
+ 113:   });
+ 114: });
+ 115: 
+ 116: // ---------------------------------------------------------------------------
+ 117: // listHolds
+ 118: // ---------------------------------------------------------------------------
+ 119: 
+ 120: describe('slotHoldsRepo.listHolds', () => {
+ 121:   beforeEach(() => vi.clearAllMocks());
+ 122: 
+ 123:   it('returns active hold docs for the given serviceId + date partition', async () => {
+ 124:     mockFetchAll.mockResolvedValue({ resources: [HOLD_DOC] });
+ 125: 
+ 126:     const result = await slotHoldsRepo.listHolds(SVC, DATE);
+ 127: 
+ 128:     expect(result).toHaveLength(1);
+ 129:     expect(result[0]!.window).toBe(WINDOW);
+ 130:     // Verify it queries on the composite partition key
+ 131:     const rawCall = mockQuery.mock.calls[0];
+ 132:     const callArg = (rawCall as unknown as [{ query: string; parameters: { name: string; value: string }[] }])[0]!;
+ 133:     expect(callArg.parameters[0]!.value).toBe(HOLD_PK);
+ 134:   });
+ 135: 
+ 136:   it('returns empty array when no active holds exist', async () => {
+ 137:     mockFetchAll.mockResolvedValue({ resources: [] });
+ 138: 
+ 139:     const result = await slotHoldsRepo.listHolds(SVC, DATE);
+ 140: 
+ 141:     expect(result).toEqual([]);
+ 142:   });
+ 143: });
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/cosmos/slot-holds-repository.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ }' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 496ms:
+   1: import { getSlotHoldsContainer } from './client.js';
+   2: import type { SlotHoldDoc } from '../schemas/slot-hold.js';
+   3: 
+   4: export class SlotHoldsRepository {
+   5:   private get container() { return getSlotHoldsContainer(); }
+   6: 
+   7:   /**
+   8:    * Attempts to create a soft hold for the given slot.
+   9:    * Returns the hold doc on success, or 'CONFLICT' if the slot is already held
+  10:    * (Cosmos 409) or there is an optimistic-concurrency conflict (Cosmos 412 â€”
+  11:    * same fallback pattern as ADR-0017 Â§5 wallet etag).
+  12:    */
+  13:   async createHold(
+  14:     serviceId: string,
+  15:     date: string,
+  16:     window: string,
+  17:     customerId: string,
+  18:   ): Promise<SlotHoldDoc | 'CONFLICT'> {
+  19:     const id = `${serviceId}|${date}|${window}`;
+  20:     const servicePartitionKey = `${serviceId}|${date}`;
+  21:     // Note: ttl is intentionally omitted â€” the container default (30 s) applies automatically.
+  22:     // exactOptionalPropertyTypes=true means we can't pass ttl?: number | undefined to create<T>.
+  23:     const doc = {
+  24:       id,
+  25:       servicePartitionKey,
+  26:       serviceId,
+  27:       date,
+  28:       window,
+  29:       customerId,
+  30:       heldAt: new Date().toISOString(),
+  31:     } satisfies Omit<SlotHoldDoc, 'bookingId' | 'ttl'>;
+  32: 
+  33:     try {
+  34:       const { resource } = await this.container.items.create(doc);
+  35:       return resource as SlotHoldDoc;
+  36:     } catch (err: unknown) {
+  37:       const code = (err as { statusCode?: number }).statusCode;
+  38:       if (code === 409 || code === 412) return 'CONFLICT';
+  39:       throw err;
+  40:     }
+  41:   }
+  42: 
+  43:   /**
+  44:    * Converts a soft hold to a permanent booking-owned slot record.
+  45:    * Uses Cosmos PATCH to write bookingId and set ttl=-1 (no expiry).
+  46:    * If the hold has already expired (404), logs a warning and returns silently â€”
+  47:    * the booking succeeded and the slot will be visible via the bookings query.
+  48:    */
+  49:   async commitHold(holdId: string, servicePartitionKey: string, bookingId: string): Promise<void> {
+  50:     try {
+  51:       await this.container.item(holdId, servicePartitionKey).patch([
+  52:         { op: 'add', path: '/bookingId', value: bookingId },
+  53:         { op: 'replace', path: '/ttl', value: -1 },
+  54:       ]);
+  55:     } catch (err: unknown) {
+  56:       const code = (err as { statusCode?: number }).statusCode;
+  57:       if (code === 404) {
+  58:         console.warn('[slotHoldsRepo] commitHold: hold already expired (non-fatal)', { holdId, bookingId });
+  59:         return;
+  60:       }
+  61:       throw err;
+  62:     }
+  63:   }
+  64: 
+  65:   /**
+  66:    * Lists all hold docs for a given service+date partition.
+  67:    * Cosmos TTL means expired docs are excluded automatically by the engine.
+  68:    */
+  69:   async listHolds(serviceId: string, date: string): Promise<SlotHoldDoc[]> {
+  70:     const pk = `${serviceId}|${date}`;
+  71:     const { resources } = await this.container.items
+  72:       .query<SlotHoldDoc>({
+  73:         query: 'SELECT * FROM c WHERE c.servicePartitionKey = @pk',
+  74:         parameters: [{ name: '@pk', value: pk }],
+  75:       })
+  76:       .fetchAll();
+  77:     return resources;
+  78:   }
+  79: }
+  80: 
+  81: export const slotHoldsRepo = new SlotHoldsRepository();
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'pnpm -C api typecheck' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 6505ms:
+
+> homeservices-api@0.1.0 typecheck C:\Alok\Business Projects\Urbanclap-dup\api
+> tsc --noEmit -p tsconfig.tests.json
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/functions/catalogue-admin.ts'; Select-String -Path "'$p -Pattern "CreateServiceBodySchema|UpdateServiceBodySchema|ServiceSchema|safeParse|service" -Context 2,3 | Select-Object -First 160' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 652ms:
+
+  api\src\functions\catalogue-admin.ts:7:import '../bootstrap.js';
+  api\src\functions\catalogue-admin.ts:8:import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+> api\src\functions\catalogue-admin.ts:9:import { CreateCategoryBodySchema, UpdateCategoryBodySchema } from 
+'../schemas/service-category.js';
+> api\src\functions\catalogue-admin.ts:10:import { CreateServiceBodySchema, UpdateServiceBodySchema } from 
+'../schemas/service.js';
+  api\src\functions\catalogue-admin.ts:11:import { requireAdmin } from '../middleware/requireAdmin.js';
+  api\src\functions\catalogue-admin.ts:12:import type { AdminContext } from '../types/admin.js';
+  api\src\functions\catalogue-admin.ts:13:import { ZodError } from 'zod';
+> api\src\functions\catalogue-admin.ts:14:import { catalogueAuditEntry } from '../services/catalogueAudit.service.js';
+  api\src\functions\catalogue-admin.ts:15:
+  api\src\functions\catalogue-admin.ts:16:const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8', 
+'Cache-Control': 'no-store' };
+  api\src\functions\catalogue-admin.ts:17:
+  api\src\functions\catalogue-admin.ts:79:}
+  api\src\functions\catalogue-admin.ts:80:
+> api\src\functions\catalogue-admin.ts:81:// ── Services 
+──────────────────────────────────────────────────────────────────
+  api\src\functions\catalogue-admin.ts:82:
+> api\src\functions\catalogue-admin.ts:83:export async function listAdminServicesHandler(req: HttpRequest, _ctx: 
+InvocationContext, _admin: AdminContext): Promise<HttpResponseInit> {
+  api\src\functions\catalogue-admin.ts:84:  const categoryId = req.query.get('categoryId') ?? undefined;
+> api\src\functions\catalogue-admin.ts:85:  const services = categoryId
+> api\src\functions\catalogue-admin.ts:86:    ? await catalogueRepo.listServicesByCategory(categoryId)
+> api\src\functions\catalogue-admin.ts:87:    : await catalogueRepo.listAllActiveServices();
+> api\src\functions\catalogue-admin.ts:88:  return { status: 200, headers: JSON_HEADERS, jsonBody: { services } };
+  api\src\functions\catalogue-admin.ts:89:}
+  api\src\functions\catalogue-admin.ts:90:
+> api\src\functions\catalogue-admin.ts:91:export async function getServiceHandler(req: HttpRequest, _ctx: 
+InvocationContext, _admin: AdminContext): Promise<HttpResponseInit> {
+  api\src\functions\catalogue-admin.ts:92:  const id = req.params['id']!;
+> api\src\functions\catalogue-admin.ts:93:  const service = await catalogueRepo.getServiceByIdCrossPartition(id);
+> api\src\functions\catalogue-admin.ts:94:  if (!service) return { status: 404, headers: JSON_HEADERS, jsonBody: { 
+error: 'Service not found' } };
+> api\src\functions\catalogue-admin.ts:95:  return { status: 200, headers: JSON_HEADERS, jsonBody: service };
+  api\src\functions\catalogue-admin.ts:96:}
+  api\src\functions\catalogue-admin.ts:97:
+> api\src\functions\catalogue-admin.ts:98:export async function createServiceHandler(req: HttpRequest, _ctx: 
+InvocationContext, admin: AdminContext): Promise<HttpResponseInit> {
+  api\src\functions\catalogue-admin.ts:99:  try {
+> api\src\functions\catalogue-admin.ts:100:    const body = CreateServiceBodySchema.parse(await parseJson(req));
+> api\src\functions\catalogue-admin.ts:101:    const existing = await 
+catalogueRepo.getServiceByIdCrossPartition(body.id);
+> api\src\functions\catalogue-admin.ts:102:    if (existing) return { status: 409, headers: JSON_HEADERS, jsonBody: { 
+error: `Service '${body.id}' already exists` } };
+> api\src\functions\catalogue-admin.ts:103:    const created = await catalogueRepo.createService(body, admin.adminId);
+> api\src\functions\catalogue-admin.ts:104:    await catalogueAuditEntry(admin.adminId, admin.role, 
+'CATALOGUE_SERVICE_CREATED', 'service', created.id, { name: created.name, categoryId: created.categoryId });
+  api\src\functions\catalogue-admin.ts:105:    return { status: 201, headers: JSON_HEADERS, jsonBody: created };
+  api\src\functions\catalogue-admin.ts:106:  } catch (err) {
+  api\src\functions\catalogue-admin.ts:107:    if (err instanceof ZodError) return zodErr(err);
+  api\src\functions\catalogue-admin.ts:110:}
+  api\src\functions\catalogue-admin.ts:111:
+> api\src\functions\catalogue-admin.ts:112:export async function updateServiceHandler(req: HttpRequest, _ctx: 
+InvocationContext, admin: AdminContext): Promise<HttpResponseInit> {
+  api\src\functions\catalogue-admin.ts:113:  try {
+  api\src\functions\catalogue-admin.ts:114:    const id = req.params['id']!;
+> api\src\functions\catalogue-admin.ts:115:    const body = UpdateServiceBodySchema.parse(await parseJson(req));
+> api\src\functions\catalogue-admin.ts:116:    const updated = await catalogueRepo.updateService(id, body, 
+admin.adminId);
+> api\src\functions\catalogue-admin.ts:117:    if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { 
+error: 'Service not found' } };
+> api\src\functions\catalogue-admin.ts:118:    await catalogueAuditEntry(admin.adminId, admin.role, 
+'CATALOGUE_SERVICE_UPDATED', 'service', id, { changes: body });
+  api\src\functions\catalogue-admin.ts:119:    return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
+  api\src\functions\catalogue-admin.ts:120:  } catch (err) {
+  api\src\functions\catalogue-admin.ts:121:    if (err instanceof ZodError) return zodErr(err);
+  api\src\functions\catalogue-admin.ts:124:}
+  api\src\functions\catalogue-admin.ts:125:
+> api\src\functions\catalogue-admin.ts:126:export async function toggleServiceHandler(req: HttpRequest, _ctx: 
+InvocationContext, admin: AdminContext): Promise<HttpResponseInit> {
+  api\src\functions\catalogue-admin.ts:127:  const id = req.params['id']!;
+> api\src\functions\catalogue-admin.ts:128:  const updated = await catalogueRepo.toggleService(id, admin.adminId);
+> api\src\functions\catalogue-admin.ts:129:  if (!updated) return { status: 404, headers: JSON_HEADERS, jsonBody: { 
+error: 'Service not found' } };
+> api\src\functions\catalogue-admin.ts:130:  await catalogueAuditEntry(admin.adminId, admin.role, 
+'CATALOGUE_SERVICE_TOGGLED', 'service', id, { isActive: updated.isActive });
+  api\src\functions\catalogue-admin.ts:131:  return { status: 200, headers: JSON_HEADERS, jsonBody: updated };
+  api\src\functions\catalogue-admin.ts:132:}
+  api\src\functions\catalogue-admin.ts:133:
+  api\src\functions\catalogue-admin.ts:141:app.http('adminUpdateCategory', { methods: ['PUT'], route: 
+'v1/admin/catalogue/categories/{id}', authLevel: 'anonymous', handler: adminRoles(updateCategoryHandler) });
+  api\src\functions\catalogue-admin.ts:142:app.http('adminToggleCategory', { methods: ['PATCH'], route: 
+'v1/admin/catalogue/categories/{id}/toggle', authLevel: 'anonymous', handler: adminRoles(toggleCategoryHandler) });
+> api\src\functions\catalogue-admin.ts:143:app.http('adminListServices', { methods: ['GET'], route: 
+'v1/admin/catalogue/services', authLevel: 'anonymous', handler: adminRoles(listAdminServicesHandler) });
+> api\src\functions\catalogue-admin.ts:144:app.http('adminGetService', { methods: ['GET'], route: 
+'v1/admin/catalogue/services/{id}', authLevel: 'anonymous', handler: adminRoles(getServiceHandler) });
+> api\src\functions\catalogue-admin.ts:145:app.http('adminCreateService', { methods: ['POST'], route: 
+'v1/admin/catalogue/services', authLevel: 'anonymous', handler: adminRoles(createServiceHandler) });
+> api\src\functions\catalogue-admin.ts:146:app.http('adminUpdateService', { methods: ['PUT'], route: 
+'v1/admin/catalogue/services/{id}', authLevel: 'anonymous', handler: adminRoles(updateServiceHandler) });
+> api\src\functions\catalogue-admin.ts:147:app.http('adminToggleService', { methods: ['PATCH'], route: 
+'v1/admin/catalogue/services/{id}/toggle', authLevel: 'anonymous', handler: adminRoles(toggleServiceHandler) });
+
+
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/cosmos/catalogue-repository.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 180' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 1390ms:
+   1: import { getCatalogueContainers } from './client.js';
+   2: import type { ServiceCategory, CreateCategoryBody, UpdateCategoryBody } from '../schemas/service-category.js';
+   3: import type { Service, CreateServiceBody, UpdateServiceBody } from '../schemas/service.js';
+   4: 
+   5: function now(): string {
+   6:   return new Date().toISOString();
+   7: }
+   8: 
+   9: export class CatalogueRepository {
+  10:   private get cats() { return getCatalogueContainers().categories; }
+  11:   private get svcs() { return getCatalogueContainers().services; }
+  12: 
+  13:   // â”€â”€ Categories â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  14: 
+  15:   async listActiveCategories(): Promise<ServiceCategory[]> {
+  16:     const { resources } = await this.cats.items
+  17:       .query<ServiceCategory>('SELECT * FROM c WHERE c.isActive = true ORDER BY c.sortOrder ASC')
+  18:       .fetchAll();
+  19:     return resources;
+  20:   }
+  21: 
+  22:   async listAllCategories(): Promise<ServiceCategory[]> {
+  23:     const { resources } = await this.cats.items
+  24:       .query<ServiceCategory>('SELECT * FROM c ORDER BY c.sortOrder ASC')
+  25:       .fetchAll();
+  26:     return resources;
+  27:   }
+  28: 
+  29:   async getCategoryById(id: string): Promise<ServiceCategory | null> {
+  30:     const { resources } = await this.cats.items
+  31:       .query<ServiceCategory>({
+  32:         query: 'SELECT * FROM c WHERE c.id = @id',
+  33:         parameters: [{ name: '@id', value: id }],
+  34:       })
+  35:       .fetchAll();
+  36:     return resources[0] ?? null;
+  37:   }
+  38: 
+  39:   async createCategory(body: CreateCategoryBody, uid: string): Promise<ServiceCategory> {
+  40:     const doc: ServiceCategory = { ...body, isActive: true, updatedBy: uid, createdAt: now(), updatedAt: now() };
+  41:     const { resource } = await this.cats.items.create<ServiceCategory>(doc);
+  42:     return resource!;
+  43:   }
+  44: 
+  45:   async updateCategory(id: string, body: UpdateCategoryBody, uid: string): Promise<ServiceCategory | null> {
+  46:     const existing = await this.getCategoryById(id);
+  47:     if (!existing) return null;
+  48:     const updated: ServiceCategory = { ...existing, ...body, id, updatedBy: uid, updatedAt: now() };
+  49:     const { resource } = await this.cats.items.upsert<ServiceCategory>(updated);
+  50:     return resource!;
+  51:   }
+  52: 
+  53:   async toggleCategory(id: string, uid: string): Promise<ServiceCategory | null> {
+  54:     const existing = await this.getCategoryById(id);
+  55:     if (!existing) return null;
+  56:     const updated = { ...existing, isActive: !existing.isActive, updatedBy: uid, updatedAt: now() };
+  57:     const { resource } = await this.cats.items.upsert<ServiceCategory>(updated);
+  58:     return resource!;
+  59:   }
+  60: 
+  61:   async upsertCategory(doc: ServiceCategory): Promise<void> {
+  62:     await this.cats.items.upsert(doc);
+  63:   }
+  64: 
+  65:   // â”€â”€ Services â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  66: 
+  67:   async listAllActiveServices(): Promise<Service[]> {
+  68:     const { resources } = await this.svcs.items
+  69:       .query<Service>('SELECT * FROM c WHERE c.isActive = true')
+  70:       .fetchAll();
+  71:     return resources;
+  72:   }
+  73: 
+  74:   async listServicesByCategory(categoryId: string, activeOnly = false): Promise<Service[]> {
+  75:     const q = activeOnly
+  76:       ? { query: 'SELECT * FROM c WHERE c.categoryId = @cid AND c.isActive = true', parameters: [{ name: '@cid', value: categoryId }] }
+  77:       : { query: 'SELECT * FROM c WHERE c.categoryId = @cid', parameters: [{ name: '@cid', value: categoryId }] };
+  78:     const { resources } = await this.svcs.items.query<Service>(q).fetchAll();
+  79:     return resources;
+  80:   }
+  81: 
+  82:   async getServiceByIdCrossPartition(id: string): Promise<Service | null> {
+  83:     const { resources } = await this.svcs.items
+  84:       .query<Service>({ query: 'SELECT * FROM c WHERE c.id = @id', parameters: [{ name: '@id', value: id }] })
+  85:       .fetchAll();
+  86:     return resources[0] ?? null;
+  87:   }
+  88: 
+  89:   async createService(body: CreateServiceBody, uid: string): Promise<Service> {
+  90:     const doc: Service = { ...body, isActive: true, updatedBy: uid, createdAt: now(), updatedAt: now() };
+  91:     const { resource } = await this.svcs.items.create<Service>(doc);
+  92:     return resource!;
+  93:   }
+  94: 
+  95:   async updateService(id: string, body: UpdateServiceBody, uid: string): Promise<Service | null> {
+  96:     const existing = await this.getServiceByIdCrossPartition(id);
+  97:     if (!existing) return null;
+  98:     const updated: Service = { ...existing, ...body, id, categoryId: existing.categoryId, updatedBy: uid, updatedAt: now() };
+  99:     const { resource } = await this.svcs.item(id, existing.categoryId).replace<Service>(updated);
+ 100:     return resource!;
+ 101:   }
+ 102: 
+ 103:   async toggleService(id: string, uid: string): Promise<Service | null> {
+ 104:     const existing = await this.getServiceByIdCrossPartition(id);
+ 105:     if (!existing) return null;
+ 106:     const updated = { ...existing, isActive: !existing.isActive, updatedBy: uid, updatedAt: now() };
+ 107:     const { resource } = await this.svcs.item(id, existing.categoryId).replace<Service>(updated);
+ 108:     return resource!;
+ 109:   }
+ 110: 
+ 111:   async upsertService(doc: Service): Promise<void> {
+ 112:     await this.svcs.items.upsert(doc);
+ 113:   }
+ 114: }
+ 115: 
+ 116: export const catalogueRepo = new CatalogueRepository();
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/cosmos/client.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ } | Select-Object -First 160' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 605ms:
+   1: import { CosmosClient, type Container } from '@azure/cosmos';
+   2: 
+   3: let _client: CosmosClient | null = null;
+   4: 
+   5: const RETRY_OPTIONS = {
+   6:   maxRetryAttemptsOnThrottledRequests: 9,
+   7:   maxWaitTimeInSeconds: 30,
+   8: } as const;
+   9: 
+  10: /**
+  11:  * Parse a Cosmos DB connection string into endpoint + key components.
+  12:  * Format: AccountEndpoint=https://...;AccountKey=<base64>=;
+  13:  */
+  14: function parseConnectionString(cs: string): { endpoint: string; key: string } {
+  15:   const endpointMatch = /AccountEndpoint=([^;]+)/i.exec(cs);
+  16:   const keyMatch = /AccountKey=([^;]+)/i.exec(cs);
+  17:   if (!endpointMatch || !keyMatch) {
+  18:     throw new Error('Invalid COSMOS_CONNECTION_STRING: missing AccountEndpoint or AccountKey');
+  19:   }
+  20:   return { endpoint: endpointMatch[1]!, key: keyMatch[1]! };
+  21: }
+  22: 
+  23: export function getCosmosClient(): CosmosClient {
+  24:   if (!_client) {
+  25:     const connectionString = process.env.COSMOS_CONNECTION_STRING;
+  26:     const userAgentSuffix = `homeservices-api/${process.env.GIT_SHA || 'local'}`;
+  27: 
+  28:     if (connectionString) {
+  29:       const { endpoint, key } = parseConnectionString(connectionString);
+  30:       _client = new CosmosClient({
+  31:         endpoint,
+  32:         key,
+  33:         connectionPolicy: { retryOptions: RETRY_OPTIONS },
+  34:         userAgentSuffix,
+  35:       });
+  36:     } else {
+  37:       const endpoint = process.env.COSMOS_ENDPOINT;
+  38:       const key = process.env.COSMOS_KEY;
+  39:       if (!endpoint || !key) {
+  40:         throw new Error('Missing COSMOS_CONNECTION_STRING or COSMOS_ENDPOINT+COSMOS_KEY');
+  41:       }
+  42:       _client = new CosmosClient({
+  43:         endpoint,
+  44:         key,
+  45:         connectionPolicy: { retryOptions: RETRY_OPTIONS },
+  46:         userAgentSuffix,
+  47:       });
+  48:     }
+  49:   }
+  50:   return _client;
+  51: }
+  52: 
+  53: export const DB_NAME = process.env.COSMOS_DATABASE ?? 'homeservices';
+  54: 
+  55: export function getCatalogueContainers(): { categories: Container; services: Container } {
+  56:   const db = getCosmosClient().database(DB_NAME);
+  57:   return {
+  58:     categories: db.container('service_categories'),
+  59:     services: db.container('services'),
+  60:   };
+  61: }
+  62: 
+  63: export function getBookingsContainer(): Container {
+  64:   return getCosmosClient().database(DB_NAME).container('bookings');
+  65: }
+  66: 
+  67: export function getDispatchAttemptsContainer(): Container {
+  68:   return getCosmosClient().database(DB_NAME).container('dispatch_attempts');
+  69: }
+  70: 
+  71: export function getBookingEventsContainer(): Container {
+  72:   return getCosmosClient().database(DB_NAME).container('booking_events');
+  73: }
+  74: 
+  75: export function getSscLeviesContainer(): Container {
+  76:   return getCosmosClient().database(DB_NAME).container('ssc_levies');
+  77: }
+  78: 
+  79: export function getWalletLedgerContainer(): Container {
+  80:   return getCosmosClient().database(DB_NAME).container('wallet_ledger');
+  81: }
+  82: 
+  83: export function getRatingsContainer(): Container {
+  84:   return getCosmosClient().database(DB_NAME).container('ratings');
+  85: }
+  86: 
+  87: export function getCustomerCreditsContainer(): Container {
+  88:   return getCosmosClient().database(DB_NAME).container('customer_credits');
+  89: }
+  90: 
+  91: export function getWebhookEventsContainer(): Container {
+  92:   return getCosmosClient().database(DB_NAME).container('webhook_events');
+  93: }
+  94: 
+  95: export function getSystemContainer(): Container {
+  96:   return getCosmosClient().database(DB_NAME).container('system');
+  97: }
+  98: 
+  99: export function getPendingActionsContainer(): Container {
+ 100:   return getCosmosClient().database(DB_NAME).container('pending_actions');
+ 101: }
+ 102: 
+ 103: /**
+ 104:  * E13-S01: Customer credit ledger entries (issued / applied / refunded).
+ 105:  * Stored in the existing `customer_credits` container, partitioned by /customerId.
+ 106:  * No new container â€” the original `CustomerCreditDoc` records remain; we add
+ 107:  * new `CustomerCreditLedgerDoc` records alongside them with type='CREDIT_APPLIED'.
+ 108:  */
+ 109: export function getCustomerCreditLedgerContainer(): Container {
+ 110:   return getCosmosClient().database(DB_NAME).container('customer_credits');
+ 111: }
+ 112: 
+ 113: /**
+ 114:  * E13-S01: Applied-credit idempotency dedup.
+ 115:  * Separate container so TTL can be set at the container level (86400 s = 24h).
+ 116:  * Partitioned by /customerId (same access pattern as credits).
+ 117:  */
+ 118: export function getAppliedCreditIdempotencyContainer(): Container {
+ 119:   return getCosmosClient().database(DB_NAME).container('applied_credit_idempotency');
+ 120: }
+ 121: 
+ 122: /**
+ 123:  * E16-S02: Slot holds for conflict locking.
+ 124:  * Partitioned by /servicePartitionKey ("<serviceId>|<date>"). Default TTL = 30 s.
+ 125:  * commitHold sets ttl=-1 on committed docs to make them permanent.
+ 126:  */
+ 127: export function getSlotHoldsContainer(): Container {
+ 128:   return getCosmosClient().database(DB_NAME).container('slot_holds');
+ 129: }
+ 130: 
+ 131: /** Inject a mock CosmosClient in tests. */
+ 132: export function _setCosmosClientForTest(mock: CosmosClient): void {
+ 133:   _client = mock;
+ 134: }
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command '$p='"'api/src/functions/services-availability.ts'; "'$i=0; Get-Content $p | ForEach-Object { $i++; '"'{0,4}: {1}' -f "'$i, $_ }' in C:\Alok\Business Projects\Urbanclap-dup
+ succeeded in 900ms:
+   1: import { app } from '@azure/functions';
+   2: import { z } from 'zod';
+   3: import { requireCustomer, type CustomerHttpHandler } from '../middleware/requireCustomer.js';
+   4: import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+   5: import { slotHoldsRepo } from '../cosmos/slot-holds-repository.js';
+   6: import { bookingRepo } from '../cosmos/booking-repository.js';
+   7: import { generateSlots } from '../shared/slot-utils.js';
+   8: 
+   9: // IST offset from UTC in minutes (UTC+5:30)
+  10: const IST_OFFSET_MINUTES = 5 * 60 + 30;
+  11: 
+  12: function todayIst(): string {
+  13:   const now = new Date();
+  14:   const istMs = now.getTime() + IST_OFFSET_MINUTES * 60_000;
+  15:   return new Date(istMs).toISOString().slice(0, 10);
+  16: }
+  17: 
+  18: function addDays(yyyymmdd: string, days: number): string {
+  19:   const d = new Date(`${yyyymmdd}T00:00:00Z`);
+  20:   d.setUTCDate(d.getUTCDate() + days);
+  21:   return d.toISOString().slice(0, 10);
+  22: }
+  23: 
+  24: const DateQuerySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine((s) => {
+  25:   const d = new Date(`${s}T00:00:00Z`);
+  26:   return !isNaN(d.getTime());
+  27: }, { message: 'Invalid calendar date' });
+  28: 
+  29: export const availabilityHandler: CustomerHttpHandler = async (req, _ctx, _customer) => {
+  30:   const { id: serviceId } = (req as unknown as { params: { id: string } }).params;
+  31:   const dateParam = (req as unknown as { query: { get(k: string): string | null } }).query.get('date');
+  32: 
+  33:   // Validate date param format
+  34:   const dateParsed = DateQuerySchema.safeParse(dateParam);
+  35:   if (!dateParsed.success) {
+  36:     return { status: 422, jsonBody: { code: 'INVALID_DATE_RANGE', message: 'date must be YYYY-MM-DD' } };
+  37:   }
+  38:   const date = dateParsed.data;
+  39: 
+  40:   // Validate range: today IST â‰¤ date â‰¤ today+7 IST
+  41:   const today = todayIst();
+  42:   const max = addDays(today, 7);
+  43:   if (date < today || date > max) {
+  44:     return {
+  45:       status: 422,
+  46:       jsonBody: {
+  47:         code: 'INVALID_DATE_RANGE',
+  48:         message: `date must be between ${today} and ${max} (IST)`,
+  49:       },
+  50:     };
+  51:   }
+  52: 
+  53:   // Look up service
+  54:   const service = await catalogueRepo.getServiceByIdCrossPartition(serviceId);
+  55:   if (!service || !service.isActive) {
+  56:     return { status: 404, jsonBody: { code: 'SERVICE_NOT_FOUND' } };
+  57:   }
+  58: 
+  59:   // Generate server-side slot windows
+  60:   const allWindows = generateSlots(service, date);
+  61: 
+  62:   // Load held + hard-booked windows in parallel
+  63:   const [holds, bookedWindows] = await Promise.all([
+  64:     slotHoldsRepo.listHolds(serviceId, date),
+  65:     bookingRepo.getBookedWindowsByServiceDate(serviceId, date),
+  66:   ]);
+  67: 
+  68:   const unavailable = new Set<string>([
+  69:     ...holds.map((h) => h.window),
+  70:     ...bookedWindows,
+  71:   ]);
+  72: 
+  73:   return {
+  74:     status: 200,
+  75:     jsonBody: {
+  76:       serviceId,
+  77:       date,
+  78:       slotGranularityMinutes: service.durationMinutes,
+  79:       slots: allWindows.map((window) => ({ window, available: !unavailable.has(window) })),
+  80:     },
+  81:   };
+  82: };
+  83: 
+  84: app.http('servicesAvailability', {
+  85:   methods: ['GET'],
+  86:   route: 'v1/services/{id}/availability',
+  87:   handler: requireCustomer(availabilityHandler),
+  88: });
+
+exec
+"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command 'Select-String -Path api/**/* -Pattern "slot_holds|SlotHolds|commitHold|createHold|availability" -CaseSensitive:$false -ErrorAction SilentlyContinue | Select-Object -First 200' in C:\Alok\Business Projects\Urbanclap-dup
+2026-05-16T13:32:54.687363Z ERROR codex_core::tools::router: error=Exit code: 1
+Wall time: 0.6 seconds
+Output:
+
+api\coverage\lcov.info:1621:FN:84,defaultAvailabilityWindows
+api\coverage\lcov.info:1622:FN:90,normalizeAvailability
+api\coverage\lcov.info:1623:FN:102,getTechnicianAvailability
+api\coverage\lcov.info:1624:FN:109,patchTechnicianAvailability
+api\coverage\lcov.info:1646:FNDA:0,defaultAvailabilityWindows
+api\coverage\lcov.info:1647:FNDA:0,normalizeAvailability
+api\coverage\lcov.info:1648:FNDA:0,getTechnicianAvailability
+api\coverage\lcov.info:1649:FNDA:0,patchTechnicianAvailability
+api\coverage\lcov.info:4314:FN:90,getMyTechnicianAvailabilityHandler
+api\coverage\lcov.info:4315:FN:109,patchMyTechnicianAvailabilityHandler
+api\coverage\lcov.info:4326:FNDA:2,getMyTechnicianAvailabilityHandler
+api\coverage\lcov.info:4327:FNDA:2,patchMyTechnicianAvailabilityHandler
+api\scripts\seed-technicians.ts:20:    availabilityWindows: [
+api\scripts\seed-technicians.ts:37:    availabilityWindows: [
+api\scripts\seed-technicians.ts:53:    availabilityWindows: [
+api\scripts\seed-technicians.ts:71:    availabilityWindows: [
+api\scripts\seed-technicians.ts:89:    availabilityWindows: [
+api\scripts\seed-technicians.ts:104:    availabilityWindows: [
+api\scripts\seed-technicians.ts:119:    availabilityWindows: [
+api\scripts\seed-technicians.ts:135:    availabilityWindows: [
+api\scripts\seed-technicians.ts:151:    availabilityWindows: [
+api\scripts\seed-technicians.ts:166:    availabilityWindows: [
+api\scripts\setup-cosmos.ts:100:  // Default TTL = 30 s (soft hold). commitHold sets TTL = -1 on the doc to make 
+permanent.
+api\scripts\setup-cosmos.ts:102:    id: 'slot_holds',
+api\scripts\setup-cosmos.ts:106:  console.log("Container 'slot_holds' ready.");
+
+
+
+ exited 1 in 649ms:
+
+api\coverage\lcov.info:1621:FN:84,defaultAvailabilityWindows
+api\coverage\lcov.info:1622:FN:90,normalizeAvailability
+api\coverage\lcov.info:1623:FN:102,getTechnicianAvailability
+api\coverage\lcov.info:1624:FN:109,patchTechnicianAvailability
+api\coverage\lcov.info:1646:FNDA:0,defaultAvailabilityWindows
+api\coverage\lcov.info:1647:FNDA:0,normalizeAvailability
+api\coverage\lcov.info:1648:FNDA:0,getTechnicianAvailability
+api\coverage\lcov.info:1649:FNDA:0,patchTechnicianAvailability
+api\coverage\lcov.info:4314:FN:90,getMyTechnicianAvailabilityHandler
+api\coverage\lcov.info:4315:FN:109,patchMyTechnicianAvailabilityHandler
+api\coverage\lcov.info:4326:FNDA:2,getMyTechnicianAvailabilityHandler
+api\coverage\lcov.info:4327:FNDA:2,patchMyTechnicianAvailabilityHandler
+api\scripts\seed-technicians.ts:20:    availabilityWindows: [
+api\scripts\seed-technicians.ts:37:    availabilityWindows: [
+api\scripts\seed-technicians.ts:53:    availabilityWindows: [
+api\scripts\seed-technicians.ts:71:    availabilityWindows: [
+api\scripts\seed-technicians.ts:89:    availabilityWindows: [
+api\scripts\seed-technicians.ts:104:    availabilityWindows: [
+api\scripts\seed-technicians.ts:119:    availabilityWindows: [
+api\scripts\seed-technicians.ts:135:    availabilityWindows: [
+api\scripts\seed-technicians.ts:151:    availabilityWindows: [
+api\scripts\seed-technicians.ts:166:    availabilityWindows: [
+api\scripts\setup-cosmos.ts:100:  // Default TTL = 30 s (soft hold). commitHold sets TTL = -1 on the doc to make 
+permanent.
+api\scripts\setup-cosmos.ts:102:    id: 'slot_holds',
+api\scripts\setup-cosmos.ts:106:  console.log("Container 'slot_holds' ready.");
+
+
+
+codex
+The slot-locking path can still allow duplicate bookings because it does not enforce existing bookings and committed holds fail to become permanent. Cosmos error handling also misses real conflict codes, and same-day availability can expose already elapsed slots.
+
+Full review comments:
+
+- [P1] Reject existing bookings before holding slots — C:\Alok\Business Projects\Urbanclap-dup\api\src\cosmos\slot-holds-repository.ts:34-34
+  When a slot already has an active booking but no `slot_holds` document (for example, every booking created before this container is deployed/backfilled, or after a hold doc is lost/expired), this create-only check succeeds and the handler proceeds to create another booking for the same `serviceId`/date/window. The availability endpoint consults `bookings`, but `POST /v1/bookings` does not, so availability is only advisory; please reject active booked windows here or backfill/enforce them in the hold container.
+
+- [P1] Add ttl instead of replacing an absent field — C:\Alok\Business Projects\Urbanclap-dup\api\src\cosmos\slot-holds-repository.ts:53-53
+  New soft holds intentionally omit `ttl`, so Cosmos PATCH `replace` on `/ttl` targets a property that does not exist and fails the whole patch. Because callers treat `commitHold` as non-fatal, the hold remains soft and expires after 30s; after that `createHold` can accept the same slot again. Use `add`/`set` for `/ttl` or include `ttl` on create.
+
+- [P2] Read Cosmos errors from code, not statusCode — C:\Alok\Business Projects\Urbanclap-dup\api\src\cosmos\slot-holds-repository.ts:37-38
+  The `@azure/cosmos` `ErrorResponse` sets the HTTP status on `err.code`, not `statusCode` as mocked here. In production, a duplicate hold will throw `{ code: 409 }`, so this path rethrows and the booking API returns a 500 instead of `SLOT_UNAVAILABLE`; the same pattern below also misses 404 from `commitHold`.
+
+- [P2] Filter elapsed slots for today's date — C:\Alok\Business Projects\Urbanclap-dup\api\src\functions\services-availability.ts:60-60
+  When the requested date is today's IST date after some slots have already elapsed, `generateSlots` still returns the full day and these windows are emitted as available; the create path uses the same unfiltered generation to accept them. This lets customers book times in the past, so filter out elapsed windows for `date === today` before marking them available or valid.
+2026-05-16T13:33:48.318981Z ERROR codex_core::session: failed to record rollout items: thread 019e30f9-0346-70d2-8bd7-beee1b5e94a7 not found
+2026-05-16T13:33:48.411993Z ERROR codex_core::session: failed to record rollout items: thread 019e30f9-022a-76b2-a4b7-e7134e183283 not found
+The slot-locking path can still allow duplicate bookings because it does not enforce existing bookings and committed holds fail to become permanent. Cosmos error handling also misses real conflict codes, and same-day availability can expose already elapsed slots.
+
+Full review comments:
+
+- [P1] Reject existing bookings before holding slots — C:\Alok\Business Projects\Urbanclap-dup\api\src\cosmos\slot-holds-repository.ts:34-34
+  When a slot already has an active booking but no `slot_holds` document (for example, every booking created before this container is deployed/backfilled, or after a hold doc is lost/expired), this create-only check succeeds and the handler proceeds to create another booking for the same `serviceId`/date/window. The availability endpoint consults `bookings`, but `POST /v1/bookings` does not, so availability is only advisory; please reject active booked windows here or backfill/enforce them in the hold container.
+
+- [P1] Add ttl instead of replacing an absent field — C:\Alok\Business Projects\Urbanclap-dup\api\src\cosmos\slot-holds-repository.ts:53-53
+  New soft holds intentionally omit `ttl`, so Cosmos PATCH `replace` on `/ttl` targets a property that does not exist and fails the whole patch. Because callers treat `commitHold` as non-fatal, the hold remains soft and expires after 30s; after that `createHold` can accept the same slot again. Use `add`/`set` for `/ttl` or include `ttl` on create.
+
+- [P2] Read Cosmos errors from code, not statusCode — C:\Alok\Business Projects\Urbanclap-dup\api\src\cosmos\slot-holds-repository.ts:37-38
+  The `@azure/cosmos` `ErrorResponse` sets the HTTP status on `err.code`, not `statusCode` as mocked here. In production, a duplicate hold will throw `{ code: 409 }`, so this path rethrows and the booking API returns a 500 instead of `SLOT_UNAVAILABLE`; the same pattern below also misses 404 from `commitHold`.
+
+- [P2] Filter elapsed slots for today's date — C:\Alok\Business Projects\Urbanclap-dup\api\src\functions\services-availability.ts:60-60
+  When the requested date is today's IST date after some slots have already elapsed, `generateSlots` still returns the full day and these windows are emitted as available; the create path uses the same unfiltered generation to accept them. This lets customers book times in the past, so filter out elapsed windows for `date === today` before marking them available or valid.


### PR DESCRIPTION
## Summary

- **GET /v1/services/{id}/availability?date=YYYY-MM-DD** — new endpoint; generates server-side slot windows using `service.durationMinutes` / `workStart` / `workEnd` (defaults 08:00–20:00); overlays soft holds (`slot_holds` Cosmos container, 30 s TTL) and hard bookings to return per-slot `available: boolean`. Past windows filtered for today (IST).
- **POST /v1/bookings** extended with slot-hold gate: validates `slotWindow` against generated windows (422 `INVALID_SLOT_WINDOW`), checks existing bookings for pre-deployment safety (409 `SLOT_UNAVAILABLE`), creates a soft hold via `createHold` (409/412 Cosmos → `SLOT_UNAVAILABLE`), then commits the hold to permanent after booking write.
- **`slot_holds` Cosmos container** provisioned in `setup-cosmos.ts` (TTL=30s, partition key `/servicePartitionKey`).
- **Service schema** gains optional `workStart`/`workEnd` fields (additive; no catalogue migration).
- **Codex P1/P2 fixes included**: `err.code` not `err.statusCode`, PATCH `add` not `replace` for absent `ttl`, pre-hold bookings guard, elapsed slot filtering.

## Files changed

| Layer | File |
|---|---|
| Container provisioning | `api/scripts/setup-cosmos.ts` |
| Cosmos client | `api/src/cosmos/client.ts` — `getSlotHoldsContainer` |
| New repository | `api/src/cosmos/slot-holds-repository.ts` |
| Booking repo | `api/src/cosmos/booking-repository.ts` — `getBookedWindowsByServiceDate` |
| New schema | `api/src/schemas/slot-hold.ts` |
| Service schema | `api/src/schemas/service.ts` — `workStart`/`workEnd`, `AvailabilityResponseSchema` |
| Shared util | `api/src/shared/slot-utils.ts` — `generateSlots`, `filterElapsedSlots`, `todayIst`, `currentIstMinuteOfDay` |
| New function | `api/src/functions/services-availability.ts` |
| Modified function | `api/src/functions/bookings.ts` — slot-hold gate + commitHold on all 4 success paths |
| Tests (5 new) | `slot-hold.test.ts`, `slot-utils.test.ts`, `slot-holds-repository.test.ts`, `services-availability.test.ts`, `bookings-slot-gate.test.ts` |
| Tests (3 updated) | `create.test.ts`, `create-apply-credit.test.ts`, `create-service-area.test.ts` — slotHoldsRepo mock + durationMinutes |

## Test plan

- [x] Pre-codex smoke gate passed (`bash tools/pre-codex-smoke-api.sh`) — 1265 tests green
- [x] Codex review run (`gpt-5.5`) — 2 P1s + 2 P2s found and fixed in a follow-up commit
- [x] `.codex-review-passed` marker written at `ce64aa02`
- [ ] CI green on push

## ADR / threat-model notes

Hold duration is 30 s (plan default). Extending past 300 s requires a separate ADR. Slot-spoofing is bounded by server-side `generateSlots` validation + service-area gating (ADR-0020) upstream.

**Blocks:** E16-S05 (customer-app slot picker UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)