### PR TITLE
feat(E16-S05): API-driven slot picker (customer-app)

### DIFF
--- a/.codex-review-passed
+++ b/.codex-review-passed
@@ -1,1 +1,1 @@
-{"timestamp":"2026-05-17T13:55:00-04:00","commit":"815f3304","reviewer":"codex","model":"gpt-5.5","story":"E17-S01","rounds":2,"notes":"Round 1: P2 report-path mismatch (fixed). Round 2: no discrete issues."}
+{"timestamp":"2026-05-17T16:15:00-04:00","commit":"ed1a32a9","reviewer":"codex","model":"gpt-5.5","story":"E16-S05","rounds":3,"notes":"R1: 3xP2 (hour-only filter, race, retry-date) — fixed. R2: 3xP2 (recompose-reset, IST clock, flaky test) — fixed. R3: 1xP2 (non-scrollable content) — fixed without re-review per CLAUDE.md 'don't burn rounds iterating' rule."}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/SlotAvailabilityRepository.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/SlotAvailabilityRepository.kt
@@ -1,0 +1,12 @@
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+
+public interface SlotAvailabilityRepository {
+    public fun getAvailability(
+        serviceId: String,
+        date: LocalDate,
+    ): Flow<Result<List<SlotWindow>>>
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/SlotAvailabilityRepositoryImpl.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/SlotAvailabilityRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.homeservices.customer.data.booking
+
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+internal class SlotAvailabilityRepositoryImpl
+    @Inject
+    constructor(
+        private val api: BookingApiService,
+    ) : SlotAvailabilityRepository {
+        override fun getAvailability(
+            serviceId: String,
+            date: LocalDate,
+        ): Flow<Result<List<SlotWindow>>> =
+            flow {
+                emit(
+                    runCatching {
+                        api
+                            .getSlotAvailability(
+                                serviceId = serviceId,
+                                date = date.format(DateTimeFormatter.ISO_LOCAL_DATE),
+                            ).slots
+                            .map { it.toDomain() }
+                    },
+                )
+            }
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
@@ -18,12 +18,20 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.time.Clock
+import java.time.ZoneId
 import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 public annotation class AuthOkHttpClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+public annotation class IstClock
+
+private val IST_ZONE: ZoneId = ZoneId.of("Asia/Kolkata")
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -35,6 +43,11 @@ public abstract class BookingModule {
     internal abstract fun bindSlotAvailabilityRepository(impl: SlotAvailabilityRepositoryImpl): SlotAvailabilityRepository
 
     public companion object {
+        @Provides
+        @Singleton
+        @IstClock
+        public fun provideIstClock(): Clock = Clock.system(IST_ZONE)
+
         @Provides
         @Singleton
         @AuthOkHttpClient

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/di/BookingModule.kt
@@ -3,6 +3,8 @@ package com.homeservices.customer.data.booking.di
 import com.homeservices.customer.BuildConfig
 import com.homeservices.customer.data.booking.BookingRepository
 import com.homeservices.customer.data.booking.BookingRepositoryImpl
+import com.homeservices.customer.data.booking.SlotAvailabilityRepository
+import com.homeservices.customer.data.booking.SlotAvailabilityRepositoryImpl
 import com.homeservices.customer.data.booking.remote.BookingApiService
 import com.homeservices.customer.data.network.auth.FirebaseTokenAuthenticator
 import com.homeservices.customer.data.network.auth.IdTokenCache
@@ -28,6 +30,9 @@ public annotation class AuthOkHttpClient
 public abstract class BookingModule {
     @Binds
     internal abstract fun bindBookingRepository(impl: BookingRepositoryImpl): BookingRepository
+
+    @Binds
+    internal abstract fun bindSlotAvailabilityRepository(impl: SlotAvailabilityRepositoryImpl): SlotAvailabilityRepository
 
     public companion object {
         @Provides

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/BookingApiService.kt
@@ -8,11 +8,13 @@ import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
 import com.homeservices.customer.data.booking.remote.dto.CreateBookingResponseDto
 import com.homeservices.customer.data.booking.remote.dto.CustomerBookingsResponseDto
 import com.homeservices.customer.data.booking.remote.dto.GetBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.SlotAvailabilityResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 public interface BookingApiService {
     @POST("v1/bookings")
@@ -40,4 +42,10 @@ public interface BookingApiService {
         @Path("id") bookingId: String,
         @Body body: ApproveFinalPriceRequestDto,
     ): ApproveFinalPriceResponseDto
+
+    @GET("v1/services/{id}/availability")
+    public suspend fun getSlotAvailability(
+        @Path("id") serviceId: String,
+        @Query("date") date: String,
+    ): SlotAvailabilityResponseDto
 }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/SlotAvailabilityDtos.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/data/booking/remote/dto/SlotAvailabilityDtos.kt
@@ -1,0 +1,17 @@
+package com.homeservices.customer.data.booking.remote.dto
+
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+public data class SlotDto(
+    val window: String,
+    val available: Boolean,
+) {
+    public fun toDomain(): SlotWindow = SlotWindow(window = window, available = available)
+}
+
+@JsonClass(generateAdapter = true)
+public data class SlotAvailabilityResponseDto(
+    val slots: List<SlotDto>,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/GetSlotAvailabilityUseCase.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/GetSlotAvailabilityUseCase.kt
@@ -1,0 +1,18 @@
+package com.homeservices.customer.domain.booking
+
+import com.homeservices.customer.data.booking.SlotAvailabilityRepository
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import javax.inject.Inject
+
+public class GetSlotAvailabilityUseCase
+    @Inject
+    public constructor(
+        private val repository: SlotAvailabilityRepository,
+    ) {
+        public operator fun invoke(
+            serviceId: String,
+            date: LocalDate,
+        ): Flow<Result<List<SlotWindow>>> = repository.getAvailability(serviceId, date)
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/SlotWindow.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/domain/booking/model/SlotWindow.kt
@@ -1,0 +1,6 @@
+package com.homeservices.customer.domain.booking.model
+
+public data class SlotWindow(
+    val window: String,
+    val available: Boolean,
+)

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/navigation/MainGraph.kt
@@ -188,6 +188,7 @@ private fun NavGraphBuilder.slotPickerDestination(navController: NavController) 
         val serviceId = backStackEntry.arguments?.getString("serviceId") ?: ""
         val categoryId = backStackEntry.arguments?.getString("categoryId") ?: ""
         SlotPickerScreen(
+            serviceId = serviceId,
             onSlotSelected = { slot ->
                 vm.pendingServiceId = serviceId
                 vm.pendingCategoryId = categoryId

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
@@ -58,10 +58,10 @@ internal fun SlotPickerScreen(
     viewModel: SlotPickerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
-    val initialDate = LocalDate.now()
+    val initialDate = viewModel.currentIstDate()
 
     LaunchedEffect(serviceId) {
-        viewModel.loadSlots(serviceId, initialDate)
+        viewModel.ensureInitialLoad(serviceId)
     }
 
     Scaffold(
@@ -120,6 +120,7 @@ internal fun SlotPickerContent(
                 )
 
                 DateChipsRow(
+                    today = initialDate,
                     selectedDate = (state as? SlotPickerUiState.Loaded)?.date ?: initialDate,
                     onDateSelect = onDateSelect,
                 )
@@ -153,10 +154,10 @@ internal fun SlotPickerContent(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun DateChipsRow(
+    today: LocalDate,
     selectedDate: LocalDate,
     onDateSelect: (LocalDate) -> Unit,
 ) {
-    val today = LocalDate.now()
     val dates = (0..6).map { today.plusDays(it.toLong()) }
     SlotCard(title = stringResource(R.string.slot_picker_date_label)) {
         FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
@@ -85,7 +85,7 @@ internal fun SlotPickerScreen(
             modifier = Modifier.fillMaxSize().padding(innerPadding),
             onDateSelect = { date -> viewModel.loadSlots(serviceId, date) },
             onSlotSelect = viewModel::selectSlot,
-            onRetry = { viewModel.retry(serviceId, initialDate) },
+            onRetry = viewModel::retry,
             onConfirm = { date, slot -> onSlotSelected(BookingSlot(date.format(DATE_ISO), slot.window)) },
         )
     }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
@@ -105,7 +107,11 @@ internal fun SlotPickerContent(
     Surface(modifier = modifier, color = MaterialTheme.colorScheme.background) {
         Column(modifier = Modifier.fillMaxSize()) {
             Column(
-                modifier = Modifier.weight(1f).padding(16.dp),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Text(

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreen.kt
@@ -1,6 +1,7 @@
 package com.homeservices.customer.ui.booking
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -15,52 +16,53 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.homeservices.customer.R
 import com.homeservices.customer.domain.booking.model.BookingSlot
+import com.homeservices.customer.domain.booking.model.SlotWindow
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 private val DATE_DISPLAY = DateTimeFormatter.ofPattern("EEE, d MMM")
 private val DATE_ISO = DateTimeFormatter.ISO_LOCAL_DATE
 
-private val TIME_WINDOWS =
-    listOf(
-        "08:00-10:00",
-        "10:00-12:00",
-        "12:00-14:00",
-        "14:00-16:00",
-        "16:00-18:00",
-        "18:00-20:00",
-    )
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SlotPickerScreen(
+    serviceId: String,
     onSlotSelected: (BookingSlot) -> Unit,
     onBack: () -> Unit,
+    viewModel: SlotPickerViewModel = hiltViewModel(),
 ) {
-    val today = LocalDate.now()
-    val dates = (0..6).map { today.plusDays(it.toLong()) }
-    var selectedDate by rememberSaveable { mutableStateOf<LocalDate?>(null) }
-    var selectedWindow by rememberSaveable { mutableStateOf<String?>(null) }
+    val state by viewModel.uiState.collectAsState()
+    val initialDate = LocalDate.now()
+
+    LaunchedEffect(serviceId) {
+        viewModel.loadSlots(serviceId, initialDate)
+    }
 
     Scaffold(
         topBar = {
@@ -77,60 +79,70 @@ internal fun SlotPickerScreen(
             )
         },
     ) { innerPadding ->
-        Surface(modifier = Modifier.fillMaxSize().padding(innerPadding), color = MaterialTheme.colorScheme.background) {
-            Column(modifier = Modifier.fillMaxSize()) {
-                Column(
-                    modifier = Modifier.weight(1f).padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        stringResource(R.string.slot_picker_heading),
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    Text(
-                        stringResource(R.string.slot_picker_subtitle),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    SlotSection(title = stringResource(R.string.slot_picker_date_label)) {
-                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            dates.forEach { date ->
-                                FilterChip(
-                                    selected = selectedDate == date,
-                                    onClick = { selectedDate = date },
-                                    label = { Text(date.format(DATE_DISPLAY)) },
-                                )
-                            }
-                        }
-                    }
-                    SlotSection(title = stringResource(R.string.slot_picker_time_label)) {
-                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            TIME_WINDOWS.forEach { window ->
-                                FilterChip(
-                                    selected = selectedWindow == window,
-                                    onClick = { selectedWindow = window },
-                                    label = { Text(window) },
-                                )
-                            }
-                        }
-                    }
+        SlotPickerContent(
+            state = state,
+            initialDate = initialDate,
+            modifier = Modifier.fillMaxSize().padding(innerPadding),
+            onDateSelect = { date -> viewModel.loadSlots(serviceId, date) },
+            onSlotSelect = viewModel::selectSlot,
+            onRetry = { viewModel.retry(serviceId, initialDate) },
+            onConfirm = { date, slot -> onSlotSelected(BookingSlot(date.format(DATE_ISO), slot.window)) },
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun SlotPickerContent(
+    state: SlotPickerUiState,
+    initialDate: LocalDate,
+    modifier: Modifier = Modifier,
+    onDateSelect: (LocalDate) -> Unit,
+    onSlotSelect: (SlotWindow) -> Unit,
+    onRetry: () -> Unit,
+    onConfirm: (LocalDate, SlotWindow) -> Unit,
+) {
+    Surface(modifier = modifier, color = MaterialTheme.colorScheme.background) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.weight(1f).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    stringResource(R.string.slot_picker_heading),
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    stringResource(R.string.slot_picker_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                DateChipsRow(
+                    selectedDate = (state as? SlotPickerUiState.Loaded)?.date ?: initialDate,
+                    onDateSelect = onDateSelect,
+                )
+
+                when (state) {
+                    is SlotPickerUiState.Loading -> LoadingBlock()
+                    is SlotPickerUiState.Error -> ErrorBlock(message = state.message, onRetry = onRetry)
+                    is SlotPickerUiState.Loaded -> LoadedBlock(state = state, onSlotSelect = onSlotSelect)
                 }
-                Surface(shadowElevation = 8.dp, color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxWidth()) {
-                    Row(modifier = Modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp)) {
-                        Button(
-                            onClick = {
-                                val date = selectedDate
-                                val window = selectedWindow
-                                if (date != null && window != null) {
-                                    onSlotSelected(BookingSlot(date.format(DATE_ISO), window))
-                                }
-                            },
-                            enabled = selectedDate != null && selectedWindow != null,
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(stringResource(R.string.slot_picker_next))
-                        }
+            }
+
+            Surface(shadowElevation = 8.dp, color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxWidth()) {
+                Row(modifier = Modifier.fillMaxWidth().navigationBarsPadding().padding(16.dp)) {
+                    val loaded = state as? SlotPickerUiState.Loaded
+                    val selected = loaded?.selected
+                    Button(
+                        onClick = {
+                            if (loaded != null && selected != null) onConfirm(loaded.date, selected)
+                        },
+                        enabled = selected != null && selected.available,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(R.string.slot_picker_confirm_slot))
                     }
                 }
             }
@@ -138,8 +150,141 @@ internal fun SlotPickerScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun SlotSection(
+private fun DateChipsRow(
+    selectedDate: LocalDate,
+    onDateSelect: (LocalDate) -> Unit,
+) {
+    val today = LocalDate.now()
+    val dates = (0..6).map { today.plusDays(it.toLong()) }
+    SlotCard(title = stringResource(R.string.slot_picker_date_label)) {
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            dates.forEach { date ->
+                FilterChip(
+                    selected = selectedDate == date,
+                    onClick = { onDateSelect(date) },
+                    label = { Text(date.format(DATE_DISPLAY)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingBlock() {
+    val desc = stringResource(R.string.slot_picker_loading_desc)
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(32.dp)
+                .semantics { contentDescription = desc },
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorBlock(
+    message: String,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            stringResource(R.string.slot_picker_error_label),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.error,
+        )
+        if (message.isNotBlank()) {
+            Text(message, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        OutlinedButton(onClick = onRetry) {
+            Text(stringResource(R.string.slot_picker_retry_button))
+        }
+    }
+}
+
+@Composable
+private fun LoadedBlock(
+    state: SlotPickerUiState.Loaded,
+    onSlotSelect: (SlotWindow) -> Unit,
+) {
+    val sections =
+        listOf(
+            stringResource(R.string.slot_picker_morning_label) to state.filteredSlots.filter { startHour(it.window) < MORNING_END },
+            stringResource(R.string.slot_picker_afternoon_label) to
+                state.filteredSlots.filter { startHour(it.window) in MORNING_END until EVENING_START },
+            stringResource(R.string.slot_picker_evening_label) to state.filteredSlots.filter { startHour(it.window) >= EVENING_START },
+        ).filter { it.second.isNotEmpty() }
+
+    if (sections.isEmpty()) {
+        Text(
+            stringResource(R.string.slot_picker_no_slots_label),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+
+    sections.forEach { (title, slots) ->
+        SlotSection(
+            title = title,
+            slots = slots,
+            selectedWindow = state.selected?.window,
+            onSelect = onSlotSelect,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun SlotSection(
+    title: String,
+    slots: List<SlotWindow>,
+    selectedWindow: String?,
+    onSelect: (SlotWindow) -> Unit,
+) {
+    SlotCard(title = title) {
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            slots.forEach { s ->
+                SlotChip(
+                    slot = s,
+                    selected = selectedWindow == s.window,
+                    onClick = { onSelect(s) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun SlotChip(
+    slot: SlotWindow,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        enabled = slot.available,
+        label = { Text(slot.window) },
+        colors =
+            FilterChipDefaults.filterChipColors(
+                disabledLabelColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+            ),
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun SlotCard(
     title: String,
     content: @Composable ColumnScope.() -> Unit,
 ) {
@@ -154,3 +299,8 @@ private fun SlotSection(
         }
     }
 }
+
+private const val MORNING_END = 12
+private const val EVENING_START = 17
+
+private fun startHour(window: String): Int = window.substringBefore(":").toIntOrNull() ?: 0

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerUiState.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerUiState.kt
@@ -1,0 +1,19 @@
+package com.homeservices.customer.ui.booking
+
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import java.time.LocalDate
+
+public sealed class SlotPickerUiState {
+    public object Loading : SlotPickerUiState()
+
+    public data class Loaded(
+        val date: LocalDate,
+        val slots: List<SlotWindow>,
+        val filteredSlots: List<SlotWindow>,
+        val selected: SlotWindow?,
+    ) : SlotPickerUiState()
+
+    public data class Error(
+        val message: String,
+    ) : SlotPickerUiState()
+}

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModel.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModel.kt
@@ -2,6 +2,7 @@ package com.homeservices.customer.ui.booking
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.homeservices.customer.data.booking.di.IstClock
 import com.homeservices.customer.domain.booking.GetSlotAvailabilityUseCase
 import com.homeservices.customer.domain.booking.model.SlotWindow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalTime
 import javax.inject.Inject
@@ -22,6 +24,7 @@ public class SlotPickerViewModel
     @Inject
     public constructor(
         private val getSlotAvailability: GetSlotAvailabilityUseCase,
+        @IstClock private val clock: Clock,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<SlotPickerUiState>(SlotPickerUiState.Loading)
         public val uiState: StateFlow<SlotPickerUiState> = _uiState.asStateFlow()
@@ -29,6 +32,18 @@ public class SlotPickerViewModel
         private var loadJob: Job? = null
         private var lastServiceId: String? = null
         private var lastRequestedDate: LocalDate? = null
+
+        public fun currentIstDate(): LocalDate = LocalDate.now(clock)
+
+        /**
+         * Idempotent first-time load. Safe to call on every recomposition: subsequent calls for the
+         * same serviceId are a no-op, preserving any user selection through configuration changes
+         * and back-stack restoration.
+         */
+        public fun ensureInitialLoad(serviceId: String) {
+            if (lastServiceId == serviceId) return
+            loadSlots(serviceId, currentIstDate())
+        }
 
         public fun loadSlots(
             serviceId: String,
@@ -77,8 +92,8 @@ public class SlotPickerViewModel
             slots: List<SlotWindow>,
             date: LocalDate,
         ): List<SlotWindow> {
-            if (date != LocalDate.now()) return slots
-            val nowMinute = LocalTime.now().toSecondOfDay() / SECONDS_PER_MINUTE
+            if (date != currentIstDate()) return slots
+            val nowMinute = LocalTime.now(clock).toSecondOfDay() / SECONDS_PER_MINUTE
             return slots.map { s ->
                 val startMinute = parseStartMinute(s.window)
                 if (startMinute != null && startMinute <= nowMinute) s.copy(available = false) else s

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModel.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModel.kt
@@ -1,0 +1,79 @@
+package com.homeservices.customer.ui.booking
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.homeservices.customer.domain.booking.GetSlotAvailabilityUseCase
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.LocalTime
+import javax.inject.Inject
+
+@HiltViewModel
+public class SlotPickerViewModel
+    @Inject
+    public constructor(
+        private val getSlotAvailability: GetSlotAvailabilityUseCase,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<SlotPickerUiState>(SlotPickerUiState.Loading)
+        public val uiState: StateFlow<SlotPickerUiState> = _uiState.asStateFlow()
+
+        public fun loadSlots(
+            serviceId: String,
+            date: LocalDate,
+        ) {
+            _uiState.value = SlotPickerUiState.Loading
+            viewModelScope.launch {
+                getSlotAvailability(serviceId, date)
+                    .catch { err ->
+                        _uiState.value = SlotPickerUiState.Error(err.message ?: "Unknown error")
+                    }.onEach { result ->
+                        result
+                            .onSuccess { slots ->
+                                _uiState.value =
+                                    SlotPickerUiState.Loaded(
+                                        date = date,
+                                        slots = slots,
+                                        filteredSlots = applyPastTimeFilter(slots, date),
+                                        selected = null,
+                                    )
+                            }.onFailure { err ->
+                                _uiState.value = SlotPickerUiState.Error(err.message ?: "Unknown error")
+                            }
+                    }.collect()
+            }
+        }
+
+        public fun selectSlot(slot: SlotWindow) {
+            val current = _uiState.value
+            if (current is SlotPickerUiState.Loaded) {
+                _uiState.value = current.copy(selected = slot)
+            }
+        }
+
+        public fun retry(
+            serviceId: String,
+            date: LocalDate,
+        ) {
+            loadSlots(serviceId, date)
+        }
+
+        private fun applyPastTimeFilter(
+            slots: List<SlotWindow>,
+            date: LocalDate,
+        ): List<SlotWindow> {
+            if (date != LocalDate.now()) return slots
+            val nowHour = LocalTime.now().hour
+            return slots.map { s ->
+                val startHour = s.window.substringBefore(":").toIntOrNull() ?: 0
+                if (startHour <= nowHour) s.copy(available = false) else s
+            }
+        }
+    }

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModel.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.homeservices.customer.domain.booking.GetSlotAvailabilityUseCase
 import com.homeservices.customer.domain.booking.model.SlotWindow
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,30 +26,38 @@ public class SlotPickerViewModel
         private val _uiState = MutableStateFlow<SlotPickerUiState>(SlotPickerUiState.Loading)
         public val uiState: StateFlow<SlotPickerUiState> = _uiState.asStateFlow()
 
+        private var loadJob: Job? = null
+        private var lastServiceId: String? = null
+        private var lastRequestedDate: LocalDate? = null
+
         public fun loadSlots(
             serviceId: String,
             date: LocalDate,
         ) {
+            lastServiceId = serviceId
+            lastRequestedDate = date
+            loadJob?.cancel()
             _uiState.value = SlotPickerUiState.Loading
-            viewModelScope.launch {
-                getSlotAvailability(serviceId, date)
-                    .catch { err ->
-                        _uiState.value = SlotPickerUiState.Error(err.message ?: "Unknown error")
-                    }.onEach { result ->
-                        result
-                            .onSuccess { slots ->
-                                _uiState.value =
-                                    SlotPickerUiState.Loaded(
-                                        date = date,
-                                        slots = slots,
-                                        filteredSlots = applyPastTimeFilter(slots, date),
-                                        selected = null,
-                                    )
-                            }.onFailure { err ->
-                                _uiState.value = SlotPickerUiState.Error(err.message ?: "Unknown error")
-                            }
-                    }.collect()
-            }
+            loadJob =
+                viewModelScope.launch {
+                    getSlotAvailability(serviceId, date)
+                        .catch { err ->
+                            _uiState.value = SlotPickerUiState.Error(err.message ?: "Unknown error")
+                        }.onEach { result ->
+                            result
+                                .onSuccess { slots ->
+                                    _uiState.value =
+                                        SlotPickerUiState.Loaded(
+                                            date = date,
+                                            slots = slots,
+                                            filteredSlots = applyPastTimeFilter(slots, date),
+                                            selected = null,
+                                        )
+                                }.onFailure { err ->
+                                    _uiState.value = SlotPickerUiState.Error(err.message ?: "Unknown error")
+                                }
+                        }.collect()
+                }
         }
 
         public fun selectSlot(slot: SlotWindow) {
@@ -58,10 +67,9 @@ public class SlotPickerViewModel
             }
         }
 
-        public fun retry(
-            serviceId: String,
-            date: LocalDate,
-        ) {
+        public fun retry() {
+            val serviceId = lastServiceId ?: return
+            val date = lastRequestedDate ?: return
             loadSlots(serviceId, date)
         }
 
@@ -70,10 +78,20 @@ public class SlotPickerViewModel
             date: LocalDate,
         ): List<SlotWindow> {
             if (date != LocalDate.now()) return slots
-            val nowHour = LocalTime.now().hour
+            val nowMinute = LocalTime.now().toSecondOfDay() / SECONDS_PER_MINUTE
             return slots.map { s ->
-                val startHour = s.window.substringBefore(":").toIntOrNull() ?: 0
-                if (startHour <= nowHour) s.copy(available = false) else s
+                val startMinute = parseStartMinute(s.window)
+                if (startMinute != null && startMinute <= nowMinute) s.copy(available = false) else s
             }
         }
+
+        private fun parseStartMinute(window: String): Int? {
+            val parts = window.substringBefore('-').trim().split(':')
+            val hh = parts.getOrNull(0)?.toIntOrNull()
+            val mm = parts.getOrNull(1)?.toIntOrNull()
+            return if (hh != null && mm != null) hh * MINUTES_PER_HOUR + mm else null
+        }
     }
+
+private const val SECONDS_PER_MINUTE = 60
+private const val MINUTES_PER_HOUR = 60

--- a/customer-app/app/src/main/res/values-hi/strings.xml
+++ b/customer-app/app/src/main/res/values-hi/strings.xml
@@ -324,8 +324,14 @@
     <string name="slot_picker_heading">अपना स्लॉट चुनें</string>
     <string name="slot_picker_subtitle">सुविधाजनक आने का समय चुनें। भुगतान से पहले आप सब कुछ देख सकते हैं।</string>
     <string name="slot_picker_date_label">तारीख</string>
-    <string name="slot_picker_time_label">समय</string>
-    <string name="slot_picker_next">आगे</string>
+    <string name="slot_picker_morning_label">सुबह</string>
+    <string name="slot_picker_afternoon_label">दोपहर</string>
+    <string name="slot_picker_evening_label">शाम</string>
+    <string name="slot_picker_loading_desc">उपलब्ध स्लॉट लोड हो रहे हैं</string>
+    <string name="slot_picker_error_label">स्लॉट लोड नहीं हो सके। कृपया पुनः प्रयास करें।</string>
+    <string name="slot_picker_retry_button">पुनः प्रयास करें</string>
+    <string name="slot_picker_confirm_slot">स्लॉट पक्का करें</string>
+    <string name="slot_picker_no_slots_label">इस तारीख के लिए कोई स्लॉट उपलब्ध नहीं</string>
 
     <!-- Trust dossier — Aadhaar/Police badges, certifications, languages, reviews -->
     <string name="trust_dossier_assigning">आपके स्लॉट के लिए जल्द ही तकनीशियन असाइन किया जाएगा।</string>

--- a/customer-app/app/src/main/res/values/strings.xml
+++ b/customer-app/app/src/main/res/values/strings.xml
@@ -56,8 +56,14 @@
     <string name="slot_picker_heading">Choose your slot</string>
     <string name="slot_picker_subtitle">Pick a convenient arrival window. You can review everything before payment.</string>
     <string name="slot_picker_date_label">Date</string>
-    <string name="slot_picker_time_label">Time</string>
-    <string name="slot_picker_next">Next</string>
+    <string name="slot_picker_morning_label">Morning</string>
+    <string name="slot_picker_afternoon_label">Afternoon</string>
+    <string name="slot_picker_evening_label">Evening</string>
+    <string name="slot_picker_loading_desc">Loading available slots</string>
+    <string name="slot_picker_error_label">Could not load slots. Please try again.</string>
+    <string name="slot_picker_retry_button">Retry</string>
+    <string name="slot_picker_confirm_slot">Confirm Slot</string>
+    <string name="slot_picker_no_slots_label">No slots available for this date</string>
     <string name="address_screen_title">Your Address</string>
     <string name="address_heading">Where should the technician come?</string>
     <string name="address_subtitle">Add the full service address so the technician can reach you without follow-up calls.</string>

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/data/booking/SlotAvailabilityRepositoryImplTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/data/booking/SlotAvailabilityRepositoryImplTest.kt
@@ -1,0 +1,52 @@
+package com.homeservices.customer.data.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.remote.BookingApiService
+import com.homeservices.customer.data.booking.remote.dto.SlotAvailabilityResponseDto
+import com.homeservices.customer.data.booking.remote.dto.SlotDto
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.io.IOException
+import java.time.LocalDate
+
+public class SlotAvailabilityRepositoryImplTest {
+    private val api: BookingApiService = mockk()
+    private val sut = SlotAvailabilityRepositoryImpl(api)
+
+    @Test
+    public fun `getAvailability maps slots list to domain`(): Unit =
+        runTest {
+            coEvery { api.getSlotAvailability("svc-1", "2026-05-20") } returns
+                SlotAvailabilityResponseDto(
+                    slots =
+                        listOf(
+                            SlotDto(window = "08:00-10:00", available = true),
+                            SlotDto(window = "10:00-12:00", available = false),
+                            SlotDto(window = "12:00-14:00", available = true),
+                        ),
+                )
+
+            val result = sut.getAvailability("svc-1", LocalDate.of(2026, 5, 20)).first()
+
+            assertThat(result.isSuccess).isTrue()
+            val slots = result.getOrThrow()
+            assertThat(slots).hasSize(3)
+            assertThat(slots[0].window).isEqualTo("08:00-10:00")
+            assertThat(slots[0].available).isTrue()
+            assertThat(slots[1].available).isFalse()
+        }
+
+    @Test
+    public fun `getAvailability propagates API exception as Result failure`(): Unit =
+        runTest {
+            coEvery { api.getSlotAvailability(any(), any()) } throws IOException("timeout")
+
+            val result = sut.getAvailability("svc-1", LocalDate.of(2026, 5, 20)).first()
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isInstanceOf(IOException::class.java)
+        }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImplTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/data/tracking/TrackingRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import com.homeservices.customer.data.booking.remote.dto.CreateBookingRequestDto
 import com.homeservices.customer.data.booking.remote.dto.CreateBookingResponseDto
 import com.homeservices.customer.data.booking.remote.dto.CustomerBookingsResponseDto
 import com.homeservices.customer.data.booking.remote.dto.GetBookingResponseDto
+import com.homeservices.customer.data.booking.remote.dto.SlotAvailabilityResponseDto
 import com.homeservices.customer.domain.tracking.model.BookingStatus
 import com.homeservices.customer.domain.tracking.model.TrackingState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,6 +48,11 @@ public class TrackingRepositoryImplTest {
             bookingId: String,
             body: ApproveFinalPriceRequestDto,
         ): ApproveFinalPriceResponseDto = error("not used")
+
+        override suspend fun getSlotAvailability(
+            serviceId: String,
+            date: String,
+        ): SlotAvailabilityResponseDto = error("not used")
     }
 
     @Test

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/GetSlotAvailabilityUseCaseTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/domain/booking/GetSlotAvailabilityUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.homeservices.customer.domain.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.data.booking.SlotAvailabilityRepository
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.LocalDate
+
+public class GetSlotAvailabilityUseCaseTest {
+    private val repository: SlotAvailabilityRepository = mockk()
+    private val sut = GetSlotAvailabilityUseCase(repository)
+
+    @Test
+    public fun `invoke delegates to repository and returns result unchanged`(): Unit =
+        runTest {
+            val slots =
+                listOf(
+                    SlotWindow(window = "10:00-12:00", available = true),
+                    SlotWindow(window = "14:00-16:00", available = false),
+                )
+            every { repository.getAvailability("svc-1", LocalDate.of(2026, 5, 20)) } returns
+                flowOf(Result.success(slots))
+
+            val result = sut("svc-1", LocalDate.of(2026, 5, 20)).first()
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo(slots)
+        }
+
+    @Test
+    public fun `invoke propagates repository failure`(): Unit =
+        runTest {
+            val error = RuntimeException("boom")
+            every { repository.getAvailability(any(), any()) } returns flowOf(Result.failure(error))
+
+            val result = sut("svc-1", LocalDate.of(2026, 5, 20)).first()
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(result.exceptionOrNull()).isSameInstanceAs(error)
+        }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreenPaparazziTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerScreenPaparazziTest.kt
@@ -2,10 +2,12 @@ package com.homeservices.customer.ui.booking
 
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import com.homeservices.customer.domain.booking.model.SlotWindow
 import com.homeservices.designsystem.theme.HomeservicesTheme
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDate
 
 public class SlotPickerScreenPaparazziTest {
     @get:Rule
@@ -15,27 +17,157 @@ public class SlotPickerScreenPaparazziTest {
             theme = "android:Theme.Material3.DayNight.NoActionBar",
         )
 
-    @Ignore("Golden to be re-recorded on CI after design-system updates from E07-S01b merge — paparazzi-record.yml")
+    private val today: LocalDate = LocalDate.of(2026, 5, 20)
+    private val tomorrow: LocalDate = today.plusDays(1)
+
+    private fun slot(
+        window: String,
+        available: Boolean = true,
+    ): SlotWindow = SlotWindow(window = window, available = available)
+
+    private val morningSlots =
+        listOf(
+            slot("08:00-10:00"),
+            slot("10:00-12:00"),
+        )
+
+    private val afternoonSlots =
+        listOf(
+            slot("12:00-14:00"),
+            slot("14:00-16:00"),
+        )
+
+    private val mixedSlots =
+        listOf(
+            slot("08:00-10:00", available = false),
+            slot("10:00-12:00", available = false),
+            slot("12:00-14:00"),
+            slot("14:00-16:00"),
+            slot("16:00-18:00"),
+            slot("18:00-20:00"),
+        )
+
+    @Ignore("Goldens recorded on CI Linux only — paparazzi-record.yml")
     @Test
-    public fun slotPickerInitial_lightTheme() {
+    public fun slotPickerLoadedMorningSlots_lightTheme() {
         paparazzi.snapshot {
             HomeservicesTheme(darkTheme = false) {
-                SlotPickerScreen(
-                    onSlotSelected = {},
-                    onBack = {},
+                SlotPickerContent(
+                    state =
+                        SlotPickerUiState.Loaded(
+                            date = tomorrow,
+                            slots = morningSlots,
+                            filteredSlots = morningSlots,
+                            selected = null,
+                        ),
+                    initialDate = tomorrow,
+                    onDateSelect = {},
+                    onSlotSelect = {},
+                    onRetry = {},
+                    onConfirm = { _, _ -> },
                 )
             }
         }
     }
 
-    @Ignore("Golden to be re-recorded on CI after design-system updates from E07-S01b merge — paparazzi-record.yml")
+    @Ignore("Goldens recorded on CI Linux only — paparazzi-record.yml")
     @Test
-    public fun slotPickerInitial_darkTheme() {
+    public fun slotPickerLoadedAfternoonSlots_lightTheme() {
         paparazzi.snapshot {
-            HomeservicesTheme(darkTheme = true) {
-                SlotPickerScreen(
-                    onSlotSelected = {},
-                    onBack = {},
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(
+                    state =
+                        SlotPickerUiState.Loaded(
+                            date = tomorrow,
+                            slots = afternoonSlots,
+                            filteredSlots = afternoonSlots,
+                            selected = afternoonSlots[0],
+                        ),
+                    initialDate = tomorrow,
+                    onDateSelect = {},
+                    onSlotSelect = {},
+                    onRetry = {},
+                    onConfirm = { _, _ -> },
+                )
+            }
+        }
+    }
+
+    @Ignore("Goldens recorded on CI Linux only — paparazzi-record.yml")
+    @Test
+    public fun slotPickerPastTimeFiltered_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(
+                    state =
+                        SlotPickerUiState.Loaded(
+                            date = today,
+                            slots = mixedSlots,
+                            filteredSlots = mixedSlots,
+                            selected = null,
+                        ),
+                    initialDate = today,
+                    onDateSelect = {},
+                    onSlotSelect = {},
+                    onRetry = {},
+                    onConfirm = { _, _ -> },
+                )
+            }
+        }
+    }
+
+    @Ignore("Goldens recorded on CI Linux only — paparazzi-record.yml")
+    @Test
+    public fun slotPickerEmptyState_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(
+                    state =
+                        SlotPickerUiState.Loaded(
+                            date = today,
+                            slots = emptyList(),
+                            filteredSlots = emptyList(),
+                            selected = null,
+                        ),
+                    initialDate = today,
+                    onDateSelect = {},
+                    onSlotSelect = {},
+                    onRetry = {},
+                    onConfirm = { _, _ -> },
+                )
+            }
+        }
+    }
+
+    @Ignore("Goldens recorded on CI Linux only — paparazzi-record.yml")
+    @Test
+    public fun slotPickerErrorState_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(
+                    state = SlotPickerUiState.Error(message = "Network unreachable"),
+                    initialDate = today,
+                    onDateSelect = {},
+                    onSlotSelect = {},
+                    onRetry = {},
+                    onConfirm = { _, _ -> },
+                )
+            }
+        }
+    }
+
+    @Ignore("Goldens recorded on CI Linux only — paparazzi-record.yml")
+    @Test
+    public fun slotPickerLoading_lightTheme() {
+        paparazzi.snapshot {
+            HomeservicesTheme(darkTheme = false) {
+                SlotPickerContent(
+                    state = SlotPickerUiState.Loading,
+                    initialDate = today,
+                    onDateSelect = {},
+                    onSlotSelect = {},
+                    onRetry = {},
+                    onConfirm = { _, _ -> },
                 )
             }
         }

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModelTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModelTest.kt
@@ -16,16 +16,21 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalTime
-import java.util.Locale
+import java.time.ZoneId
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class SlotPickerViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val getSlots: GetSlotAvailabilityUseCase = mockk()
 
-    private val today: LocalDate = LocalDate.now()
+    // Frozen IST clock at 2026-05-20 10:30 IST (= 05:00 UTC). Eliminates time-of-day flakiness.
+    private val istZone: ZoneId = ZoneId.of("Asia/Kolkata")
+    private val frozenClock: Clock = Clock.fixed(Instant.parse("2026-05-20T05:00:00Z"), istZone)
+
+    private val today: LocalDate = LocalDate.of(2026, 5, 20)
     private val tomorrow: LocalDate = today.plusDays(1)
     private val serviceId = "svc-1"
 
@@ -44,12 +49,18 @@ public class SlotPickerViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun vm() = SlotPickerViewModel(getSlots)
+    private fun vm() = SlotPickerViewModel(getSlots, frozenClock)
 
     @Test
     public fun `initial state is Loading`(): Unit =
         runTest(dispatcher) {
             assertThat(vm().uiState.value).isInstanceOf(SlotPickerUiState.Loading::class.java)
+        }
+
+    @Test
+    public fun `currentIstDate returns the clock's date`(): Unit =
+        runTest(dispatcher) {
+            assertThat(vm().currentIstDate()).isEqualTo(today)
         }
 
     @Test
@@ -79,35 +90,27 @@ public class SlotPickerViewModelTest {
         }
 
     @Test
-    public fun `past-time filter marks slots whose start minute is before now as unavailable today`(): Unit =
+    public fun `past-time filter marks slots whose start minute is at or before now as unavailable today`(): Unit =
         runTest(dispatcher) {
-            val nowMinute = LocalTime.now().toSecondOfDay() / SECONDS_PER_MINUTE
-            // Past slot — always elapsed unless the test is in the very first minutes of the day.
-            val earlySlot = slot("00:00-02:00", available = true)
-            val futureStartMinute = (nowMinute + LOOK_AHEAD_MINUTES) % MINUTES_PER_DAY
-            val futureSlot =
-                slot(
-                    window =
-                        String.format(
-                            Locale.ROOT,
-                            "%02d:%02d-%02d:%02d",
-                            futureStartMinute / MINUTES_PER_HOUR,
-                            futureStartMinute % MINUTES_PER_HOUR,
-                            ((futureStartMinute + WINDOW_LENGTH_MINUTES) / MINUTES_PER_HOUR) % HOURS_PER_DAY,
-                            (futureStartMinute + WINDOW_LENGTH_MINUTES) % MINUTES_PER_HOUR,
-                        ),
-                    available = true,
-                )
-            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(earlySlot, futureSlot)))
+            // Clock is 10:30 IST. Elapsed: 00:00-02:00, 08:00-10:00, 10:30-11:00 (>= 10:30? no, exactly).
+            // Future: 11:00-12:00, 14:00-16:00.
+            val past1 = slot("00:00-02:00")
+            val past2 = slot("08:00-10:00")
+            val borderline = slot("10:30-11:00") // start == now → treated as past per <= filter
+            val future1 = slot("11:00-12:00")
+            val future2 = slot("14:00-16:00")
+            every { getSlots(serviceId, today) } returns
+                flowOf(Result.success(listOf(past1, past2, borderline, future1, future2)))
 
             val v = vm()
             v.loadSlots(serviceId, today)
 
             val state = v.uiState.value as SlotPickerUiState.Loaded
-            val filteredEarly = state.filteredSlots.first { it.window == earlySlot.window }
-            assertThat(filteredEarly.available).isFalse()
-            val filteredFuture = state.filteredSlots.first { it.window == futureSlot.window }
-            assertThat(filteredFuture.available).isTrue()
+            assertThat(state.filteredSlots.first { it.window == past1.window }.available).isFalse()
+            assertThat(state.filteredSlots.first { it.window == past2.window }.available).isFalse()
+            assertThat(state.filteredSlots.first { it.window == borderline.window }.available).isFalse()
+            assertThat(state.filteredSlots.first { it.window == future1.window }.available).isTrue()
+            assertThat(state.filteredSlots.first { it.window == future2.window }.available).isTrue()
         }
 
     @Test
@@ -150,7 +153,6 @@ public class SlotPickerViewModelTest {
 
             val state = v.uiState.value as SlotPickerUiState.Loaded
             assertThat(state.date).isEqualTo(tomorrow)
-            // retry must reload the date that failed, not today
             verify(atLeast = 2) { getSlots(serviceId, tomorrow) }
         }
 
@@ -158,7 +160,7 @@ public class SlotPickerViewModelTest {
     public fun `retry uses the most recent requested date when user changed dates`(): Unit =
         runTest(dispatcher) {
             val later = tomorrow.plusDays(1)
-            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(slot("10:00-12:00"))))
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(slot("11:00-12:00"))))
             every { getSlots(serviceId, later) } returns flowOf(Result.failure(RuntimeException("boom")))
             val v = vm()
             v.loadSlots(serviceId, tomorrow)
@@ -183,7 +185,7 @@ public class SlotPickerViewModelTest {
     @Test
     public fun `date change resets selected`(): Unit =
         runTest(dispatcher) {
-            val s = slot("10:00-12:00")
+            val s = slot("11:00-12:00")
             every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(s)))
             val v = vm()
             v.loadSlots(serviceId, tomorrow)
@@ -195,11 +197,47 @@ public class SlotPickerViewModelTest {
 
             assertThat((v.uiState.value as SlotPickerUiState.Loaded).selected).isNull()
         }
-}
 
-private const val SECONDS_PER_MINUTE = 60
-private const val MINUTES_PER_HOUR = 60
-private const val HOURS_PER_DAY = 24
-private const val MINUTES_PER_DAY = MINUTES_PER_HOUR * HOURS_PER_DAY
-private const val LOOK_AHEAD_MINUTES = 90
-private const val WINDOW_LENGTH_MINUTES = 60
+    @Test
+    public fun `ensureInitialLoad loads on first call`(): Unit =
+        runTest(dispatcher) {
+            val s = slot("11:00-12:00")
+            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(s)))
+
+            val v = vm()
+            v.ensureInitialLoad(serviceId)
+
+            verify(exactly = 1) { getSlots(serviceId, today) }
+            assertThat((v.uiState.value as SlotPickerUiState.Loaded).date).isEqualTo(today)
+        }
+
+    @Test
+    public fun `ensureInitialLoad is a no-op when same serviceId already loaded`(): Unit =
+        runTest(dispatcher) {
+            val s = slot("11:00-12:00")
+            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(s)))
+            val v = vm()
+            v.ensureInitialLoad(serviceId)
+            v.selectSlot(s)
+
+            v.ensureInitialLoad(serviceId)
+
+            // No second call; selection preserved.
+            verify(exactly = 1) { getSlots(serviceId, today) }
+            assertThat((v.uiState.value as SlotPickerUiState.Loaded).selected).isEqualTo(s)
+        }
+
+    @Test
+    public fun `ensureInitialLoad reloads when serviceId changes`(): Unit =
+        runTest(dispatcher) {
+            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(slot("11:00-12:00"))))
+            every { getSlots("svc-2", today) } returns flowOf(Result.success(listOf(slot("14:00-16:00"))))
+
+            val v = vm()
+            v.ensureInitialLoad(serviceId)
+            v.ensureInitialLoad("svc-2")
+
+            verify(exactly = 1) { getSlots(serviceId, today) }
+            verify(exactly = 1) { getSlots("svc-2", today) }
+        }
+}

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModelTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModelTest.kt
@@ -5,6 +5,7 @@ import com.homeservices.customer.domain.booking.GetSlotAvailabilityUseCase
 import com.homeservices.customer.domain.booking.model.SlotWindow
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -78,18 +79,26 @@ public class SlotPickerViewModelTest {
         }
 
     @Test
-    public fun `past-time filter marks slots before now hour as unavailable today`(): Unit =
+    public fun `past-time filter marks slots whose start minute is before now as unavailable today`(): Unit =
         runTest(dispatcher) {
-            val nowHour = LocalTime.now().hour
-            // Use a slot that starts in the past relative to nowHour. Pick "00:00-02:00" — always elapsed
-            // unless the test runs in the very first hour of the day.
+            val nowMinute = LocalTime.now().toSecondOfDay() / SECONDS_PER_MINUTE
+            // Past slot — always elapsed unless the test is in the very first minutes of the day.
             val earlySlot = slot("00:00-02:00", available = true)
-            val lateSlot =
+            val futureStartMinute = (nowMinute + LOOK_AHEAD_MINUTES) % MINUTES_PER_DAY
+            val futureSlot =
                 slot(
-                    window = String.format(Locale.ROOT, "%02d:00-%02d:00", (nowHour + 1) % 24, (nowHour + 3) % 24),
+                    window =
+                        String.format(
+                            Locale.ROOT,
+                            "%02d:%02d-%02d:%02d",
+                            futureStartMinute / MINUTES_PER_HOUR,
+                            futureStartMinute % MINUTES_PER_HOUR,
+                            ((futureStartMinute + WINDOW_LENGTH_MINUTES) / MINUTES_PER_HOUR) % HOURS_PER_DAY,
+                            (futureStartMinute + WINDOW_LENGTH_MINUTES) % MINUTES_PER_HOUR,
+                        ),
                     available = true,
                 )
-            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(earlySlot, lateSlot)))
+            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(earlySlot, futureSlot)))
 
             val v = vm()
             v.loadSlots(serviceId, today)
@@ -97,6 +106,8 @@ public class SlotPickerViewModelTest {
             val state = v.uiState.value as SlotPickerUiState.Loaded
             val filteredEarly = state.filteredSlots.first { it.window == earlySlot.window }
             assertThat(filteredEarly.available).isFalse()
+            val filteredFuture = state.filteredSlots.first { it.window == futureSlot.window }
+            assertThat(filteredFuture.available).isTrue()
         }
 
     @Test
@@ -126,7 +137,7 @@ public class SlotPickerViewModelTest {
         }
 
     @Test
-    public fun `retry re-triggers load`(): Unit =
+    public fun `retry re-triggers load for the last requested date`(): Unit =
         runTest(dispatcher) {
             every { getSlots(serviceId, tomorrow) } returns flowOf(Result.failure(RuntimeException("boom")))
             val v = vm()
@@ -135,9 +146,38 @@ public class SlotPickerViewModelTest {
 
             val s = slot("10:00-12:00")
             every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(s)))
-            v.retry(serviceId, tomorrow)
+            v.retry()
 
-            assertThat(v.uiState.value).isInstanceOf(SlotPickerUiState.Loaded::class.java)
+            val state = v.uiState.value as SlotPickerUiState.Loaded
+            assertThat(state.date).isEqualTo(tomorrow)
+            // retry must reload the date that failed, not today
+            verify(atLeast = 2) { getSlots(serviceId, tomorrow) }
+        }
+
+    @Test
+    public fun `retry uses the most recent requested date when user changed dates`(): Unit =
+        runTest(dispatcher) {
+            val later = tomorrow.plusDays(1)
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(slot("10:00-12:00"))))
+            every { getSlots(serviceId, later) } returns flowOf(Result.failure(RuntimeException("boom")))
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+            v.loadSlots(serviceId, later)
+            assertThat(v.uiState.value).isInstanceOf(SlotPickerUiState.Error::class.java)
+
+            every { getSlots(serviceId, later) } returns flowOf(Result.success(listOf(slot("14:00-16:00"))))
+            v.retry()
+
+            val state = v.uiState.value as SlotPickerUiState.Loaded
+            assertThat(state.date).isEqualTo(later)
+        }
+
+    @Test
+    public fun `retry is a no-op before any load`(): Unit =
+        runTest(dispatcher) {
+            val v = vm()
+            v.retry()
+            assertThat(v.uiState.value).isInstanceOf(SlotPickerUiState.Loading::class.java)
         }
 
     @Test
@@ -156,3 +196,10 @@ public class SlotPickerViewModelTest {
             assertThat((v.uiState.value as SlotPickerUiState.Loaded).selected).isNull()
         }
 }
+
+private const val SECONDS_PER_MINUTE = 60
+private const val MINUTES_PER_HOUR = 60
+private const val HOURS_PER_DAY = 24
+private const val MINUTES_PER_DAY = MINUTES_PER_HOUR * HOURS_PER_DAY
+private const val LOOK_AHEAD_MINUTES = 90
+private const val WINDOW_LENGTH_MINUTES = 60

--- a/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModelTest.kt
+++ b/customer-app/app/src/test/kotlin/com/homeservices/customer/ui/booking/SlotPickerViewModelTest.kt
@@ -1,0 +1,158 @@
+package com.homeservices.customer.ui.booking
+
+import com.google.common.truth.Truth.assertThat
+import com.homeservices.customer.domain.booking.GetSlotAvailabilityUseCase
+import com.homeservices.customer.domain.booking.model.SlotWindow
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public class SlotPickerViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val getSlots: GetSlotAvailabilityUseCase = mockk()
+
+    private val today: LocalDate = LocalDate.now()
+    private val tomorrow: LocalDate = today.plusDays(1)
+    private val serviceId = "svc-1"
+
+    private fun slot(
+        window: String,
+        available: Boolean = true,
+    ): SlotWindow = SlotWindow(window = window, available = available)
+
+    @Before
+    public fun setUp(): Unit {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    public fun tearDown(): Unit {
+        Dispatchers.resetMain()
+    }
+
+    private fun vm() = SlotPickerViewModel(getSlots)
+
+    @Test
+    public fun `initial state is Loading`(): Unit =
+        runTest(dispatcher) {
+            assertThat(vm().uiState.value).isInstanceOf(SlotPickerUiState.Loading::class.java)
+        }
+
+    @Test
+    public fun `loadSlots success transitions to Loaded`(): Unit =
+        runTest(dispatcher) {
+            val slots = listOf(slot("10:00-12:00"), slot("14:00-16:00", available = false))
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(slots))
+
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+
+            val state = v.uiState.value as SlotPickerUiState.Loaded
+            assertThat(state.date).isEqualTo(tomorrow)
+            assertThat(state.slots).isEqualTo(slots)
+            assertThat(state.selected).isNull()
+        }
+
+    @Test
+    public fun `loadSlots failure transitions to Error`(): Unit =
+        runTest(dispatcher) {
+            every { getSlots(any(), any()) } returns flowOf(Result.failure(RuntimeException("boom")))
+
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+
+            assertThat(v.uiState.value).isInstanceOf(SlotPickerUiState.Error::class.java)
+        }
+
+    @Test
+    public fun `past-time filter marks slots before now hour as unavailable today`(): Unit =
+        runTest(dispatcher) {
+            val nowHour = LocalTime.now().hour
+            // Use a slot that starts in the past relative to nowHour. Pick "00:00-02:00" — always elapsed
+            // unless the test runs in the very first hour of the day.
+            val earlySlot = slot("00:00-02:00", available = true)
+            val lateSlot =
+                slot(
+                    window = String.format(Locale.ROOT, "%02d:00-%02d:00", (nowHour + 1) % 24, (nowHour + 3) % 24),
+                    available = true,
+                )
+            every { getSlots(serviceId, today) } returns flowOf(Result.success(listOf(earlySlot, lateSlot)))
+
+            val v = vm()
+            v.loadSlots(serviceId, today)
+
+            val state = v.uiState.value as SlotPickerUiState.Loaded
+            val filteredEarly = state.filteredSlots.first { it.window == earlySlot.window }
+            assertThat(filteredEarly.available).isFalse()
+        }
+
+    @Test
+    public fun `past-time filter does not affect future dates`(): Unit =
+        runTest(dispatcher) {
+            val s = slot("00:00-02:00", available = true)
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(s)))
+
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+
+            val state = v.uiState.value as SlotPickerUiState.Loaded
+            assertThat(state.filteredSlots.single().available).isTrue()
+        }
+
+    @Test
+    public fun `selectSlot updates Loaded selected`(): Unit =
+        runTest(dispatcher) {
+            val s = slot("10:00-12:00")
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(s)))
+
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+            v.selectSlot(s)
+
+            assertThat((v.uiState.value as SlotPickerUiState.Loaded).selected).isEqualTo(s)
+        }
+
+    @Test
+    public fun `retry re-triggers load`(): Unit =
+        runTest(dispatcher) {
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.failure(RuntimeException("boom")))
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+            assertThat(v.uiState.value).isInstanceOf(SlotPickerUiState.Error::class.java)
+
+            val s = slot("10:00-12:00")
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(s)))
+            v.retry(serviceId, tomorrow)
+
+            assertThat(v.uiState.value).isInstanceOf(SlotPickerUiState.Loaded::class.java)
+        }
+
+    @Test
+    public fun `date change resets selected`(): Unit =
+        runTest(dispatcher) {
+            val s = slot("10:00-12:00")
+            every { getSlots(serviceId, tomorrow) } returns flowOf(Result.success(listOf(s)))
+            val v = vm()
+            v.loadSlots(serviceId, tomorrow)
+            v.selectSlot(s)
+
+            val later = tomorrow.plusDays(1)
+            every { getSlots(serviceId, later) } returns flowOf(Result.success(listOf(s)))
+            v.loadSlots(serviceId, later)
+
+            assertThat((v.uiState.value as SlotPickerUiState.Loaded).selected).isNull()
+        }
+}


### PR DESCRIPTION
## Summary

- Replaces the hard-coded 6-window `SlotPickerScreen` with a Loading/Loaded/Error state machine that consumes `GET /v1/services/{id}/availability` (E16-S02 API).
- Three time-of-day sections (morning < 12:00, afternoon 12–17, evening 17+); unavailable chips greyed/disabled; empty sections hidden; sections scroll for dense availability.
- IST clock injected via Hilt (`@IstClock`) so devices outside Asia/Kolkata still request the right date.
- Soft-hold release relies on Cosmos TTL auto-expiry per E16-S02 (no client DELETE call — none exists on the API).

## Codex review

Three rounds. Each found real correctness issues:
- R1: hour-only past-time filter on 45/90-min slots; date-change race; retry hardcoded `initialDate`.
- R2: recomposition reset wiping user selection; non-IST `LocalDate.now()`; flaky time-of-day test.
- R3: non-scrollable content column hiding later slots on small screens.

All fixed. Round-3 fix committed without re-review per CLAUDE.md "don't burn rounds iterating" rule (mechanical scroll change; smoke gate green).

## Test plan

- [x] 13 new ViewModel tests (frozen IST clock, no time-of-day flake)
- [x] 2 repository tests + 2 use-case tests
- [x] 6 `@Ignored` Paparazzi stubs (record on CI Linux via `paparazzi-record.yml`)
- [x] Pre-Codex smoke gate (assembleDebug, ktlintCheck, detekt, lintDebug, testDebugUnitTest, koverVerify): all 6 green
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)