### PR TITLE
fix(tech): CRIT wave 2 — storage path + availability hoist + locale race

### DIFF
--- a/docs/patterns/compose-locale-init-sync.md
+++ b/docs/patterns/compose-locale-init-sync.md
@@ -1,0 +1,66 @@
+# Pattern: Synchronous locale init in Application.onCreate (Compose)
+
+**Problem:** `AppCompatDelegate.setApplicationLocales()` must be called before `Activity.setContent {}` 
+or the first Compose frame renders in the wrong language. DataStore is async; calling 
+`currentLocale.first()` in a coroutine on `Dispatchers.Main.immediate` does not guarantee 
+completion before `MainActivity.onCreate()` runs on the same thread.
+
+**Root cause:** `flow.first()` suspends until the DataStore file is read from disk. Even on 
+`Dispatchers.Main.immediate`, the coroutine yields at the suspension point. `MainActivity.onCreate()` 
+runs in the same message-loop slot and is not blocked, so `setContent {}` races with 
+`setApplicationLocales()`.
+
+**Fix pattern — SharedPreferences mirror:**
+
+1. Write a plain `SharedPreferences` mirror entry on every `setLocale()` call:
+
+```kotlin
+// LocaleRepositoryImpl.setLocale()
+override suspend fun setLocale(tag: String) {
+    context.getSharedPreferences(MIRROR_PREFS, Context.MODE_PRIVATE)
+        .edit().putString(MIRROR_KEY, tag).apply()   // synchronous write, no suspension
+    dataStore.edit { prefs -> prefs[KEY_LOCALE_TAG] = tag }
+}
+```
+
+2. Read the mirror synchronously in `Application.onCreate()` **before** any coroutine is launched:
+
+```kotlin
+override fun onCreate() {
+    super.onCreate()
+    // Synchronous mirror read — eliminates first-frame language flash
+    val syncTag = LocaleRepositoryImpl.readMirrorLocale(this)
+        ?: LocaleRepositoryImpl.DEFAULT_LOCALE   // default on first install
+    AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(syncTag))
+
+    // Async reconciliation in case mirror lags DataStore (e.g. crashed before apply())
+    CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
+        val tag = localeEp.localeRepository().currentLocale.first()
+        if (tag != syncTag) {
+            AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag))
+        }
+    }
+}
+```
+
+**Why `SharedPreferences.apply()` is safe here:** `apply()` is asynchronous relative to the 
+calling thread but it writes to an in-memory cache immediately and queues the disk write. A 
+subsequent `getString()` on the same `SharedPreferences` instance reads from the in-memory 
+cache, so it is consistent even before the disk write completes — as long as the process does 
+not die in the window between `apply()` and disk flush (extremely unlikely for a locale write).
+
+**First-install behaviour:** On first install, no mirror exists. `readMirrorLocale()` returns 
+`null`; `Application.onCreate` falls back to `DEFAULT_LOCALE` (`"hi"` for the Ayodhya/UP pilot). 
+This is correct: the first frame is in Hindi, which matches the onboarding intent.
+
+**Do not use `runBlocking` here:** `runBlocking` on `Main` blocks the message loop and can 
+cause ANR if DataStore disk I/O is slow (cold boot, first install, encrypted storage). The 
+SharedPreferences-mirror approach avoids this entirely.
+
+**Files implementing this pattern:**
+- `data/locale/LocaleRepositoryImpl.kt` — mirror write in `setLocale()`, `readMirrorLocale()` companion fn
+- `HomeservicesTechnicianApplication.kt` — synchronous read + async reconciliation
+
+**Tests:**
+- `LocaleRepositoryImplTest.kt` — verifies mirror write on `setLocale()`
+- `SetAppLocaleUseCaseTest.kt` — verifies `setLocale` is called before `setApplicationLocales`

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/HomeservicesTechnicianApplication.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/HomeservicesTechnicianApplication.kt
@@ -7,6 +7,7 @@ import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.homeservices.technician.data.activeJob.ActiveJobLocationObserver
 import com.homeservices.technician.data.fcm.HomeservicesFcmService
+import com.homeservices.technician.data.locale.LocaleRepositoryImpl
 import com.homeservices.technician.domain.flags.GrowthBookFeatureFlags
 import com.homeservices.technician.domain.locale.LocaleRepository
 import com.homeservices.technician.observability.AppCheckInitializer
@@ -65,11 +66,21 @@ public class HomeservicesTechnicianApplication :
                 .refreshAsync()
         }
 
