### PR TITLE
Fix admin generated OpenAPI client after sprint merge

### DIFF
--- a/admin-web/src/api/generated/openapi.json
+++ b/admin-web/src/api/generated/openapi.json
@@ -527,6 +527,9 @@
             "type": "integer",
             "minimum": 0
           },
+          "safetyTag": {
+            "type": "boolean"
+          },
           "isActive": {
             "type": "boolean"
           },
@@ -1919,6 +1922,9 @@
                   "sortOrder": {
                     "type": "integer",
                     "minimum": 0
+                  },
+                  "safetyTag": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
@@ -2031,6 +2037,9 @@
                   "sortOrder": {
                     "type": "integer",
                     "minimum": 0
+                  },
+                  "safetyTag": {
+                    "type": "boolean"
                   }
                 },
                 "required": [

--- a/admin-web/src/api/generated/schema.d.ts
+++ b/admin-web/src/api/generated/schema.d.ts
@@ -641,6 +641,7 @@ export interface components {
             /** Format: uri */
             heroImageUrl: string;
             sortOrder: number;
+            safetyTag?: boolean;
             isActive: boolean;
             updatedBy: string;
             /** Format: date-time */
@@ -1199,6 +1200,7 @@ export interface operations {
                     /** Format: uri */
                     heroImageUrl: string;
                     sortOrder: number;
+                    safetyTag?: boolean;
                 };
             };
         };
@@ -1288,6 +1290,7 @@ export interface operations {
                     /** Format: uri */
                     heroImageUrl: string;
                     sortOrder: number;
+                    safetyTag?: boolean;
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Refreshes `admin-web/src/api/generated/openapi.json` and `schema.d.ts` after the merged Sprint 6 API schema added `safetyTag` to service categories.

## Verification
- `pnpm -C admin-web openapi:client`
- `pnpm -C admin-web typecheck`

## Context
- Fixes the `admin-ship / quality-gate` failure on merged PR #286.