### PR TITLE
fix(api): close Cosmos container drift — 12 missing declarations + 3 truly-missing containers + customer-credits typo

### DIFF
--- a/api/scripts/setup-cosmos.ts
+++ b/api/scripts/setup-cosmos.ts
@@ -47,6 +47,43 @@ const containers = [
   // Partitioned by /userId for single-partition reads per user.
   // No defaultTtl — manual prune via daily timer allows >60 day idle tokens if device used recently.
   { id: 'device_tokens', partitionKey: '/userId', ttl: undefined },
+  // ── Out-of-band containers (existed on prod before this script tracked them) ──
+  // Bookings — core transactional store. /id partition for point reads keyed by
+  // bookingId; cross-partition for filter queries. Predates this script.
+  { id: 'bookings', partitionKey: '/id', ttl: undefined },
+  // Booking change-feed events for projectors; /bookingId for single-partition
+  // ordered reads per booking.
+  { id: 'booking_events', partitionKey: '/bookingId', ttl: undefined },
+  // Dispatch attempts ledger — one doc per attempt, /id partition.
+  { id: 'dispatch_attempts', partitionKey: '/id', ttl: undefined },
+  // Ratings — one doc per booking, /bookingId partition so all ratings for a
+  // booking sit in one partition (some bookings have customer + tech ratings).
+  { id: 'ratings', partitionKey: '/bookingId', ttl: undefined },
+  // Service catalogue: services partitioned by /categoryId for listing per
+  // category in a single-partition query.
+  { id: 'services', partitionKey: '/categoryId', ttl: undefined },
+  // Service categories — top-level catalogue node. TTL=-1 = preserve forever.
+  { id: 'service_categories', partitionKey: '/id', ttl: -1 },
+  // Technicians directory — /id partition, point reads by technicianId.
+  { id: 'technicians', partitionKey: '/id', ttl: undefined },
+  // Wallet ledger — append-only credit/debit entries; /partitionKey field set
+  // to customerId at write time so per-customer balance reads are single-partition.
+  { id: 'wallet_ledger', partitionKey: '/partitionKey', ttl: undefined },
+  // Razorpay webhook idempotency — /id is the webhook event id from Razorpay.
+  { id: 'webhook_events', partitionKey: '/id', ttl: undefined },
+  // ── Truly-missing containers (code references but never provisioned) ──
+  // Finance: weekly payout snapshots — /partitionKey = weekStart (per
+  // finance-repository.ts:181 upsert body). Missing → finance payout history
+  // endpoint throws.
+  { id: 'payout_snapshots', partitionKey: '/partitionKey', ttl: undefined },
+  // Sliding-window token-bucket rate limiter — /id partition (key === id).
+  // Missing → rate-limited endpoints fail unpredictably (the repo fails open
+  // on Cosmos errors via Sentry warn, so this is degraded not blocking).
+  { id: 'rate_limit_tokens', partitionKey: '/id', ttl: undefined },
+  // Operational state cache (currently used by Truecaller public-key cache).
+  // /id partition with a fixed doc id; missing → first request after cache TTL
+  // throws inside truecaller.service.ts.
+  { id: 'system', partitionKey: '/id', ttl: undefined },
 ] as const;
 
 async function main() {
@@ -97,16 +134,20 @@ async function main() {
   });
   console.log(`Container 'pending_actions' ready.`);
 