-        // Apply persisted locale BEFORE first Activity onCreate so the initial frame uses correct strings.
+        // Apply locale synchronously from SharedPreferences mirror so the first Compose frame uses
+        // the correct language with no race. The mirror is written on every SetAppLocaleUseCase call.
+        // Fall back to DEFAULT_LOCALE on first install (no mirror yet).
+        val syncTag =
+            LocaleRepositoryImpl.readMirrorLocale(this)
+                ?: LocaleRepositoryImpl.DEFAULT_LOCALE
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(syncTag))
+
+        // Async reconciliation: DataStore may have a newer tag (e.g. if mirror write failed).
         val localeEp = EntryPointAccessors.fromApplication(this, LocaleEntryPoint::class.java)
         CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
             val tag = localeEp.localeRepository().currentLocale.first()
-            AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag))
+            if (tag != syncTag) {
+                AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(tag))
+            }
         }
     }
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/locale/LocaleRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/locale/LocaleRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package com.homeservices.technician.data.locale
 
+import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.homeservices.technician.data.locale.di.LocalePrefs
 import com.homeservices.technician.domain.locale.LocaleRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.Locale
@@ -17,16 +19,38 @@ public class LocaleRepositoryImpl
     @Inject
     constructor(
         @LocalePrefs private val dataStore: DataStore<Preferences>,
+        @ApplicationContext private val context: Context,
     ) : LocaleRepository {
-        private companion object {
-            val KEY_LOCALE_TAG = stringPreferencesKey("locale_tag")
-            const val DEFAULT_LOCALE = "hi" // ADR-0018: Hindi default for Ayodhya/UP pilot
+        public companion object {
+            internal val KEY_LOCALE_TAG = stringPreferencesKey("locale_tag")
+            public const val DEFAULT_LOCALE: String = "hi" // ADR-0018: Hindi default for Ayodhya/UP pilot
+
+            // SharedPreferences mirror for synchronous cold-start read in Application.onCreate.
+            // Written on every setLocale() call so Application.onCreate can apply the locale
+            // synchronously before the first Compose frame, eliminating the DataStore-race flash.
+            private const val MIRROR_PREFS = "locale_mirror"
+            private const val MIRROR_KEY = "locale_tag"
+
+            public fun readMirrorLocale(context: Context): String? {
+                val prefs = context.getSharedPreferences(MIRROR_PREFS, Context.MODE_PRIVATE)
+                return prefs.getString(MIRROR_KEY, null)
+            }
+
+            internal fun writeMirrorLocale(
+                context: Context,
+                tag: String,
+            ) {
+                val editor = context.getSharedPreferences(MIRROR_PREFS, Context.MODE_PRIVATE).edit()
+                editor.putString(MIRROR_KEY, tag)
+                editor.apply()
+            }
         }
 
         override val currentLocale: Flow<String> =
             dataStore.data.map { prefs -> prefs[KEY_LOCALE_TAG] ?: deviceSupportedLocale() }
 
         override suspend fun setLocale(tag: String) {
+            writeMirrorLocale(context, tag)
             dataStore.edit { prefs -> prefs[KEY_LOCALE_TAG] = tag }
         }
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/kyc/PanOcrUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/kyc/PanOcrUseCase.kt
@@ -18,7 +18,7 @@ public class PanOcrUseCase
             technicianId: String,
         ): Flow<PanOcrResult> =
             flow {
-                val storagePath = "technicians/$technicianId/pan_${System.currentTimeMillis()}.jpg"
+                val storagePath = "kyc/$technicianId/pan_${System.currentTimeMillis()}.jpg"
                 val uploadedPath =
                     runCatching { uploader.upload(imageUri, storagePath) }
                         .getOrElse {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/dashboard/TechnicianDashboardScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/dashboard/TechnicianDashboardScreen.kt
@@ -23,16 +23,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.homeservices.designsystem.components.HsSectionCard
 import com.homeservices.designsystem.components.HsTrustBadge
+import com.homeservices.technician.ui.home.AvailabilityViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,7 +41,9 @@ internal fun TechnicianDashboardScreen(
     onOpenRatings: () -> Unit,
     onOpenKyc: () -> Unit,
     modifier: Modifier = Modifier,
+    availabilityViewModel: AvailabilityViewModel = hiltViewModel(),
 ) {
+    val availabilityUiState by availabilityViewModel.uiState.collectAsStateWithLifecycle()
     Scaffold(
         modifier = modifier,
         topBar = { TopAppBar(title = { Text("Technician home") }) },
@@ -52,7 +54,12 @@ internal fun TechnicianDashboardScreen(
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             item { DashboardHeader() }
-            item { AvailabilityCard() }
+            item {
+                AvailabilityCard(
+                    isOnline = availabilityUiState.availability.isOnline,
+                    onCheckedChange = availabilityViewModel::setAcceptingJobs,
+                )
+            }
             item { TodaySnapshot() }
             item {
                 WorkflowCard(
@@ -87,8 +94,10 @@ private fun DashboardHeader() {
 }
 
 @Composable
-private fun AvailabilityCard() {
-    var available by remember { mutableStateOf(true) }
+private fun AvailabilityCard(
+    isOnline: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
     HsSectionCard {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -97,7 +106,7 @@ private fun AvailabilityCard() {
         ) {
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
                 Text(
-                    text = if (available) "Available for jobs" else "Paused",
+                    text = if (isOnline) "Available for jobs" else "Paused",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
@@ -107,7 +116,7 @@ private fun AvailabilityCard() {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            Switch(checked = available, onCheckedChange = { available = it })
+            Switch(checked = isOnline, onCheckedChange = onCheckedChange)
         }
     }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/locale/LocaleRepositoryImplTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/locale/LocaleRepositoryImplTest.kt
@@ -1,6 +1,11 @@
 package com.homeservices.technician.data.locale
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -11,6 +16,16 @@ import java.io.File
 
 @OptIn(ExperimentalCoroutinesApi::class)
 public class LocaleRepositoryImplTest {
+    private val mockPrefsEditor: SharedPreferences.Editor = mockk(relaxed = true)
+    private val mockPrefs: SharedPreferences =
+        mockk(relaxed = true) {
+            every { edit() } returns mockPrefsEditor
+        }
+    private val mockContext: Context =
+        mockk(relaxed = true) {
+            every { getSharedPreferences(any<String>(), any<Int>()) } returns mockPrefs
+        }
+
     @Test
     public fun `currentLocale emits stored tag`(
         @TempDir dir: File,
@@ -20,7 +35,7 @@ public class LocaleRepositoryImplTest {
                 PreferenceDataStoreFactory.create(scope = backgroundScope) {
                     File(dir, "a.preferences_pb")
                 }
-            val r = LocaleRepositoryImpl(ds)
+            val r = LocaleRepositoryImpl(ds, mockContext)
             r.setLocale("hi")
             assertEquals("hi", r.currentLocale.first())
         }
@@ -34,7 +49,7 @@ public class LocaleRepositoryImplTest {
                 PreferenceDataStoreFactory.create(scope = backgroundScope) {
                     File(dir, "b.preferences_pb")
                 }
-            val r = LocaleRepositoryImpl(ds)
+            val r = LocaleRepositoryImpl(ds, mockContext)
             assertEquals("hi", r.currentLocale.first())
         }
 
@@ -44,10 +59,25 @@ public class LocaleRepositoryImplTest {
     ): Unit =
         runTest {
             val file = File(dir, "c.preferences_pb")
-            // Write with first instance
             val ds1 = PreferenceDataStoreFactory.create(scope = backgroundScope) { file }
-            LocaleRepositoryImpl(ds1).setLocale("hi")
-            // Read back — same file, same scope, so no "multiple DataStores" conflict
-            assertEquals("hi", LocaleRepositoryImpl(ds1).currentLocale.first())
+            LocaleRepositoryImpl(ds1, mockContext).setLocale("hi")
+            assertEquals("hi", LocaleRepositoryImpl(ds1, mockContext).currentLocale.first())
+        }
+
+    @Test
+    public fun `setLocale writes SharedPreferences mirror for synchronous cold-start read`(
+        @TempDir dir: File,
+    ): Unit =
+        runTest {
+            val ds =
+                PreferenceDataStoreFactory.create(scope = backgroundScope) {
+                    File(dir, "d.preferences_pb")
+                }
+            val r = LocaleRepositoryImpl(ds, mockContext)
+
+            r.setLocale("hi")
+
+            verify { mockPrefsEditor.putString(any(), "hi") }
+            verify { mockPrefsEditor.apply() }
         }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/kyc/PanOcrUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/kyc/PanOcrUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.homeservices.technician.data.kyc.KycRepository
 import com.homeservices.technician.domain.kyc.model.PanOcrResult
 import io.mockk.coEvery
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -24,11 +25,25 @@ public class PanOcrUseCaseTest {
     }
 
     @Test
+    public fun `storage path uses kyc prefix to match Firebase Storage rules`(): Unit =
+        runTest {
+            val imageUri = mockk<Uri>()
+            val capturedPath = slot<String>()
+            coEvery { firebaseStorageUploader.upload(imageUri, capture(capturedPath)) } returns "kyc/t1/pan.jpg"
+            coEvery { repo.submitPanOcr(any()) } returns PanOcrResult.Success("ABCDE1234F")
+
+            useCase(imageUri, technicianId = "t1").toList()
+
+            assertThat(capturedPath.captured).startsWith("kyc/t1/pan_")
+            assertThat(capturedPath.captured).doesNotStartWith("technicians/")
+        }
+
+    @Test
     public fun `emits Success with panNumber when OCR succeeds`(): Unit =
         runTest {
             val imageUri = mockk<Uri>()
-            coEvery { firebaseStorageUploader.upload(imageUri, any()) } returns "technicians/t1/pan.jpg"
-            coEvery { repo.submitPanOcr("technicians/t1/pan.jpg") } returns PanOcrResult.Success("ABCDE1234F")
+            coEvery { firebaseStorageUploader.upload(imageUri, any()) } returns "kyc/t1/pan.jpg"
+            coEvery { repo.submitPanOcr("kyc/t1/pan.jpg") } returns PanOcrResult.Success("ABCDE1234F")
 
             val results = useCase(imageUri, technicianId = "t1").toList()
 
@@ -41,7 +56,7 @@ public class PanOcrUseCaseTest {
     public fun `emits ManualReview when API returns ManualReview`(): Unit =
         runTest {
             val imageUri = mockk<Uri>()
-            coEvery { firebaseStorageUploader.upload(imageUri, any()) } returns "technicians/t1/pan.jpg"
+            coEvery { firebaseStorageUploader.upload(imageUri, any()) } returns "kyc/t1/pan.jpg"
             coEvery { repo.submitPanOcr(any()) } returns PanOcrResult.ManualReview
 
             val results = useCase(imageUri, "t1").toList()

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/home/AvailabilityViewModelTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/home/AvailabilityViewModelTest.kt
@@ -71,6 +71,25 @@ public class AvailabilityViewModelTest {
         }
 
     @Test
+    public fun `setAcceptingJobs true propagates to repository with both flags set`(): Unit =
+        runTest {
+            val offlineAvailability = availability.copy(isOnline = false, isAvailable = false)
+            coEvery { getAvailability.invoke() } returns Result.success(offlineAvailability)
+            coEvery { updateAvailability.invoke(any()) } returns Result.success(availability)
+            val vm = AvailabilityViewModel(getAvailability, updateAvailability)
+
+            vm.setAcceptingJobs(true)
+
+            coVerify {
+                updateAvailability.invoke(
+                    offlineAvailability.copy(isOnline = true, isAvailable = true),
+                )
+            }
+            assertTrue(vm.uiState.value.availability.isOnline)
+            assertTrue(vm.uiState.value.availability.isAvailable)
+        }
+
+    @Test
     public fun `setWindowEnabled expands preset window to all weekdays`(): Unit =
         runTest {
             coEvery { getAvailability.invoke() } returns Result.success(availability.copy(availabilityWindows = emptyList()))


### PR DESCRIPTION
## Summary

Closes 3 CRIT/P1 pilot blockers from the 2026-05-21 audit (wave 2 of E20 hardening). Merges cleanly on top of PR #252.

- **S-008 (security):** `PanOcrUseCase` storage path `technicians/{uid}/pan_*.jpg` → `kyc/{uid}/pan_*.jpg` — aligns with `firebase/storage.rules` match `/kyc/{userId}/{allPaths=**}`. Without this, all KYC photo uploads fail with an implicit deny in production.
- **P1-3 (data-integrity):** `AvailabilityCard` availability toggle was a UI-local `remember{mutableStateOf(true)}` no-op — never called the repository. Hoisted to `AvailabilityViewModel.setAcceptingJobs()` via `hiltViewModel()`. Partner availability now actually persists.
- **L-002 (i18n):** Locale init race eliminated. `LocaleRepositoryImpl.setLocale()` writes a plain `SharedPreferences` mirror; `Application.onCreate()` reads it synchronously before the DataStore coroutine, so the first Compose frame uses the correct language on all cold starts (returning users). First-install defaults to `"hi"`. Pattern documented in `docs/patterns/compose-locale-init-sync.md`.

## Test plan

- [ ] `PanOcrUseCaseTest` — new `storage path uses kyc prefix` test captures slot and asserts `startsWith("kyc/t1/pan_")` / `doesNotStartWith("technicians/")`
- [ ] `AvailabilityViewModelTest` — new `setAcceptingJobs true propagates to repository` test verifies `updateAvailability.invoke(offlineAvailability.copy(isOnline=true, isAvailable=true))`
- [ ] `LocaleRepositoryImplTest` — new `setLocale writes SharedPreferences mirror` test verifies `mockPrefsEditor.putString(any(), "hi")` + `apply()` called
- [ ] All 6 smoke gate steps green locally: assembleDebug → ktlintCheck → detekt → lintDebug → testDebugUnitTest → koverVerify
- [ ] QA: on-device locale switch from English → Hindi: verify no first-frame English flash on subsequent cold starts
- [ ] QA: toggle availability switch on Dashboard tab → confirm API call fires (was silently dropped before)
- [ ] QA: upload PAN photo → confirm Firebase Storage upload succeeds (path now matches rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)