### PR TITLE
fix(admin-web): Topbar hydration mismatch — dashboard half-screen layout bug

### DIFF
--- a/admin-web/src/components/dashboard/Topbar.tsx
+++ b/admin-web/src/components/dashboard/Topbar.tsx
@@ -19,10 +19,22 @@ interface TopbarProps {
 }
 
 export function Topbar({ rightSlot }: TopbarProps) {
-  const [clock, setClock] = useState<string>(() => formatClock(new Date()));
+  // Clock must be empty during SSR — server time and client time differ, which
+  // triggers React #418 hydration mismatch. The mismatch bailout discards the
+  // entire dashboard subtree and re-renders it client-side, collapsing the
+  // Rail's inline width and breaking the flex layout (manifested as the page
+  // rendering in only half the viewport on /hi/dashboard).
+  const [clock, setClock] = useState<string>('');
+  const [isoTimestamp, setIsoTimestamp] = useState<string>('');
 
   useEffect(() => {
-    const timer = setInterval(() => setClock(formatClock(new Date())), 1000);
+    const update = () => {
+      const now = new Date();
+      setClock(formatClock(now));
+      setIsoTimestamp(now.toISOString());
+    };
+    update();
+    const timer = setInterval(update, 1000);
     return () => clearInterval(timer);
   }, []);
 
@@ -41,7 +53,11 @@ export function Topbar({ rightSlot }: TopbarProps) {
           <span className="topbar__live-label">LIVE</span>
         </div>
 
-        <time className="topbar__clock" dateTime={new Date().toISOString()}>
+        <time
+          className="topbar__clock"
+          dateTime={isoTimestamp || undefined}
+          suppressHydrationWarning
+        >
           {clock}
         </time>
 


### PR DESCRIPTION
## Bug

Dashboard pages (e.g. `/hi/dashboard`) render with content collapsed into roughly the left half of the viewport, with the nav rail missing. Reproduced live by the owner on ACA today.

## Root cause

React Error #418 (hydration mismatch) on every dashboard page load. `Topbar.tsx:22` initialises clock state with `formatClock(new Date())` and line 44 sets `dateTime={new Date().toISOString()}`. Both evaluate at SSR time **and** at client hydration time. Server time ≠ client time → React detects a mismatch.

In React 19, the mismatch bailout discards the subtree from the mismatch root and re-renders client-side. During the bailout the Rail's inline `width: '192px'` style doesn't re-apply cleanly, the flex container collapses, and the dashboard renders in ~half the viewport with no nav rail.

## Fix

`Topbar.tsx`: clock and `dateTime` start as `''` on SSR; `useEffect` populates them on the client after first render. Standard React pattern for client-only values. `suppressHydrationWarning` on the `<time>` element is a safety net.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test -- Topbar` 2/2 ✅
- The 4 dashboard pages I can reason about (`/hi/dashboard`, `/hi/orders`, `/hi/finance`, `/hi/complaints`) all use the same Topbar; fix is universal.

## Deploy

CI deploys to legacy SWA (per A4 audit finding) — **this PR's merge to `main` will NOT update the live ACA automatically**. Run the manual PowerShell deploy in `admin-web/CLAUDE.md` after merge to ship the fix to `aca-admin-homeservices-prod`.

## Why the audit missed it

A7's UI/UX audit only captured unauthenticated routes (login, 404) which don't render the Topbar. Authenticated dashboard rendering was an explicit sampling gap documented in `07-uiux-design.md` — this is the kind of bug a follow-up authenticated-route audit would catch.

## Scope

Independent of S0–S5 audit-remediation stories. Merges to main directly; no rebase needed for the open audit PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)