### PR TITLE
fix(api): allow rating + complaint on COMPLETED bookings

### DIFF
--- a/api/src/functions/complaints/partner-create.ts
+++ b/api/src/functions/complaints/partner-create.ts
@@ -42,7 +42,7 @@ export async function partnerCreateComplaintHandler(
   const isCustomer = booking.customerId === uid;
   const isTechnician = booking.technicianId === uid;
   if (!isCustomer && !isTechnician) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
-  if (booking.status !== 'CLOSED') {
+  if (!['COMPLETED', 'PAID', 'CLOSED'].includes(booking.status)) {
     return { status: 409, jsonBody: { code: 'BOOKING_NOT_ELIGIBLE', status: booking.status } };
   }
 

--- a/api/src/functions/ratings.ts
+++ b/api/src/functions/ratings.ts
@@ -37,7 +37,7 @@ export const submitRatingHandler: HttpHandler = async (req, _ctx: InvocationCont
   if (!isCustomer && !isTechnician) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
   if (data.side === 'CUSTOMER_TO_TECH' && !isCustomer) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
   if (data.side === 'TECH_TO_CUSTOMER' && !isTechnician) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
-  if (booking.status !== 'CLOSED') {
+  if (!['COMPLETED', 'PAID', 'CLOSED'].includes(booking.status)) {
     return { status: 409, jsonBody: { code: 'BOOKING_NOT_CLOSED', status: booking.status } };
   }
   if (!booking.technicianId) return { status: 409, jsonBody: { code: 'NO_TECHNICIAN' } };


### PR DESCRIPTION
## Summary

- Rating (`POST /v1/ratings`) and complaint (`POST /v1/complaints`) endpoints gated on `booking.status === 'CLOSED'`
- Nothing in the API ever writes `CLOSED` — the gate permanently blocked both flows for every booking
- Widened check to `COMPLETED | PAID | CLOSED` so the pilot device test can proceed
- Proper `COMPLETED→CLOSED` transition is a follow-up story

## Root cause

`ratings.ts:41` and `complaints/partner-create.ts:45` both checked `!== 'CLOSED'`. The `CLOSED` status exists in the schema and is checked in 3 places but is never written by any handler, trigger, or webhook.

## Test plan

- [x] CI passes on this branch (quality-gate, typecheck, lint, tests, semgrep)
- [x] Device test: rating 409 reproduced before fix; deploy needed to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)