### PR TITLE
feat(E16-S03): photo-first catalogue UI behind feature flag

### DIFF
--- a/.codex-review-passed
+++ b/.codex-review-passed
@@ -1,1 +1,1 @@
-{"timestamp":"2026-05-14T10:09:56-04:00","commit":"4d117ac2b46af74560d5049f28127ef7846f9bb1","reviewer":"codex","reviews":["W5-quality-floor: gpt-5.5 no CRITICAL/MAJOR","W1-network-foundation: gpt-5.5 2 rounds P1+P2 fixed inline"]}
+{"timestamp":"2026-05-16T23:21:00Z","commit":"64dac6c7","reviewer":"codex-cli 0.125.0","reviews":["E16-S03 photo-first catalogue UI: codex review --base main — clean pass, no correctness/build/runtime issues; changes limited to ServiceListScreen flag gating + shouldRenderCdnImage helper extraction + DTO/fallback/Paparazzi tests"]}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
@@ -53,7 +53,7 @@ private fun NavGraphBuilder.catalogueGraph(
     navigation(startDestination = CatalogueRoutes.HOME, route = ROUTE_MAIN) {
         homeDestination(navController, featureFlags)
         walletDestination(navController)
-        serviceListDestination(navController)
+        serviceListDestination(navController, featureFlags)
         serviceDetailDestination(navController)
         // Complaint list — accessible from Settings → My Complaints
         composable(route = ComplaintRoutes.LIST) {
@@ -116,7 +116,10 @@ private fun NavGraphBuilder.walletDestination(navController: NavController) {
     }
 }
 
-private fun NavGraphBuilder.serviceListDestination(navController: NavController) {
+private fun NavGraphBuilder.serviceListDestination(
+    navController: NavController,
+    featureFlags: FeatureFlags,
+) {
     composable(
         route = CatalogueRoutes.SERVICE_LIST,
         arguments = listOf(navArgument("categoryId") { type = NavType.StringType }),
@@ -126,6 +129,7 @@ private fun NavGraphBuilder.serviceListDestination(navController: NavController)
             viewModel = vm,
             onServiceClick = { id -> navController.navigate(CatalogueRoutes.serviceDetail(id)) },
             onBack = { navController.popBackStack() },
+            photoFirstCatalogueEnabled = featureFlags.photoFirstCatalogueEnabled(),
         )
     }
 }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstCategoryCard.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstCategoryCard.kt
@@ -98,7 +98,7 @@ internal fun PhotoFirstCategoryCard(
 
     // Track whether the Coil load succeeded so we can show the icon fallback.
     var imageLoadFailed by remember { mutableStateOf(false) }
-    val showImage = category.imageUrl.isNotBlank() && !imageLoadFailed
+    val showImage = shouldRenderCdnImage(category.imageUrl) && !imageLoadFailed
 
     Box(
         modifier =

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstImageResolver.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstImageResolver.kt
@@ -1,0 +1,11 @@
+package com.homeservices.customer.ui.catalogue
+
+/**
+ * E16-S03 — Shared helper used by [PhotoFirstCategoryCard] and [PhotoFirstServiceCard]
+ * to decide whether to attempt a CDN image load.
+ *
+ * A blank URL means the API has not yet populated a hero photo for this item.
+ * In that case the cards short-circuit to their text/icon fallback rather than
+ * issuing a doomed Coil request.
+ */
+internal fun shouldRenderCdnImage(imageUrl: String): Boolean = imageUrl.isNotBlank()

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstServiceCard.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstServiceCard.kt
@@ -88,7 +88,7 @@ internal fun PhotoFirstServiceCard(
 @Composable
 private fun PhotoServiceHeroImage(service: Service) {
     var imageLoadFailed by remember { mutableStateOf(false) }
-    val showImage = service.imageUrl.isNotBlank() && !imageLoadFailed
+    val showImage = shouldRenderCdnImage(service.imageUrl) && !imageLoadFailed
 
     if (showImage) {
         AsyncImage(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/ServiceListScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/catalogue/ServiceListScreen.kt
@@ -66,6 +66,7 @@ internal fun ServiceListScreen(
     viewModel: ServiceListViewModel,
     onServiceClick: (String) -> Unit,
     onBack: () -> Unit,
+    photoFirstCatalogueEnabled: Boolean = false,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     Scaffold(
@@ -106,6 +107,7 @@ internal fun ServiceListScreen(
             uiState = uiState,
             onServiceClick = onServiceClick,
             modifier = Modifier.padding(innerPadding),
+            photoFirstCatalogueEnabled = photoFirstCatalogueEnabled,
         )
     }
 }
@@ -115,6 +117,7 @@ internal fun ServiceListContent(
     uiState: ServiceListUiState,
     onServiceClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    photoFirstCatalogueEnabled: Boolean = false,
 ) {
     Surface(modifier = modifier.fillMaxSize(), color = WarmIvory) {
         when (uiState) {
@@ -147,7 +150,14 @@ internal fun ServiceListContent(
                         }
                     } else {
                         items(uiState.services, key = { it.id }) { service ->
-                            ServiceCard(service = service, onClick = { onServiceClick(service.id) })
+                            if (photoFirstCatalogueEnabled) {
+                                PhotoFirstServiceCard(
+                                    service = service,
+                                    onClick = { onServiceClick(service.id) },
+                                )
+                            } else {
+                                ServiceCard(service = service, onClick = { onServiceClick(service.id) })
+                            }
                         }
                     }
                 }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/data/catalogue/remote/dto/CategoryDtoPhotoUrlTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/data/catalogue/remote/dto/CategoryDtoPhotoUrlTest.kt
@@ -1,0 +1,87 @@
+package com.homeservices.customer.data.catalogue.remote.dto
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * E16-S03 — Verifies the DTO pipeline carries `heroImageUrl` through to
+ * the domain `imageUrl` field for both [CategoryDto] and the two service DTO
+ * shapes. This is the contract that PhotoFirstCategoryCard / PhotoFirstServiceCard
+ * rely on once the catalogue API serves CDN URLs.
+ */
+public class CategoryDtoPhotoUrlTest {
+    @Test
+    public fun `CategoryDto heroImageUrl is carried to Category imageUrl`() {
+        val dto =
+            CategoryDto(
+                id = "ac-repair",
+                name = "AC Repair",
+                heroImageUrl = "https://cdn.example.com/cat.jpg",
+                sortOrder = 1,
+                services = emptyList(),
+            )
+        assertThat(dto.toDomain().imageUrl).isEqualTo("https://cdn.example.com/cat.jpg")
+    }
+
+    @Test
+    public fun `CategoryDto blank heroImageUrl is carried through (triggers fallback downstream)`() {
+        val dto =
+            CategoryDto(
+                id = "ac-repair",
+                name = "AC Repair",
+                heroImageUrl = "",
+                sortOrder = 1,
+                services = emptyList(),
+            )
+        assertThat(dto.toDomain().imageUrl).isEmpty()
+    }
+
+    @Test
+    public fun `ServiceCardDto heroImageUrl is carried to Service imageUrl`() {
+        val dto =
+            ServiceCardDto(
+                id = "ac-clean",
+                categoryId = "ac-repair",
+                name = "AC deep cleaning",
+                shortDescription = "Foam cleaning + filter wash",
+                heroImageUrl = "https://cdn.example.com/svc.jpg",
+                basePrice = 79900,
+                durationMinutes = 60,
+            )
+        assertThat(dto.toDomain().imageUrl).isEqualTo("https://cdn.example.com/svc.jpg")
+    }
+
+    @Test
+    public fun `ServiceDto heroImageUrl is carried to Service imageUrl`() {
+        val dto =
+            ServiceDto(
+                id = "ac-clean",
+                categoryId = "ac-repair",
+                name = "AC deep cleaning",
+                shortDescription = "Foam cleaning + filter wash",
+                heroImageUrl = "https://cdn.example.com/svc-detail.jpg",
+                basePrice = 79900,
+                durationMinutes = 60,
+                includes = emptyList(),
+                addOns = emptyList(),
+            )
+        assertThat(dto.toDomain().imageUrl).isEqualTo("https://cdn.example.com/svc-detail.jpg")
+    }
+
+    @Test
+    public fun `ServiceDto blank heroImageUrl is carried through`() {
+        val dto =
+            ServiceDto(
+                id = "ac-clean",
+                categoryId = "ac-repair",
+                name = "AC deep cleaning",
+                shortDescription = "Foam cleaning + filter wash",
+                heroImageUrl = "",
+                basePrice = 79900,
+                durationMinutes = 60,
+                includes = emptyList(),
+                addOns = emptyList(),
+            )
+        assertThat(dto.toDomain().imageUrl).isEmpty()
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstCardFallbackTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstCardFallbackTest.kt
@@ -1,0 +1,26 @@
+package com.homeservices.customer.ui.catalogue
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * E16-S03 — Unit tests for the [shouldRenderCdnImage] helper used by both
+ * photo-first card composables to decide between rendering an [coil.compose.AsyncImage]
+ * vs. the icon/initials fallback.
+ */
+public class PhotoFirstCardFallbackTest {
+    @Test
+    public fun `blank URL falls back (no Coil request issued)`() {
+        assertThat(shouldRenderCdnImage("")).isFalse()
+    }
+
+    @Test
+    public fun `whitespace-only URL falls back`() {
+        assertThat(shouldRenderCdnImage("   ")).isFalse()
+    }
+
+    @Test
+    public fun `valid HTTPS CDN URL triggers image render`() {
+        assertThat(shouldRenderCdnImage("https://cdn.example.com/s.jpg")).isTrue()
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstCategoryCardPaparazziTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstCategoryCardPaparazziTest.kt
@@ -1,0 +1,69 @@
+package com.homeservices.customer.ui.catalogue
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.customer.domain.catalogue.model.Category
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * E16-S03 — Paparazzi screenshots for [PhotoFirstCategoryCard].
+ *
+ * All tests are @Ignored: photo assets are not yet commissioned, the
+ * `customer.photo-first-catalogue.enabled` flag stays OFF in prod, and Paparazzi
+ * goldens for this story are recorded on CI Linux only — see
+ * docs/patterns/paparazzi-cross-os-goldens.md.
+ */
+@RunWith(JUnit4::class)
+public class PhotoFirstCategoryCardPaparazziTest {
+    @get:Rule
+    public val paparazzi: Paparazzi =
+        Paparazzi(
+            deviceConfig = DeviceConfig.PIXEL_5,
+            theme = "android:Theme.Material3.DayNight.NoActionBar",
+        )
+
+    @Ignore("Goldens recorded on CI Linux only — assets not yet commissioned (E16-S03)")
+    @Test
+    public fun withPhotoUrl_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                PhotoFirstCategoryCard(
+                    category =
+                        Category(
+                            id = "ac-repair",
+                            name = "AC Repair",
+                            imageUrl = "https://cdn.example.com/ac-hero.jpg",
+                            serviceCount = 5,
+                            minPricePaise = 29900,
+                        ),
+                    onClick = {},
+                )
+            }
+        }
+    }
+
+    @Ignore("Goldens recorded on CI Linux only — assets not yet commissioned (E16-S03)")
+    @Test
+    public fun fallbackNoUrl_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                PhotoFirstCategoryCard(
+                    category =
+                        Category(
+                            id = "plumbing",
+                            name = "Plumbing",
+                            imageUrl = "",
+                            serviceCount = 4,
+                            minPricePaise = 19900,
+                        ),
+                    onClick = {},
+                )
+            }
+        }
+    }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstServiceCardPaparazziTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/catalogue/PhotoFirstServiceCardPaparazziTest.kt
@@ -1,0 +1,77 @@
+package com.homeservices.customer.ui.catalogue
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.homeservices.customer.domain.catalogue.model.Service
+import com.homeservices.designsystem.theme.HomeservicesTheme
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * E16-S03 — Paparazzi screenshots for [PhotoFirstServiceCard].
+ *
+ * All tests are @Ignored: photo assets are not yet commissioned, the
+ * `customer.photo-first-catalogue.enabled` flag stays OFF in prod, and Paparazzi
+ * goldens for this story are recorded on CI Linux only — see
+ * docs/patterns/paparazzi-cross-os-goldens.md.
+ */
+@RunWith(JUnit4::class)
+public class PhotoFirstServiceCardPaparazziTest {
+    @get:Rule
+    public val paparazzi: Paparazzi =
+        Paparazzi(
+            deviceConfig = DeviceConfig.PIXEL_5,
+            theme = "android:Theme.Material3.DayNight.NoActionBar",
+        )
+
+    @Ignore("Goldens recorded on CI Linux only — assets not yet commissioned (E16-S03)")
+    @Test
+    public fun withPhotoUrl_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                PhotoFirstServiceCard(
+                    service =
+                        Service(
+                            id = "s1",
+                            categoryId = "ac-repair",
+                            name = "AC deep cleaning",
+                            description = "Foam cleaning, filter wash, and drain check.",
+                            basePrice = 79900,
+                            durationMinutes = 60,
+                            imageUrl = "https://cdn.example.com/ac-clean.jpg",
+                            includes = emptyList(),
+                            addOns = emptyList(),
+                        ),
+                    onClick = {},
+                )
+            }
+        }
+    }
+
+    @Ignore("Goldens recorded on CI Linux only — assets not yet commissioned (E16-S03)")
+    @Test
+    public fun fallbackNoUrl_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                PhotoFirstServiceCard(
+                    service =
+                        Service(
+                            id = "s2",
+                            categoryId = "ac-repair",
+                            name = "AC gas refill",
+                            description = "Leak inspection and pressure-adjusted gas refill.",
+                            basePrice = 129900,
+                            durationMinutes = 90,
+                            imageUrl = "",
+                            includes = emptyList(),
+                            addOns = emptyList(),
+                        ),
+                    onClick = {},
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Wires the existing `PhotoFirstServiceCard` into `ServiceListScreen` via `customer.photo-first-catalogue.enabled` (the category-grid path was already wired in main; the service-list path was the missing piece).
- Extracts the shared `shouldRenderCdnImage(url)` helper used by both photo-first composables in place of inline `isNotBlank()` checks.
- Adds unit tests for the DTO → domain `imageUrl` pipeline (`CategoryDtoPhotoUrlTest`) and the fallback helper (`PhotoFirstCardFallbackTest`).
- Adds `@Ignored` Paparazzi stubs for both photo-first cards — goldens recorded on CI Linux only per `docs/patterns/paparazzi-cross-os-goldens.md`.
- Zero behaviour change while the GrowthBook flag is OFF (default).

## Test plan
- [x] Pre-Codex smoke gate green (6/6 — assembleDebug, ktlintCheck, detekt, lintDebug, testDebugUnitTest, koverVerify)
- [x] `codex review --base main` — clean pass, no correctness/build/runtime issues
- [x] Existing `ServiceListScreenPaparazziTest` golden unchanged (flag-OFF default preserves legacy `ServiceCard`)
- [ ] CI: lint + tests + Semgrep
- [ ] Smoke on device once Firebase Storage CDN URLs land — flag stays OFF until then

🤖 Generated with [Claude Code](https://claude.com/claude-code)