-  // Lease containers for 5 change-feed projectors.
-  // Convention matches existing leases: booking_completed_leases, booking_rating_prompt_leases,
-  // booking_report_leases — all partitioned /id.
-  // createLeaseContainerIfNotExists=false in each trigger, so these MUST be pre-provisioned.
+  // Lease containers for change-feed projectors. All partitioned /id per Cosmos
+  // change-feed library convention. createLeaseContainerIfNotExists=false in each
+  // trigger, so these MUST be pre-provisioned (matches the api/CLAUDE.md Cosmos
+  // Pre-Provisioning section).
   const leaseContainers = [
     'pending_actions_bookings_leases',
     'pending_actions_complaints_leases',
     'pending_actions_dispatch_leases',
     'pending_actions_kyc_leases',
     'pending_actions_ratings_leases',
+    // ── Booking-event projectors (existed on prod before this script tracked them) ──
+    'booking_completed_leases',
+    'booking_rating_prompt_leases',
+    'booking_report_leases',
   ];
   for (const leaseId of leaseContainers) {
     await database.containers.createIfNotExists({

--- a/api/src/functions/admin/customers/refund-credit.ts
+++ b/api/src/functions/admin/customers/refund-credit.ts
@@ -29,7 +29,12 @@ export async function adminRefundCreditHandler(
     issuedAt: new Date().toISOString(),
   };
 
-  const container = getCosmosClient().database(DB_NAME).container('customer-credits');
+  // NOTE: container name is `customer_credits` (underscore) per
+  // api/src/cosmos/client.ts:88 and customer-credit-ledger-repository.ts. The
+  // previous hyphenated value was a typo — Cosmos returned "Resource not found"
+  // on every refund-credit request because no `customer-credits` container
+  // exists in prod.
+  const container = getCosmosClient().database(DB_NAME).container('customer_credits');
   await container.items.create(doc);
 
   Sentry.captureMessage('Admin refund credit issued', {


### PR DESCRIPTION
## Summary

Comprehensive cleanup of the gap between code-referenced Cosmos containers and what \`api/scripts/setup-cosmos.ts\` declared.

After PR #257 (erasure_requests) and PR #260 (customer-metadata) closed two of the missing-container bugs, an audit of all \`.container('NAME')\` references in \`api/src\` against prod Cosmos and against the setup script found this drift:

| Container | State | Fix |
|---|---|---|
| \`payout_snapshots\` | Code uses, **never provisioned** → finance payout history endpoint throws | Added with \`/partitionKey\` |
| \`rate_limit_tokens\` | Code uses, **never provisioned** → rate limiter degrades silently | Added with \`/id\` |
| \`system\` | Code uses, **never provisioned** → Truecaller key cache cold-load throws | Added with \`/id\` |
| \`customer-credits\` (hyphen) | **TYPO** in \`refund-credit.ts:32\`; every operator refund returned 500 | Fixed to \`customer_credits\` |
| bookings, booking_events, dispatch_attempts, ratings, services, service_categories, technicians, wallet_ledger, webhook_events, booking_completed_leases, booking_rating_prompt_leases, booking_report_leases | Exist on prod (created out-of-band over time), but **not declared** in setup script — fresh clone+setup would miss them | Added with partition keys probed from prod |

## Partition-key verification

All out-of-band partition keys were probed directly from prod Cosmos:
\`\`\`bash
az cosmosdb sql container show --account-name cosmos-homeservices-prod \
  --database-name homeservices --resource-group rg-homeservices-prod \
  --name <container> --query \"resource.partitionKey.paths\"
\`\`\`

So declarations match reality (e.g. \`wallet_ledger\` uses \`/partitionKey\` not \`/id\`; \`services\` uses \`/categoryId\`).

## Deploy steps after merge

\`\`\`powershell
# 1. Create the 3 truly-missing containers in prod (idempotent — no-op for existing ones)
cd api
\$env:COSMOS_ENDPOINT = \"<prod-endpoint>\"
\$env:COSMOS_KEY = \"<prod-key>\"
npx tsx scripts/setup-cosmos.ts
\`\`\`

api-ship.yml will auto-deploy the refund-credit.ts typo fix on push to main.

## Verification after deploy

- Operator can refund customer credit without 500.
- Finance payout history endpoint loads without throwing.
- Truecaller cold-load doesn't throw (low-traffic, hard to verify directly — relies on Sentry going quiet on \`TRUECALLER_KEY_REFRESH_FAILED\`).
- Fresh-clone \`setup-cosmos.ts\` run now provisions a fully-functional database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)