### PR TITLE
fix(admin+api): customers page empty — add missing customer-metadata Cosmos container + tolerant render

### DIFF
--- a/admin-web/app/[locale]/(dashboard)/customers/CustomerListClient.tsx
+++ b/admin-web/app/[locale]/(dashboard)/customers/CustomerListClient.tsx
@@ -11,6 +11,8 @@ import type { AdminCustomer, CustomerStatus } from '@/types/customer-admin';
 
 interface Props {
   initialCustomers: AdminCustomer[];
+  /** Server-side fetch error, surfaced inline instead of silently rendering empty. */
+  fetchError?: string | null;
 }
 
 type StatusFilter = 'ALL' | CustomerStatus;
@@ -44,7 +46,7 @@ interface ExpandedState {
   saving: '' | 'flag' | 'note' | 'refund';
 }
 
-export function CustomerListClient({ initialCustomers }: Props) {
+export function CustomerListClient({ initialCustomers, fetchError = null }: Props) {
   const t = useTranslations('customers');
   const locale = useLocale();
 
@@ -220,8 +222,15 @@ export function CustomerListClient({ initialCustomers }: Props) {
         </div>
       </div>
 
+      {/* Server-side fetch error — surface inline instead of silently rendering empty. */}
+      {fetchError && (
+        <p role="alert" className="alert alert-danger" style={{ margin: '1rem 0' }}>
+          customers list failed: {fetchError}
+        </p>
+      )}
+
       {/* Table */}
-      {filtered.length === 0 ? (
+      {fetchError ? null : filtered.length === 0 ? (
         <p style={{ color: 'var(--fog-0)', textAlign: 'center', padding: '3rem 0' }}>
           {t('emptyState')}
         </p>

--- a/admin-web/app/[locale]/(dashboard)/customers/page.tsx
+++ b/admin-web/app/[locale]/(dashboard)/customers/page.tsx
@@ -16,12 +16,17 @@ export default async function CustomersPage({
   const client = await getServerApiClient();
 
   let customers: AdminCustomer[] = [];
+  let fetchError: string | null = null;
   try {
     const result = await listCustomers(client);
     customers = result.customers;
-  } catch {
-    // Network failure — show empty state
+  } catch (err) {
+    // Surface the error inline instead of silently rendering empty.
+    // An empty list is ambiguous — could be "no customers" OR a failing API.
+    // Showing the message lets the operator distinguish and acts as a diagnostic
+    // when the backend rejects (e.g. missing Cosmos container, 403, network).
+    fetchError = err instanceof Error ? err.message : String(err);
   }
 
-  return <CustomerListClient initialCustomers={customers} />;
+  return <CustomerListClient initialCustomers={customers} fetchError={fetchError} />;
 }

--- a/api/scripts/setup-cosmos.ts
+++ b/api/scripts/setup-cosmos.ts
@@ -23,6 +23,13 @@ const containers = [
   // container; if it does not exist, admin compliance page server-render
   // crashes with "Resource not found" → error.tsx "Something stalled".
   { id: 'erasure_requests',  partitionKey: '/partitionKey', ttl: undefined },
+  // Admin-side customer metadata (flag, internal notes). One doc per customer
+  // id, partitioned by /id so point reads in patchCustomerMetadata are O(1).
+  // Missing this container makes the admin customers list silently empty
+  // because the page wraps the fetch in try/catch (see app/[locale]/(dashboard)/
+  // customers/page.tsx). Container name uses a hyphen per existing repo code
+  // (api/src/cosmos/customer-metadata-repository.ts:3).
+  { id: 'customer-metadata', partitionKey: '/id',           ttl: undefined },
   // E07-S04: customer credit wallet for no-show compensation — partitioned by /id
   // (one document per bookingId, idempotency-safe via conflict on duplicate /id)
   // NOTE (P1-1): this container is partitioned by /id, NOT /customerId.


### PR DESCRIPTION
## Bug

Admin /hi/customers and /en/customers always show \"no customers\" empty state, even when bookings exist.

## Root cause

\`api/src/cosmos/customer-metadata-repository.ts:3\` queries \`container('customer-metadata')\`. The setup script (\`api/scripts/setup-cosmos.ts\`) never declared this container, so prod Cosmos has never had it provisioned. Every \`getCustomerMetadata\` call throws \"Resource not found\", which propagates up to the admin /v1/admin/customers handler and rejects.

Worse, \`admin-web/app/[locale]/(dashboard)/customers/page.tsx\` wraps the fetch in a bare \`try { ... } catch { /* empty state */ }\` — the actual error is **silently swallowed**, so the operator sees an empty list and assumes there are no customers.

## Fix

Two parts:

1. **api**: add \`customer-metadata\` container to setup-cosmos.ts with \`partitionKey: '/id'\`. The repo uses point reads keyed by customerId (\`container.item(customerId, customerId).read()\`), so id === partition key.
2. **admin-web**: surface the fetch error inline as a \`role=\"alert\"\` banner, mirroring the compliance pattern in PR #257. An empty list is now distinguishable from a failing backend.

## Deploy steps after merge

\`\`\`powershell
# 1. Re-run setup-cosmos to create the container (idempotent)
cd api
\$env:COSMOS_ENDPOINT = \"<prod-endpoint>\"
\$env:COSMOS_KEY = \"<prod-key>\"
npx tsx scripts/setup-cosmos.ts

# 2. Redeploy admin-web to ACA so the new error UI ships
# (manual PowerShell template in admin-web/CLAUDE.md)
\`\`\`

After both, /hi/customers should load customers (or show the inline error if something else is still broken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)