### PR TITLE
fix(tools): refuse to build Play AAB if google-services.json is stub (Codex P1)

### DIFF
--- a/tools/build-play-bundles.ps1
+++ b/tools/build-play-bundles.ps1
@@ -65,6 +65,18 @@ function Get-ReleaseProperty($properties, $prefix, $name) {
     return $null
 }
 
+function Assert-GoogleServicesNotStub($app) {
+    $gsFile = Join-Path $app.Directory "app\google-services.json"
+    if (-not (Test-Path -LiteralPath $gsFile -PathType Leaf)) {
+        throw "google-services.json not found for $($app.Name)-app at $gsFile. The committed file is a stub; the real one is materialised by CI from the GOOGLE_SERVICES_JSON secret. For local Play AAB builds, drop the real file at this path before re-running."
+    }
+
+    $content = Get-Content -LiteralPath $gsFile -Raw
+    if ($content -match "PROJECT_ID_PLACEHOLDER" -or $content -match "AIzaSyPLACEHOLDER" -or $content -match "PROJECT_NUMBER_PLACEHOLDER") {
+        throw "google-services.json for $($app.Name)-app contains placeholder markers (SEC-01 stub). Refusing to build a release AAB with stub Firebase config — Auth/FCM would be broken in the published app. Replace the stub with the real google-services.json from Firebase Console (or restore from your GOOGLE_SERVICES_JSON GitHub secret) before re-running."
+    }
+}
+
 function Assert-SigningConfig($app) {
     $propertiesPath = Join-Path $app.Directory "local.properties"
     $properties = Read-LocalProperties $propertiesPath
@@ -100,6 +112,7 @@ function Assert-SigningConfig($app) {
 }
 
 foreach ($app in $apps) {
+    Assert-GoogleServicesNotStub $app
     Assert-SigningConfig $app
 
     $tasks = @()


### PR DESCRIPTION
## Summary

Adds a pre-flight guard in `tools/build-play-bundles.ps1` that refuses to build a release AAB if `google-services.json` still contains the SEC-01 stub markers (`PROJECT_ID_PLACEHOLDER`, `AIzaSyPLACEHOLDER`, `PROJECT_NUMBER_PLACEHOLDER`).

Closes the Codex P1 finding raised against commit `cbd52230` (SEC-01 — google-services.json stub + CI secret injection, already on `main` via PR #256).

## Context

PR #256 landed the SEC-01 stub + CI secret injection in `customer-ship.yml`. The CI path now safely materialises `google-services.json` from `secrets.GOOGLE_SERVICES_JSON` before any Gradle invocation.

However the local-laptop Play AAB build path (`tools/build-play-bundles.ps1` → `:app:bundleRelease`) had no equivalent guard. Codex flagged this: a developer could accidentally produce a release AAB with stub Firebase config, shipping an app where Firebase Auth + FCM are broken because the API key is fake and the project_id doesn't resolve to a real Firebase project.

## Change

`Assert-GoogleServicesNotStub($app)` runs before `Assert-SigningConfig($app)` and `:app:bundleRelease`. It:

1. Throws if `customer-app/app/google-services.json` (or `technician-app/app/google-services.json`) is missing — with a message pointing to the secret injection model.
2. Throws if the file contains any of the three SEC-01 stub markers — with a message instructing the dev to drop the real `google-services.json` from Firebase Console (or restore from the GitHub secret) before re-running.

13 lines added. No semantic change to the build itself when the real `google-services.json` is in place.

## Test plan

- [x] Local: with stub `google-services.json` → `pwsh tools/build-play-bundles.ps1` exits with the new error message before reaching Gradle. (Manually verified — `Get-Content -Raw -match "PROJECT_ID_PLACEHOLDER"` triggers the throw.)
- [ ] Local: with the real `google-services.json` (post-rotation) → build proceeds normally to `:app:bundleRelease`.
- [ ] CI: existing `customer-ship.yml` workflow is unaffected (this script runs on dev laptops, not in CI).

## Related

- Closes Codex P1 finding on `cbd52230` (SEC-01).
- Operational follow-up (separate from this PR): owner still needs to rotate the leaked Firebase API key in Firebase Console + upload the new file to the `GOOGLE_SERVICES_JSON` GitHub Actions secret.
- Sister task (not this PR): technician-app shares the same Firebase project key; `technician-ship.yml` will need the same secret-injection step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)