### PR TITLE
fix(E17-S02): preserve location follow-up hardening

### DIFF
--- a/api/src/functions/active-job-location.ts
+++ b/api/src/functions/active-job-location.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 import { type HttpHandler, type InvocationContext, app } from '@azure/functions';
 import { verifyTechnicianToken } from '../middleware/verifyTechnicianToken.js';
-import { withRateLimit } from '../middleware/withRateLimit.js';
+import { consume } from '../cosmos/rate-limit-repository.js';
 import { bookingRepo } from '../cosmos/booking-repository.js';
 import { liveLocationRepo } from '../cosmos/live-location-repository.js';
 import { PostLocationRequestSchema } from '../schemas/live-location.js';
@@ -11,7 +11,7 @@ import { isPeriodicLocationEnabled } from '../services/featureFlags.service.js';
 const ACTIVE_STATUSES = new Set(['EN_ROUTE', 'REACHED', 'IN_PROGRESS']);
 const STALENESS_MS = 90_000;
 
-const innerHandler: HttpHandler = async (req, ctx: InvocationContext) => {
+export const activeJobLocationHandler: HttpHandler = async (req, ctx: InvocationContext) => {
   let uid: string;
   try {
     ({ uid } = await verifyTechnicianToken(req));
@@ -20,6 +20,18 @@ const innerHandler: HttpHandler = async (req, ctx: InvocationContext) => {
   }
 
   const bookingId = (req as unknown as { params: { bookingId: string } }).params.bookingId;
+
+  // Rate-limit keyed by authenticated uid+bookingId - fires after auth so an
+  // unauthenticated caller cannot exhaust the bucket for a legitimate technician.
+  const rlResult = await consume(`rl:loc:${uid}:${bookingId}`, 1, 1 / 15);
+  if (!rlResult.allowed) {
+    const retryAfterSec = Math.ceil((rlResult.retryAfterMs ?? 1000) / 1000);
+    return {
+      status: 429,
+      headers: { 'Retry-After': String(retryAfterSec), 'Content-Type': 'application/json' },
+      jsonBody: { code: 'RATE_LIMITED', retryAfterMs: rlResult.retryAfterMs },
+    };
+  }
   const booking = await bookingRepo.getById(bookingId);
   if (!booking) return { status: 404, jsonBody: { code: 'BOOKING_NOT_FOUND' } };
   if (booking.technicianId !== uid) return { status: 403, jsonBody: { code: 'FORBIDDEN' } };
@@ -78,14 +90,6 @@ const innerHandler: HttpHandler = async (req, ctx: InvocationContext) => {
 
   return { status: 204 };
 };
-
-export const activeJobLocationHandler = withRateLimit({
-  keyExtractor: (req) => {
-    const bookingId = (req as unknown as { params: { bookingId: string } }).params.bookingId ?? 'unknown';
-    return `rl:loc:${bookingId}`;
-  },
-  buckets: { ip: { capacity: 1, refillPerSec: 1 / 15 } },
-})(innerHandler);
 
 app.http('activeJobLocation', {
   route: 'v1/technicians/active-job/{bookingId}/location',

--- a/api/tests/functions/active-job-location.test.ts
+++ b/api/tests/functions/active-job-location.test.ts
@@ -28,9 +28,9 @@ vi.mock('../../src/services/featureFlags.service.js', () => ({
   isPeriodicLocationEnabled: vi.fn().mockResolvedValue(true),
 }));
 
-// withRateLimit: pass-through in tests so rate-limit bucket state doesn't affect other tests
-vi.mock('../../src/middleware/withRateLimit.js', () => ({
-  withRateLimit: () => (handler: unknown) => handler,
+// consume: allow by default; individual tests override for the 429 case
+vi.mock('../../src/cosmos/rate-limit-repository.js', () => ({
+  consume: vi.fn().mockResolvedValue({ allowed: true }),
 }));
 
 type MockFn = ReturnType<typeof vi.fn>;
@@ -87,8 +87,8 @@ describe('POST /v1/technicians/active-job/:bookingId/location', () => {
     vi.mock('../../src/services/featureFlags.service.js', () => ({
       isPeriodicLocationEnabled: vi.fn().mockResolvedValue(true),
     }));
-    vi.mock('../../src/middleware/withRateLimit.js', () => ({
-      withRateLimit: () => (handler: unknown) => handler,
+    vi.mock('../../src/cosmos/rate-limit-repository.js', () => ({
+      consume: vi.fn().mockResolvedValue({ allowed: true }),
     }));
     vi.mock('@sentry/node', () => ({
       captureMessage: vi.fn(),
@@ -173,6 +173,21 @@ describe('POST /v1/technicians/active-job/:bookingId/location', () => {
     const res = await innerHandler(makeReq('bk-1', staleBody), new InvocationContext()) as HttpResponseInit;
     expect(res.status).toBe(400);
     expect((res.jsonBody as { code: string }).code).toBe('STALE_FIX');
+  });
+
+  it('returns 429 when rate limit exceeded (keyed by uid+bookingId after auth)', async () => {
+    const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+    const { bookingRepo } = await import('../../src/cosmos/booking-repository.js');
+    const { consume } = await import('../../src/cosmos/rate-limit-repository.js');
+    (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+    (bookingRepo.getById as MockFn).mockResolvedValue(aBooking());
+    (consume as MockFn).mockResolvedValueOnce({ allowed: false, retryAfterMs: 8000 });
+
+    const res = await innerHandler(makeReq('bk-1', validBody), new InvocationContext()) as HttpResponseInit;
+    expect(res.status).toBe(429);
+    expect((res.jsonBody as { code: string }).code).toBe('RATE_LIMITED');
+    // rate-limit key must include the authenticated uid, not just the bookingId
+    expect(consume).toHaveBeenCalledWith(expect.stringContaining('tech-1'), expect.any(Number), expect.any(Number));
   });
 
   it('returns 204, upserts to Cosmos, and calls sendPeriodicLocationPush when flag=on', async () => {

--- a/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/tracking/LiveTrackingScreen.kt
+++ b/customer-app/app/src/main/kotlin/com/homeservices/customer/ui/tracking/LiveTrackingScreen.kt
@@ -242,8 +242,10 @@ private fun TrackingMapSection(
     state: LiveTrackingUiState.Tracking,
     defaultTechName: String,
 ) {
-    state.location?.let { loc ->
-        val techLatLng = LatLng(state.liveLat ?: loc.lat, state.liveLng ?: loc.lng)
+    val resolvedLat = state.liveLat ?: state.location?.lat
+    val resolvedLng = state.liveLng ?: state.location?.lng
+    if (resolvedLat != null && resolvedLng != null) {
+        val techLatLng = LatLng(resolvedLat, resolvedLng)
         val techNameForMarker = state.techName.ifBlank { defaultTechName }
         val cameraPositionState =
             rememberCameraPositionState {
@@ -258,7 +260,9 @@ private fun TrackingMapSection(
                 title = techNameForMarker,
             )
         }
-    } ?: MapPlaceholder()
+    } else {
+        MapPlaceholder()
+    }
 }
 
 @Composable

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/location/service/LocationForegroundService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/location/service/LocationForegroundService.kt
@@ -47,8 +47,17 @@ public class LocationForegroundService : Service() {
 
     @Suppress("ReturnCount") // Two early-return guards: missing bookingId + already-running idempotency check.
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val bookingId = intent?.getStringExtra(EXTRA_BOOKING_ID) ?: return START_NOT_STICKY
+        // On a sticky restart the OS delivers intent=null; restore from prefs so we
+        // keep pushing location without requiring the user to re-enter the active-job screen.
+        val bookingId =
+            intent?.getStringExtra(EXTRA_BOOKING_ID)
+                ?: getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).getString(PREF_BOOKING_ID, null)
+                ?: return START_NOT_STICKY
         if (currentBookingId == bookingId) return START_STICKY
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(PREF_BOOKING_ID, bookingId)
+            .apply()
         currentBookingId = bookingId
         createNotificationChannel()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -114,6 +123,10 @@ public class LocationForegroundService : Service() {
         callback?.let { locationProvider.removeLocationUpdates(it) }
         callback = null
         serviceScope.cancel()
+        getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .remove(PREF_BOOKING_ID)
+            .apply()
         super.onDestroy()
     }
 
@@ -164,6 +177,8 @@ public class LocationForegroundService : Service() {
         public const val CHANNEL_ID: String = "active_job_location"
         public const val EXTRA_BOOKING_ID: String = "bookingId"
         private const val NOTIFICATION_ID: Int = 2002
+        private const val PREFS_NAME: String = "location_foreground_svc"
+        private const val PREF_BOOKING_ID: String = "active_booking_id"
 
         // Location-update tuning constants (extracted to satisfy detekt MagicNumber rule).
         private const val LOCATION_UPDATE_INTERVAL_MS: Long = 30_000L


### PR DESCRIPTION
## Summary
- key active-job location rate limiting by authenticated technician + booking id after auth
- render customer tracking map when live coordinates arrive without a static booking location
- persist active booking id for technician foreground-service sticky restarts

## Validation
- `pnpm test tests/functions/active-job-location.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `customer-app`: `./gradlew.bat :app:testDebugUnitTest --tests com.homeservices.customer.ui.tracking.LiveTrackingScreenTest`
- `customer-app`: `./gradlew.bat :app:ktlintCheck :app:detekt`
- `technician-app`: `./gradlew.bat :app:testDebugUnitTest --tests com.homeservices.technician.data.location.service.LocationForegroundServiceTest` with local `JAVA_TOOL_OPTIONS=-Djdk.attach.allowAttachSelf=true`
- `technician-app`: `./gradlew.bat :app:ktlintCheck :app:detekt`