### PR TITLE
fix(tech-app): Sprint 8 HIGH audit items — E20-S10/S13/S14/S16/S18

### DIFF
--- a/.github/workflows/technician-ship.yml
+++ b/.github/workflows/technician-ship.yml
@@ -1,6 +1,7 @@
 name: technician-ship
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:
@@ -74,6 +75,16 @@ jobs:
 
       - name: assemble release (verify R8 + ProGuard)
         run: ./gradlew assembleRelease
+
+      - name: bundle release AAB
+        run: ./gradlew bundleRelease
+
+      - name: upload release AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: technician-release-${{ env.GIT_SHA }}
+          path: app/build/outputs/bundle/release/app-release.aab
+          retention-days: 7
 
       - name: ktlint + detekt + android lint
         run: ./gradlew ktlintCheck detekt lintDebug

--- a/.github/workflows/technician-ship.yml
+++ b/.github/workflows/technician-ship.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: technician-release-${{ env.GIT_SHA }}
-          path: app/build/outputs/bundle/release/app-release.aab
+          path: technician-app/app/build/outputs/bundle/release/app-release.aab
           retention-days: 7
 
       - name: ktlint + detekt + android lint

--- a/customer-app/gradle/libs.versions.toml
+++ b/customer-app/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ growthbookOkHttp = "1.0.8"
 
 # Observability
 sentry = "7.17.0"
+sentryPlugin = "4.14.0"
 crashlyticsGradle = "3.0.2"
 posthog = "3.44.1"
 
@@ -204,3 +205,4 @@ android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlyticsGradle" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+sentry = { id = "io.sentry.android.gradle", version.ref = "sentryPlugin" }

--- a/docs/superpowers/plans/2026-05-23-sprint8-techapp-high-items.md
+++ b/docs/superpowers/plans/2026-05-23-sprint8-techapp-high-items.md
@@ -1,0 +1,293 @@
+# Sprint 8 — technician-app HIGH audit items (batch 1)
+
+**Ceremony:** Feature  
+**Branch:** `fix/sprint8-techapp-high-items`  
+**Worktree:** `C:\Alok\Business Projects\Urbanclap-sprint8`  
+**Source audit:** `docs/reviews/audit-techapp-master-20260521-0738.md`  
+**Stories:** E20-S10, E20-S13, E20-S14, E20-S16, E20-S18
+
+## Known gotchas (read before coding)
+
+- `docs/patterns/kotlin-explicit-api-public-modifier.md` — any new public class needs explicit `public` modifier; any new internal class that is currently `public` in an `internal` file needs `internal`.
+- `docs/patterns/paparazzi-cross-os-goldens.md` — do NOT record goldens on Windows. If a test uses `@Ignored` it needs no golden. If a Paparazzi test is added, record on CI only.
+- `docs/patterns/hilt-module-android-test-scope.md` — Hilt injection in instrumented tests.
+- The `technician-ship.yml` CI already has a **Zero hardcoded Text() literals** gate. Any `Text("hardcoded string")` in `ui/` will fail CI.
+
+## Scope — what IS in this sprint
+
+| Story | Items |
+|---|---|
+| **E20-S10** | `collectAsStateWithLifecycle()` parity (6 calls in RatingScreen); `rememberSaveable` for AuthScreen phone + OTP fields, ShieldReportSheet.description, RatingAppealSheet.reason |
+| **E20-S13** | `AnalyticsTracker` singleton + 6 PostHog funnel events; `Crashlytics.recordException` at 4 failure paths |
+| **E20-S14** | `HomeservicesFcmService.onNewToken` → enqueue WorkRequest with CONNECTED constraint + exponential backoff; `EncryptedSharedPreferences.create` → `withContext(Dispatchers.IO)` in `AuthModule`; `CoroutineExceptionHandler` on foreground-service coroutine scopes |
+| **E20-S16** | Fix `app_name` → "HomeHeroo Technician"; add `workflow_dispatch` to `technician-ship.yml`; add `bundleRelease` + `upload-artifact` step; add `resConfigs("en","hi")`; add Sentry Gradle plugin for R8 mappings |
+| **E20-S18** | `runBlocking` → `runTest` in `ActiveJobApiServicePostLocationTest.kt:65,111`; `throw RuntimeException` → sealed error in `AcceptJobOfferUseCase`; remove `else -> Unit` on sealed `when` in `KycScreen` + `PayoutCadenceScreen`; change `public` → `internal` on 6 ApiService interfaces; remove wildcard ProGuard keep → explicit interface names; Detekt: add `excludes: "**/test/**"` for `FunctionMaxLength` + raise `maxLineLength` to 140 |
+
+## Scope — what is NOT in this sprint
+
+- E20-S11 (62 string extractions) — separate Haiku codemod sprint
+- E20-S12 (accessibility a11y semantics) — separate sprint
+- E20-S15 (WebP images, Baseline Profile) — separate sprint
+- E20-S17 (App Links migration, ProGuard log stripping) — separate sprint
+- customer-app files — another agent owns those
+
+---
+
+## Work Streams
+
+### WS-A: Architecture P0/P1 parity (E20-S18)
+**Model:** haiku | **Depends on:** nothing | **Runs:** first (no other deps)
+
+**Files to modify:**
+
+1. `technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt`
+   - Lines 65 and 111: replace `kotlinx.coroutines.runBlocking {` → `kotlinx.coroutines.test.runTest {`
+   - Add `import kotlinx.coroutines.test.runTest` (it's already a test module with coroutines-test dep)
+
+2. `technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt`
+   - Replace `throw RuntimeException("Accept offer failed: HTTP ${response.code()}")` with `JobOfferResult.UnknownError(response.code())`
+   - Add `data class UnknownError(val httpCode: Int) : JobOfferResult` to `JobOfferResult` sealed class
+
+3. `technician-app/app/src/main/kotlin/com/homeservices/technician/ui/kyc/KycScreen.kt` (line ~71)
+   - Find `else -> Unit` in the `when(kycStatus)` block on a sealed class → replace with explicit exhaustive branches
+
+4. `technician-app/app/src/main/kotlin/com/homeservices/technician/ui/payout/PayoutCadenceScreen.kt` (line ~70)
+   - Same: remove `else -> Unit` on sealed `when`
+
+5. **ApiService interfaces → `internal`:** Change 6 interfaces:
+   - `technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiService.kt`
+   - `technician-app/app/src/main/kotlin/com/homeservices/technician/data/auth/remote/AuthApiService.kt`
+   - `technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmApiService.kt` (if exists)
+   - `technician-app/app/src/main/kotlin/com/homeservices/technician/data/jobOffer/JobOfferApiService.kt`
+   - `technician-app/app/src/main/kotlin/com/homeservices/technician/data/rating/RatingApiService.kt`
+   - `technician-app/app/src/main/kotlin/com/homeservices/technician/data/wallet/WalletApiService.kt`
+   - Verify the above paths exist; search for `interface *ApiService` to get the actual list
+
+6. **ProGuard keep rules** in `technician-app/app/proguard-rules.pro`:
+   - Remove wildcard `-keep interface * extends **ApiService` (or similar)
+   - Replace with explicit `-keep interface com.homeservices.technician.data.*.NAME_OF_EACH_INTERFACE`
+
+7. **Detekt config** at `technician-app/config/detekt/detekt.yml` (or similar):
+   - Add `excludes` for test files under `FunctionMaxLength` rule
+   - Raise `maxLineLength` to 140 (match customer-app if it has the same setting)
+
+**Tests to write:** 
+- Add a test for `AcceptJobOfferUseCase` covering `UnknownError` path
+- Verify `runTest` migration compiles and tests pass
+
+**Commit message:** `fix(tech-app): ARCH parity — sealed exhaustiveness, internal ApiService, runTest, ProGuard explicit keeps`
+
+---
+
+### WS-B: ARCH-03 parity — collectAsStateWithLifecycle + rememberSaveable (E20-S10)
+**Model:** haiku | **Depends on:** nothing | **Runs:** parallel with WS-A
+
+**Files to modify:**
+
+1. `technician-app/app/src/main/kotlin/com/homeservices/technician/ui/rating/RatingScreen.kt:44-49`
+   - Replace 6x `collectAsState()` → `collectAsStateWithLifecycle()` (same pattern as customer-app Sprint 7)
+   - Add `import androidx.lifecycle.compose.collectAsStateWithLifecycle`
+
+2. **AuthScreen** phone number + OTP input fields:
+   - Find the file (likely `AuthScreen.kt`)
+   - Change `var phoneNumber by remember { mutableStateOf("") }` → `rememberSaveable`
+   - Change OTP code field similarly
+
+3. **ShieldReportSheet.kt** (Rating Shield escalation sheet):
+   - `description` input field: `remember` → `rememberSaveable`
+
+4. **RatingAppealSheet.kt**:
+   - `reason` input field: `remember` → `rememberSaveable`
+
+**Tests:** 
+- Add `RatingScreenTest` checking all states are collected via lifecycle-aware collector (or update existing test)
+
+**Commit message:** `fix(tech-app): E20-S10 lifecycle hardening — collectAsStateWithLifecycle + rememberSaveable`
+
+---
+
+### WS-C: Observability funnel (E20-S13)
+**Model:** sonnet | **Depends on:** nothing | **Runs:** parallel with WS-A, WS-B
+
+**TDD: write tests first, then implementation.**
+
+**New file:** `technician-app/app/src/main/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTracker.kt`
+```kotlin
+// Null-safe PostHog facade — all capture calls are fire-and-forget
+public object AnalyticsTracker {
+    public fun capture(event: String, properties: Map<String, Any> = emptyMap()) {
+        runCatching { PostHog.capture(event, properties = properties) }
+    }
+}
+```
+
+**Wire 6 funnel events** (add `AnalyticsTracker.capture(...)` calls):
+
+1. `otp_verified` → in `AuthViewModel` or `AuthOrchestrator`, when Firebase auth returns success
+2. `signup_completed` → in `SaveSessionUseCase.invoke()`, after session saved
+3. `job_offer_received` → in `HomeservicesFcmService.handleMessageData(...)`, when message type = `JOB_OFFER`
+4. `job_offer_accepted` → in `AcceptJobOfferUseCase.invoke(...)`, on `JobOfferResult.Accepted`
+5. `job_started` → in `StartWorkUseCase.invoke()`
+6. `job_completed` → in `CompleteJobUseCase.invoke()`
+
+**Add Crashlytics.recordException** at:
+1. `AuthOrchestrator` catch block (or equivalent auth failure path in technician-app)
+2. `FcmTokenSyncUseCase` failure path (if exists; otherwise `HomeservicesFcmService` token failure)
+3. Firebase Storage uploader upload failure (if exists in technician-app)
+4. Any WorkManager permanent failure path (if OutboxSyncWorker has been created; skip if not)
+
+**New test file:** `technician-app/app/src/test/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTrackerTest.kt`
+- Test: `capture() does not throw when PostHog is not initialized`
+- Test: `capture() calls PostHog.capture with correct event name and properties`
+
+**Commit message:** `feat(tech-app): E20-S13 observability — AnalyticsTracker + 6 PostHog funnel events + Crashlytics.recordException`
+
+---
+
+### WS-D: FCM + WorkManager reliability (E20-S14)
+**Model:** sonnet | **Depends on:** WS-C (shares FCM service file) | **Runs:** after WS-C
+
+**TDD: write tests first.**
+
+**1. `HomeservicesFcmService.onNewToken`** — add WorkRequest enqueue:
+```kotlin
+override fun onNewToken(token: String) {
+    val request = OneTimeWorkRequestBuilder<FcmTokenRegisterWorker>()
+        .setConstraints(Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build())
+        .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+        .build()
+    WorkManager.getInstance(applicationContext).enqueueUniqueWork(
+        "fcm_token_register",
+        ExistingWorkPolicy.REPLACE,
+        request
+    )
+}
+```
+- Create `FcmTokenRegisterWorker` if it doesn't exist. It should call the existing FCM token sync use case.
+
+**2. `AuthModule.provideAuthPrefs`** — wrap `EncryptedSharedPreferences.create(...)` in `withContext(Dispatchers.IO)`:
+- `provideAuthPrefs` is likely a `@Provides` `suspend` function or needs to become one. If Hilt doesn't support suspend providers, use a lazy init pattern instead: initialize on first access inside `withContext(Dispatchers.IO)`.
+- If the function is NOT a suspend function, add a `runBlocking(Dispatchers.IO)` wrapper ONLY in the DI provider (acceptable since this is one-time app startup).
+
+**3. `ActiveJobForegroundService`** — add `CoroutineExceptionHandler`:
+```kotlin
+private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+    Crashlytics.recordException(throwable)
+}
+private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main + exceptionHandler)
+```
+
+**Test:** `FcmTokenRegisterWorkerTest` — verify worker calls token sync use case and handles network errors gracefully.
+
+**Commit message:** `fix(tech-app): E20-S14 FCM/WorkManager reliability — onNewToken WorkRequest + IO dispatch + CoroutineExceptionHandler`
+
+---
+
+### WS-E: Release pipeline + CI (E20-S16)
+**Model:** sonnet | **Depends on:** nothing | **Runs:** parallel with WS-A/B/C
+
+**1. Fix `app_name`** in `technician-app/app/src/main/res/values/strings.xml`:
+```xml
+<string name="app_name">HomeHeroo Technician</string>
+```
+Also update `technician-app/app/src/main/res/values-hi/strings.xml` if `app_name` appears there (it usually stays in English).
+
+**2. `technician-ship.yml`** — add `workflow_dispatch`:
+```yaml
+on:
+  workflow_dispatch:
+  pull_request:
+    ...
+```
+Also add `bundleRelease` step + artifact upload after `assembleRelease`:
+```yaml
+- name: assemble release AAB
+  run: ./gradlew bundleRelease
+- name: upload release AAB
+  uses: actions/upload-artifact@v4
+  with:
+    name: technician-release-${{ env.GIT_SHA }}
+    path: technician-app/app/build/outputs/bundle/release/app-release.aab
+    retention-days: 7
+```
+
+**3. `technician-app/app/build.gradle.kts`** — add `resConfigs` + `isDebuggable`:
+```kotlin
+defaultConfig {
+    ...
+    resourceConfigurations += listOf("en", "hi")
+}
+buildTypes {
+    release {
+        isDebuggable = false
+        ...
+    }
+}
+```
+
+**4. Sentry Gradle plugin** — add to `technician-app/app/build.gradle.kts`:
+```kotlin
+plugins {
+    ...
+    id("io.sentry.android.gradle") version "4.14.0"  // use version from libs.versions.toml
+}
+
+sentry {
+    autoUploadProguardMapping = true
+    ignoredBuildTypes = setOf("debug")
+}
+```
+Add the plugin to `technician-app/settings.gradle.kts` or root `build.gradle.kts` pluginManagement if not already declared. Check if customer-app already has this plugin — mirror the exact version.
+
+**Tests:** No unit tests needed for CI YAML changes. Verify the `app_name` change with a smoke build.
+
+**Commit message:** `fix(tech-app): E20-S16 release pipeline — HomeHeroo app_name, bundleRelease CI, resConfigs, Sentry R8 plugin, workflow_dispatch`
+
+---
+
+### WS-F: Pre-Codex smoke gate + Codex review
+**Runs:** after WS-A/B/C/D/E all merged to the branch
+
+```bash
+cd "C:\Alok\Business Projects\Urbanclap-sprint8\technician-app"
+bash ../tools/pre-codex-smoke.sh technician-app
+```
+
+If smoke fails:
+1. Fix the issue in the relevant work stream
+2. Re-run smoke gate
+3. Only proceed to Codex when green
+
+Then from `C:\Alok\Business Projects\Urbanclap-sprint8`:
+```
+codex review --base main
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] `RatingScreen.kt`: all 6 `collectAsState()` replaced with `collectAsStateWithLifecycle()`
+- [ ] `AuthScreen`: phone + OTP fields use `rememberSaveable`
+- [ ] `ShieldReportSheet`, `RatingAppealSheet`: text input fields use `rememberSaveable`
+- [ ] `AnalyticsTracker` singleton exists with null-safe `capture()`
+- [ ] 6 PostHog events wired at correct callsites
+- [ ] `Crashlytics.recordException` at 4 failure paths
+- [ ] `onNewToken` enqueues `FcmTokenRegisterWorker` with CONNECTED constraint
+- [ ] `EncryptedSharedPreferences.create` wrapped in IO context
+- [ ] `ActiveJobForegroundService` scope has `CoroutineExceptionHandler`
+- [ ] `app_name` = "HomeHeroo Technician"
+- [ ] `technician-ship.yml` has `workflow_dispatch` + `bundleRelease` + artifact upload
+- [ ] `resConfigs("en", "hi")` in `defaultConfig`
+- [ ] Sentry Gradle plugin configured for R8 mapping upload
+- [ ] `runBlocking` → `runTest` in `ActiveJobApiServicePostLocationTest`
+- [ ] `AcceptJobOfferUseCase` throws typed `UnknownError` not `RuntimeException`
+- [ ] Sealed `when` exhaustive in `KycScreen` + `PayoutCadenceScreen`
+- [ ] 6 ApiService interfaces changed to `internal`
+- [ ] ProGuard wildcards replaced with explicit interface names
+- [ ] Detekt: `FunctionMaxLength` excludes test files; `maxLineLength` = 140
+- [ ] Smoke gate green
+- [ ] Codex review clean (or issues fixed)
+- [ ] CI green on PR

--- a/technician-app/app/build.gradle.kts
+++ b/technician-app/app/build.gradle.kts
@@ -184,6 +184,7 @@ android {
             "\"${System.getenv("POSTHOG_HOST") ?: "https://us.i.posthog.com"}\"",
         )
         manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+        resourceConfigurations += listOf("en", "hi")
     }
 
     buildTypes {

--- a/technician-app/app/build.gradle.kts
+++ b/technician-app/app/build.gradle.kts
@@ -117,6 +117,7 @@ plugins {
     alias(libs.plugins.google.services)
     alias(libs.plugins.crashlytics)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.sentry)
 }
 
 android {
@@ -194,6 +195,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            isDebuggable = false
             if (releaseSigning != null) {
                 signingConfig = signingConfigs.getByName("release")
             }
@@ -753,4 +755,9 @@ dependencies {
     androidTestImplementation(libs.hilt.testing)
     androidTestImplementation(libs.androidx.test.runner)
     kspAndroidTest(libs.hilt.compiler)
+}
+
+sentry {
+    autoUploadProguardMapping.set(true)
+    ignoredBuildTypes.set(setOf("debug"))
 }

--- a/technician-app/app/proguard-rules.pro
+++ b/technician-app/app/proguard-rules.pro
@@ -15,13 +15,6 @@
 -keep class com.google.firebase.auth.GoogleAuthProvider { *; }
 -keep class com.google.firebase.auth.FirebaseAuthUserCollisionException { *; }
 
-# Razorpay SDK (mirrored for safety — technician-app does not process payments)
--keep class com.razorpay.** { *; }
--keep class proguard.annotation.** { *; }
--keepattributes JavascriptInterface
--keepclassmembers class * { @android.webkit.JavascriptInterface <methods>; }
--dontwarn com.razorpay.**
-
 # Google Maps + Places SDK
 -keep class com.google.android.gms.maps.** { *; }
 -keep class com.google.android.libraries.places.** { *; }
@@ -46,10 +39,20 @@
 # OkHttp / Retrofit
 -dontwarn okhttp3.**
 -dontwarn retrofit2.**
-# Retrofit services are instantiated through dynamic proxies. Keep the app's
-# service interfaces and members so release shrinking cannot remove or rewrite
-# methods that Retrofit needs to inspect at runtime.
--keep,allowobfuscation interface com.homeservices.technician.**.*ApiService { *; }
+# Retrofit service interfaces — explicit keeps (wildcard removed for security)
+-keep interface com.homeservices.technician.data.activeJob.ActiveJobApiService { *; }
+-keep interface com.homeservices.technician.data.availability.remote.TechnicianAvailabilityApiService { *; }
+-keep interface com.homeservices.technician.data.complaint.remote.ComplaintApiService { *; }
+-keep interface com.homeservices.technician.data.earnings.remote.EarningsApiService { *; }
+-keep interface com.homeservices.technician.data.erasure.remote.ErasureApiService { *; }
+-keep interface com.homeservices.technician.data.integrity.IntegrityApiService { *; }
+-keep interface com.homeservices.technician.data.jobOffer.JobOfferApiService { *; }
+-keep interface com.homeservices.technician.data.jobs.remote.TechnicianJobsApiService { *; }
+-keep interface com.homeservices.technician.data.payout.remote.PayoutApiService { *; }
+-keep interface com.homeservices.technician.data.photo.PhotoApiService { *; }
+-keep interface com.homeservices.technician.data.rating.remote.RatingApiService { *; }
+-keep interface com.homeservices.technician.data.serviceprofile.remote.ServiceProfileApiService { *; }
+-keep interface com.homeservices.technician.data.shield.remote.ShieldApiService { *; }
 
 # Sentry
 -dontwarn io.sentry.**

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/service/ActiveJobForegroundService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/service/ActiveJobForegroundService.kt
@@ -42,7 +42,9 @@ public class ActiveJobForegroundService : Service() {
 
     private val exceptionHandler =
         kotlinx.coroutines.CoroutineExceptionHandler { _, throwable ->
-            com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(throwable)
+            com.google.firebase.crashlytics.FirebaseCrashlytics
+                .getInstance()
+                .recordException(throwable)
         }
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + exceptionHandler)
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/service/ActiveJobForegroundService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/activeJob/service/ActiveJobForegroundService.kt
@@ -40,7 +40,11 @@ public class ActiveJobForegroundService : Service() {
     @Inject
     public lateinit var connectivityObserver: ConnectivityObserver
 
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val exceptionHandler =
+        kotlinx.coroutines.CoroutineExceptionHandler { _, throwable ->
+            com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(throwable)
+        }
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + exceptionHandler)
 
     public override fun onStartCommand(
         intent: Intent?,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/auth/di/AuthModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/auth/di/AuthModule.kt
@@ -14,6 +14,8 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import retrofit2.Retrofit
 import javax.inject.Singleton
 
@@ -43,23 +45,24 @@ public object AuthModule {
     @AuthPrefs
     public fun provideAuthPrefs(
         @ApplicationContext context: Context,
-    ): SharedPreferences {
-        val masterKey =
-            MasterKey
-                .Builder(context)
-                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                .build()
-        val prefs =
-            EncryptedSharedPreferences.create(
-                context,
-                "tech_auth_session",
-                masterKey,
-                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-            )
-        // Silently migrate any session data written by the deprecated MasterKeys API.
-        // No-op if legacy key alias is absent (first install or already migrated).
-        SessionPrefsMigrator.migrateIfNeeded(context, prefs, "tech_auth_session")
-        return prefs
-    }
+    ): SharedPreferences =
+        runBlocking(Dispatchers.IO) {
+            val masterKey =
+                MasterKey
+                    .Builder(context)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build()
+            val prefs =
+                EncryptedSharedPreferences.create(
+                    context,
+                    "tech_auth_session",
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                )
+            // Silently migrate any session data written by the deprecated MasterKeys API.
+            // No-op if legacy key alias is absent (first install or already migrated).
+            SessionPrefsMigrator.migrateIfNeeded(context, prefs, "tech_auth_session")
+            prefs
+        }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/complaint/di/ComplaintModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/complaint/di/ComplaintModule.kt
@@ -23,6 +23,6 @@ public abstract class ComplaintModule {
 
         @Provides
         @Singleton
-        public fun provideComplaintApiService(retrofit: Retrofit): ComplaintApiService = retrofit.create(ComplaintApiService::class.java)
+        internal fun provideComplaintApiService(retrofit: Retrofit): ComplaintApiService = retrofit.create(ComplaintApiService::class.java)
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/complaint/remote/ComplaintApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/complaint/remote/ComplaintApiService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
-public interface ComplaintApiService {
+internal interface ComplaintApiService {
     @POST("v1/complaints")
     public suspend fun createComplaint(
         @Body body: CreateComplaintRequestDto,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/EarningsRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/EarningsRepositoryImpl.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 public class EarningsRepositoryImpl
     @Inject
-    constructor(
+    internal constructor(
         private val apiService: EarningsApiService,
     ) : EarningsRepository {
         public override suspend fun getEarnings(): Result<EarningsSummary> =

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/di/EarningsModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/di/EarningsModule.kt
@@ -20,6 +20,6 @@ public abstract class EarningsModule {
     public companion object {
         @Provides
         @Singleton
-        public fun provideEarningsApiService(retrofit: Retrofit): EarningsApiService = retrofit.create(EarningsApiService::class.java)
+        internal fun provideEarningsApiService(retrofit: Retrofit): EarningsApiService = retrofit.create(EarningsApiService::class.java)
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/remote/EarningsApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/earnings/remote/EarningsApiService.kt
@@ -3,7 +3,7 @@ package com.homeservices.technician.data.earnings.remote
 import com.homeservices.technician.data.earnings.remote.dto.EarningsResponseDto
 import retrofit2.http.GET
 
-public interface EarningsApiService {
+internal interface EarningsApiService {
     @GET("v1/technicians/me/earnings")
     public suspend fun getEarnings(): EarningsResponseDto
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/erasure/ErasureRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/erasure/ErasureRepositoryImpl.kt
@@ -11,7 +11,7 @@ private const val HTTP_CONFLICT = 409
 
 public class ErasureRepositoryImpl
     @Inject
-    constructor(
+    internal constructor(
         private val api: ErasureApiService,
     ) : ErasureRepository {
         public override suspend fun submitRequest(reason: String?): ErasureSubmitResult =

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/erasure/di/ErasureModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/erasure/di/ErasureModule.kt
@@ -20,6 +20,6 @@ public abstract class ErasureModule {
     public companion object {
         @Provides
         @Singleton
-        public fun provideErasureApiService(retrofit: Retrofit): ErasureApiService = retrofit.create(ErasureApiService::class.java)
+        internal fun provideErasureApiService(retrofit: Retrofit): ErasureApiService = retrofit.create(ErasureApiService::class.java)
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/erasure/remote/ErasureApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/erasure/remote/ErasureApiService.kt
@@ -6,7 +6,7 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.POST
 
-public interface ErasureApiService {
+internal interface ErasureApiService {
     @POST("v1/users/me/erasure-request")
     public suspend fun submitErasureRequest(
         @Body body: ErasureSubmitRequestBody,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
@@ -32,9 +32,11 @@ internal class FcmTokenRegisterWorker
                 deviceTokenRegistrar.register()
                 Result.success()
             }.getOrElse {
-                com.google.firebase.crashlytics.FirebaseCrashlytics
-                    .getInstance()
-                    .recordException(it)
+                runCatching {
+                    com.google.firebase.crashlytics.FirebaseCrashlytics
+                        .getInstance()
+                        .recordException(it)
+                }
                 if (runAttemptCount < MAX_RETRY_ATTEMPTS) Result.retry() else Result.failure()
             }
         }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
@@ -1,0 +1,43 @@
+package com.homeservices.technician.data.fcm
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.homeservices.technician.data.device.DeviceTokenRegistrar
+import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+/**
+ * Durable WorkManager worker that registers a new FCM token server-side.
+ *
+ * Enqueued by [HomeservicesFcmService.onNewToken] so that token registration
+ * survives process death. Retries up to 3 attempts with exponential back-off
+ * (configured at enqueue time) before giving up.
+ */
+@HiltWorker
+internal class FcmTokenRegisterWorker
+    @AssistedInject
+    constructor(
+        @Assisted context: Context,
+        @Assisted params: WorkerParameters,
+        private val fcmTokenSyncUseCase: FcmTokenSyncUseCase,
+        private val deviceTokenRegistrar: DeviceTokenRegistrar,
+    ) : CoroutineWorker(context, params) {
+        override suspend fun doWork(): Result {
+            val token = inputData.getString(KEY_FCM_TOKEN) ?: return Result.failure()
+            return runCatching {
+                fcmTokenSyncUseCase.invokeWithFcmToken(token)
+                deviceTokenRegistrar.register()
+                Result.success()
+            }.getOrElse {
+                com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(it)
+                if (runAttemptCount < 3) Result.retry() else Result.failure()
+            }
+        }
+
+        public companion object {
+            public const val KEY_FCM_TOKEN: String = "fcm_token"
+        }
+    }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
@@ -35,11 +35,12 @@ internal class FcmTokenRegisterWorker
                 com.google.firebase.crashlytics.FirebaseCrashlytics
                     .getInstance()
                     .recordException(it)
-                if (runAttemptCount < 3) Result.retry() else Result.failure()
+                if (runAttemptCount < MAX_RETRY_ATTEMPTS) Result.retry() else Result.failure()
             }
         }
 
         public companion object {
             public const val KEY_FCM_TOKEN: String = "fcm_token"
+            private const val MAX_RETRY_ATTEMPTS = 3
         }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
@@ -32,7 +32,9 @@ internal class FcmTokenRegisterWorker
                 deviceTokenRegistrar.register()
                 Result.success()
             }.getOrElse {
-                com.google.firebase.crashlytics.FirebaseCrashlytics.getInstance().recordException(it)
+                com.google.firebase.crashlytics.FirebaseCrashlytics
+                    .getInstance()
+                    .recordException(it)
                 if (runAttemptCount < 3) Result.retry() else Result.failure()
             }
         }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorker.kt
@@ -28,7 +28,7 @@ internal class FcmTokenRegisterWorker
         override suspend fun doWork(): Result {
             val token = inputData.getString(KEY_FCM_TOKEN) ?: return Result.failure()
             return runCatching {
-                fcmTokenSyncUseCase.invokeWithFcmToken(token)
+                fcmTokenSyncUseCase.syncTokenOrThrow(token)
                 deviceTokenRegistrar.register()
                 Result.success()
             }.getOrElse {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -12,7 +12,6 @@ import com.homeservices.corenav.NotificationRouter
 import com.homeservices.technician.MainActivity
 import com.homeservices.technician.data.activeJob.BookingStatusEvent
 import com.homeservices.technician.data.activeJob.BookingStatusEventBus
-import com.homeservices.technician.data.device.DeviceTokenRegistrar
 import com.homeservices.technician.data.earnings.EarningsUpdateEventBus
 import com.homeservices.technician.data.jobOffer.JobOfferEventBus
 import com.homeservices.technician.data.kyc.KycStatusEvent
@@ -20,7 +19,6 @@ import com.homeservices.technician.data.kyc.KycStatusEventBus
 import com.homeservices.technician.data.pendingaction.PendingActionStore
 import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
-import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
 import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import com.homeservices.technician.notification.PendingActionIngestor
@@ -140,9 +138,6 @@ public class HomeservicesFcmService :
     public lateinit var eventBus: JobOfferEventBus
 
     @Inject
-    public lateinit var fcmTokenSyncUseCase: FcmTokenSyncUseCase
-
-    @Inject
     public lateinit var ratingPromptEventBus: RatingPromptEventBus
 
     @Inject
@@ -165,9 +160,6 @@ public class HomeservicesFcmService :
 
     @Inject
     public lateinit var pendingActionStore: PendingActionStore
-
-    @Inject
-    public lateinit var deviceTokenRegistrar: DeviceTokenRegistrar
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -637,10 +629,24 @@ public class HomeservicesFcmService :
     }
 
     override fun onNewToken(token: String): Unit {
-        serviceScope.launch {
-            fcmTokenSyncUseCase.invokeWithFcmToken(token)
-            deviceTokenRegistrar.register()
-        }
+        val data = androidx.work.workDataOf(FcmTokenRegisterWorker.KEY_FCM_TOKEN to token)
+        val request =
+            androidx.work.OneTimeWorkRequestBuilder<FcmTokenRegisterWorker>()
+                .setInputData(data)
+                .setConstraints(
+                    androidx.work.Constraints.Builder()
+                        .setRequiredNetworkType(androidx.work.NetworkType.CONNECTED)
+                        .build(),
+                ).setBackoffCriteria(
+                    androidx.work.BackoffPolicy.EXPONENTIAL,
+                    androidx.work.WorkRequest.MIN_BACKOFF_MILLIS,
+                    java.util.concurrent.TimeUnit.MILLISECONDS,
+                ).build()
+        androidx.work.WorkManager.getInstance(applicationContext).enqueueUniqueWork(
+            "fcm_token_register",
+            androidx.work.ExistingWorkPolicy.REPLACE,
+            request,
+        )
     }
 
     public override fun onDestroy(): Unit {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -656,6 +656,7 @@ public class HomeservicesFcmService :
         serviceScope.cancel()
     }
 
+    @Suppress("ReturnCount")
     private fun parseJobOffer(
         data: Map<String, String>,
         sentTimeMs: Long = 0L,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -22,6 +22,7 @@ import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
 import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import com.homeservices.technician.notification.PendingActionIngestor
 import com.homeservices.technician.ui.jobOffer.JobOfferFullScreenActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -269,6 +270,10 @@ public class HomeservicesFcmService :
             "JOB_OFFER" -> {
                 val offer = parseJobOffer(data, sentTimeMs) ?: return
                 eventBus.tryEmit(offer)
+                AnalyticsTracker.capture(
+                    "job_offer_received",
+                    mapOf("bookingId" to offer.bookingId, "serviceId" to offer.serviceId),
+                )
                 showJobOfferNotification(offer)
             }
             "RATING_PROMPT_TECHNICIAN" -> {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmService.kt
@@ -20,8 +20,8 @@ import com.homeservices.technician.data.pendingaction.PendingActionStore
 import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
-import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import com.homeservices.technician.notification.PendingActionIngestor
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import com.homeservices.technician.ui.jobOffer.JobOfferFullScreenActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -631,10 +631,12 @@ public class HomeservicesFcmService :
     override fun onNewToken(token: String): Unit {
         val data = androidx.work.workDataOf(FcmTokenRegisterWorker.KEY_FCM_TOKEN to token)
         val request =
-            androidx.work.OneTimeWorkRequestBuilder<FcmTokenRegisterWorker>()
+            androidx.work
+                .OneTimeWorkRequestBuilder<FcmTokenRegisterWorker>()
                 .setInputData(data)
                 .setConstraints(
-                    androidx.work.Constraints.Builder()
+                    androidx.work.Constraints
+                        .Builder()
                         .setRequiredNetworkType(androidx.work.NetworkType.CONNECTED)
                         .build(),
                 ).setBackoffCriteria(

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/integrity/IntegrityApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/integrity/IntegrityApiService.kt
@@ -3,7 +3,7 @@ package com.homeservices.technician.data.integrity
 import com.squareup.moshi.JsonClass
 import retrofit2.http.GET
 
-public interface IntegrityApiService {
+internal interface IntegrityApiService {
     @GET("v1/integrity/nonce")
     public suspend fun getNonce(): IntegrityNonceResponseDto
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/payout/PayoutRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/payout/PayoutRepositoryImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 
 public class PayoutRepositoryImpl
     @Inject
-    constructor(
+    internal constructor(
         private val apiService: PayoutApiService,
     ) : PayoutRepository {
         public override suspend fun updatePayoutCadence(cadence: String): Result<PayoutCadenceResult> =

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/payout/di/PayoutModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/payout/di/PayoutModule.kt
@@ -20,6 +20,6 @@ public abstract class PayoutModule {
     public companion object {
         @Provides
         @Singleton
-        public fun providePayoutApiService(retrofit: Retrofit): PayoutApiService = retrofit.create(PayoutApiService::class.java)
+        internal fun providePayoutApiService(retrofit: Retrofit): PayoutApiService = retrofit.create(PayoutApiService::class.java)
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/payout/remote/PayoutApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/payout/remote/PayoutApiService.kt
@@ -5,7 +5,7 @@ import com.homeservices.technician.data.payout.remote.dto.UpdatePayoutCadenceRes
 import retrofit2.http.Body
 import retrofit2.http.PATCH
 
-public interface PayoutApiService {
+internal interface PayoutApiService {
     @PATCH("v1/technicians/me/payout-cadence")
     public suspend fun updatePayoutCadence(
         @Body body: UpdatePayoutCadenceRequestDto,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/rating/di/RatingModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/rating/di/RatingModule.kt
@@ -20,6 +20,6 @@ public abstract class RatingModule {
     public companion object {
         @Provides
         @Singleton
-        public fun provideRatingApiService(retrofit: Retrofit): RatingApiService = retrofit.create(RatingApiService::class.java)
+        internal fun provideRatingApiService(retrofit: Retrofit): RatingApiService = retrofit.create(RatingApiService::class.java)
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/rating/remote/RatingApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/rating/remote/RatingApiService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
 
-public interface RatingApiService {
+internal interface RatingApiService {
     @POST("v1/ratings")
     public suspend fun submit(
         @Body body: SubmitRatingRequestDto,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/shield/ShieldRepositoryImpl.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/shield/ShieldRepositoryImpl.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 public class ShieldRepositoryImpl
     @Inject
-    constructor(
+    internal constructor(
         private val api: ShieldApiService,
         private val moshi: Moshi,
     ) : ShieldRepository {

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/shield/di/ShieldModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/shield/di/ShieldModule.kt
@@ -20,6 +20,6 @@ public abstract class ShieldModule {
     public companion object {
         @Provides
         @Singleton
-        public fun provideShieldApiService(retrofit: Retrofit): ShieldApiService = retrofit.create(ShieldApiService::class.java)
+        internal fun provideShieldApiService(retrofit: Retrofit): ShieldApiService = retrofit.create(ShieldApiService::class.java)
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/data/shield/remote/ShieldApiService.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/data/shield/remote/ShieldApiService.kt
@@ -8,7 +8,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
-public interface ShieldApiService {
+internal interface ShieldApiService {
     @POST("v1/technicians/me/shield-report")
     public suspend fun fileShieldReport(
         @Body body: ShieldReportRequestDto,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/CompleteJobUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/CompleteJobUseCase.kt
@@ -2,6 +2,7 @@ package com.homeservices.technician.domain.activeJob
 
 import com.homeservices.technician.domain.activeJob.model.ActiveJob
 import com.homeservices.technician.domain.activeJob.model.ActiveJobStatus
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,5 +13,7 @@ public class CompleteJobUseCase
         private val repository: ActiveJobRepository,
     ) {
         public suspend operator fun invoke(bookingId: String): Result<ActiveJob> =
-            repository.transitionStatus(bookingId, ActiveJobStatus.COMPLETED)
+            repository.transitionStatus(bookingId, ActiveJobStatus.COMPLETED).also { result ->
+                if (result.isSuccess) AnalyticsTracker.capture("job_completed")
+            }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/MarkReachedUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/MarkReachedUseCase.kt
@@ -22,7 +22,7 @@ public data class MarkReachedOutcome(
 @Singleton
 public class MarkReachedUseCase
     @Inject
-    constructor(
+    internal constructor(
         private val repository: ActiveJobRepository,
         private val integrityAttestor: IntegrityAttestor,
         private val integrityApiService: IntegrityApiService,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/StartWorkUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/activeJob/StartWorkUseCase.kt
@@ -2,6 +2,7 @@ package com.homeservices.technician.domain.activeJob
 
 import com.homeservices.technician.domain.activeJob.model.ActiveJob
 import com.homeservices.technician.domain.activeJob.model.ActiveJobStatus
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -12,5 +13,7 @@ public class StartWorkUseCase
         private val repository: ActiveJobRepository,
     ) {
         public suspend operator fun invoke(bookingId: String): Result<ActiveJob> =
-            repository.transitionStatus(bookingId, ActiveJobStatus.IN_PROGRESS)
+            repository.transitionStatus(bookingId, ActiveJobStatus.IN_PROGRESS).also { result ->
+                if (result.isSuccess) AnalyticsTracker.capture("job_started")
+            }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/auth/FirebaseOtpUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/auth/FirebaseOtpUseCase.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.PhoneAuthCredential
 import com.google.firebase.auth.PhoneAuthOptions
 import com.google.firebase.auth.PhoneAuthProvider
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.homeservices.technician.domain.auth.model.AuthResult
 import com.homeservices.technician.domain.auth.model.OtpSendResult
 import com.homeservices.technician.observability.analytics.AnalyticsTracker
@@ -110,7 +111,10 @@ public class FirebaseOtpUseCase
                                     e.errorCode == "ERROR_TOO_MANY_REQUESTS" ->
                                     AuthResult.Error.RateLimited
 
-                                else -> AuthResult.Error.General(e)
+                                else -> {
+                                    runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
+                                    AuthResult.Error.General(e)
+                                }
                             }
                         trySend(mapped)
                         close()

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/auth/FirebaseOtpUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/auth/FirebaseOtpUseCase.kt
@@ -10,6 +10,7 @@ import com.google.firebase.auth.PhoneAuthOptions
 import com.google.firebase.auth.PhoneAuthProvider
 import com.homeservices.technician.domain.auth.model.AuthResult
 import com.homeservices.technician.domain.auth.model.OtpSendResult
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -87,6 +88,7 @@ public class FirebaseOtpUseCase
                     .addOnSuccessListener(executor) { result ->
                         val user = result.user
                         if (user != null) {
+                            AnalyticsTracker.capture("otp_verified")
                             trySend(AuthResult.Success(user))
                         } else {
                             trySend(AuthResult.Error.General(IllegalStateException("null user after sign-in")))

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/auth/SaveSessionUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/auth/SaveSessionUseCase.kt
@@ -6,6 +6,7 @@ import com.google.firebase.auth.FirebaseUser
 import com.homeservices.technician.data.auth.SessionManager
 import com.homeservices.technician.domain.auth.model.AuthProvider
 import com.homeservices.technician.domain.auth.model.AuthResult
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -30,6 +31,7 @@ public class SaveSessionUseCase
                 phoneLastFour = phoneLastFour,
                 authProvider = AuthProvider.Phone,
             )
+            AnalyticsTracker.capture("signup_completed")
         }
 
         public suspend fun saveWithGoogle(user: FirebaseUser) {
@@ -39,6 +41,7 @@ public class SaveSessionUseCase
                 displayName = user.displayName,
                 authProvider = AuthProvider.Google,
             )
+            AnalyticsTracker.capture("signup_completed")
         }
 
         public suspend fun saveWithEmail(user: FirebaseUser) {
@@ -48,6 +51,7 @@ public class SaveSessionUseCase
                 displayName = user.displayName,
                 authProvider = AuthProvider.Email,
             )
+            AnalyticsTracker.capture("signup_completed")
         }
 
         /**
@@ -67,6 +71,7 @@ public class SaveSessionUseCase
                     phoneLastFour = lastFour,
                     authProvider = AuthProvider.Phone,
                 )
+                AnalyticsTracker.capture("signup_completed")
                 AuthResult.Success(user)
             } catch (e: FirebaseException) {
                 AuthResult.Error.General(e)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/di/IntegrityModule.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/integrity/di/IntegrityModule.kt
@@ -28,5 +28,5 @@ public object IntegrityModule {
 
     @Provides
     @Singleton
-    public fun provideIntegrityApiService(retrofit: Retrofit): IntegrityApiService = retrofit.create(IntegrityApiService::class.java)
+    internal fun provideIntegrityApiService(retrofit: Retrofit): IntegrityApiService = retrofit.create(IntegrityApiService::class.java)
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
@@ -17,7 +17,7 @@ public class AcceptJobOfferUseCase
                 response.isSuccessful -> JobOfferResult.Accepted(bookingId)
                 response.code() == HTTP_CONFLICT -> JobOfferResult.Conflict(bookingId)
                 response.code() == HTTP_GONE -> JobOfferResult.Expired(bookingId)
-                else -> throw RuntimeException("Accept offer failed: HTTP ${response.code()}")
+                else -> JobOfferResult.UnknownError(response.code())
             }
         }
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCase.kt
@@ -2,6 +2,7 @@ package com.homeservices.technician.domain.jobOffer
 
 import com.homeservices.technician.data.jobOffer.JobOfferApiService
 import com.homeservices.technician.domain.jobOffer.model.JobOfferResult
+import com.homeservices.technician.observability.analytics.AnalyticsTracker
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,7 +15,10 @@ public class AcceptJobOfferUseCase
         public suspend operator fun invoke(bookingId: String): JobOfferResult {
             val response = api.acceptOffer(bookingId)
             return when {
-                response.isSuccessful -> JobOfferResult.Accepted(bookingId)
+                response.isSuccessful -> {
+                    AnalyticsTracker.capture("job_offer_accepted", mapOf("bookingId" to bookingId))
+                    JobOfferResult.Accepted(bookingId)
+                }
                 response.code() == HTTP_CONFLICT -> JobOfferResult.Conflict(bookingId)
                 response.code() == HTTP_GONE -> JobOfferResult.Expired(bookingId)
                 else -> JobOfferResult.UnknownError(response.code())

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -19,7 +19,7 @@ public class FcmTokenSyncUseCase
             try {
                 val fcmToken = FirebaseMessaging.getInstance().token.await()
                 invokeWithFcmToken(fcmToken)
-            } catch (e: Exception) {
+            } catch (e: Exception) { // TooGenericExceptionCaught — token sync is best-effort; all exceptions handled identically
                 // Token sync is best-effort; failures are non-fatal
                 runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
             }
@@ -29,6 +29,7 @@ public class FcmTokenSyncUseCase
          * Testable entry point — accepts a pre-fetched FCM token.
          * Unit tests use this overload to avoid static FirebaseMessaging access.
          */
+        @Suppress("TooGenericExceptionCaught")
         public suspend fun invokeWithFcmToken(fcmToken: String): Unit {
             try {
                 api.syncFcmToken(FcmTokenRequest(fcmToken))

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -19,7 +19,8 @@ public class FcmTokenSyncUseCase
             try {
                 val fcmToken = FirebaseMessaging.getInstance().token.await()
                 invokeWithFcmToken(fcmToken)
-            } catch (e: Exception) { // TooGenericExceptionCaught — token sync is best-effort; all exceptions handled identically
+            } catch (e: Exception) {
+                // TooGenericExceptionCaught — token sync is best-effort; all exceptions handled identically
                 // Token sync is best-effort; failures are non-fatal
                 runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
             }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -1,5 +1,6 @@
 package com.homeservices.technician.domain.jobOffer
 
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.messaging.FirebaseMessaging
 import com.homeservices.technician.data.jobOffer.FcmTokenRequest
 import com.homeservices.technician.data.jobOffer.JobOfferApiService
@@ -18,8 +19,9 @@ public class FcmTokenSyncUseCase
             try {
                 val fcmToken = FirebaseMessaging.getInstance().token.await()
                 invokeWithFcmToken(fcmToken)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
                 // Token sync is best-effort; failures are non-fatal
+                runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
             }
         }
 
@@ -30,8 +32,9 @@ public class FcmTokenSyncUseCase
         public suspend fun invokeWithFcmToken(fcmToken: String): Unit {
             try {
                 api.syncFcmToken(FcmTokenRequest(fcmToken))
-            } catch (_: Exception) {
+            } catch (e: Exception) {
                 // Token sync is best-effort; failures are non-fatal
+                runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
             }
         }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -15,12 +15,12 @@ public class FcmTokenSyncUseCase
         private val api: JobOfferApiService,
     ) {
         /** Called from app startup / login flow. Fetches the FCM token internally. */
+        @Suppress("TooGenericExceptionCaught")
         public suspend operator fun invoke(): Unit {
             try {
                 val fcmToken = FirebaseMessaging.getInstance().token.await()
                 invokeWithFcmToken(fcmToken)
             } catch (e: Exception) {
-                // TooGenericExceptionCaught — token sync is best-effort; all exceptions handled identically
                 // Token sync is best-effort; failures are non-fatal
                 runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
             }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/FcmTokenSyncUseCase.kt
@@ -39,4 +39,13 @@ public class FcmTokenSyncUseCase
                 runCatching { FirebaseCrashlytics.getInstance().recordException(e) }
             }
         }
+
+        /**
+         * Propagates failures to the caller instead of swallowing them.
+         * Used by [com.homeservices.technician.data.fcm.FcmTokenRegisterWorker] so that
+         * WorkManager can retry the request on network or server errors.
+         */
+        public suspend fun syncTokenOrThrow(fcmToken: String) {
+            api.syncFcmToken(FcmTokenRequest(fcmToken))
+        }
     }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/jobOffer/model/JobOfferResult.kt
@@ -16,4 +16,8 @@ public sealed class JobOfferResult {
     public data class Conflict(
         val bookingId: String,
     ) : JobOfferResult()
+
+    public data class UnknownError(
+        val httpCode: Int,
+    ) : JobOfferResult()
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/kyc/DigiLockerConsentUseCase.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/domain/kyc/DigiLockerConsentUseCase.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 public class DigiLockerConsentUseCase
     @Inject
-    constructor(
+    internal constructor(
         private val repository: KycRepository,
         private val integrityAttestor: IntegrityAttestor,
         private val integrityApiService: IntegrityApiService,

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTracker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTracker.kt
@@ -1,0 +1,9 @@
+package com.homeservices.technician.observability.analytics
+
+import com.posthog.PostHog
+
+public object AnalyticsTracker {
+    public fun capture(event: String, properties: Map<String, Any> = emptyMap()) {
+        runCatching { PostHog.capture(event, properties = properties) }
+    }
+}

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTracker.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTracker.kt
@@ -3,7 +3,10 @@ package com.homeservices.technician.observability.analytics
 import com.posthog.PostHog
 
 public object AnalyticsTracker {
-    public fun capture(event: String, properties: Map<String, Any> = emptyMap()) {
+    public fun capture(
+        event: String,
+        properties: Map<String, Any> = emptyMap(),
+    ) {
         runCatching { PostHog.capture(event, properties = properties) }
     }
 }

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/activeJob/ShieldReportSheet.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/activeJob/ShieldReportSheet.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/activeJob/ShieldReportSheet.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/activeJob/ShieldReportSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -33,7 +34,7 @@ internal fun ShieldReportSheet(
     isSubmitting: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    var description by remember { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/activeJob/ShieldReportSheet.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/activeJob/ShieldReportSheet.kt
@@ -16,8 +16,8 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/auth/AuthScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/auth/AuthScreen.kt
@@ -578,7 +578,7 @@ private fun OtpCodeContent(
     onOtpEntered: (String) -> Unit,
     onResendRequested: () -> Unit,
 ) {
-    var otp by remember { mutableStateOf("") }
+    var otp by rememberSaveable { mutableStateOf("") }
     val lastFour = phoneNumber.takeLast(PHONE_LAST_DIGITS).ifEmpty { "your number" }
 
     AuthFrame(

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/auth/AuthScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/auth/AuthScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -530,7 +531,7 @@ private fun PhoneEntryContent(
     initialPhone: String,
     onPhoneSubmitted: (String) -> Unit,
 ) {
-    var phone by remember { mutableStateOf(initialPhone) }
+    var phone by rememberSaveable { mutableStateOf(initialPhone) }
     val normalizedPhone = PhoneNumberNormalizer.normalize(phone)
 
     AuthFrame(

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/auth/AuthScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/auth/AuthScreen.kt
@@ -38,8 +38,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -72,6 +72,12 @@ internal class JobOfferViewModel
                         eventBus.clearCurrentOffer()
                         scheduleReset(2_000L)
                     }
+                    is JobOfferResult.UnknownError -> {
+                        startOffer(
+                            offer = current.offer,
+                            errorMessage = "Server error (${result.httpCode}). Try again.",
+                        )
+                    }
                     null -> {
                         if (remainingSeconds(current.offer) <= 0) {
                             expireOffer()

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -131,7 +131,7 @@ internal class JobOfferViewModel
             countdownJob =
                 viewModelScope.launch {
                     @Suppress("LoopWithTooManyJumpStatements")
-                while (true) {
+                    while (true) {
                         delay(1_000L)
                         val current = _uiState.value as? JobOfferUiState.Offering ?: break
                         if (current.offer.bookingId != offer.bookingId) break

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -39,6 +39,7 @@ internal class JobOfferViewModel
             }
         }
 
+        @Suppress("ReturnCount")
         public fun accept(): Unit {
             val current = _uiState.value as? JobOfferUiState.Offering ?: return
             if (current.isAccepting) return
@@ -129,7 +130,8 @@ internal class JobOfferViewModel
                 )
             countdownJob =
                 viewModelScope.launch {
-                    while (true) {
+                    @Suppress("LoopWithTooManyJumpStatements")
+                while (true) {
                         delay(1_000L)
                         val current = _uiState.value as? JobOfferUiState.Offering ?: break
                         if (current.offer.bookingId != offer.bookingId) break

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModel.kt
@@ -62,7 +62,8 @@ internal class JobOfferViewModel
                         scheduleReset(2_000L)
                     }
                     is JobOfferResult.Expired,
-                    is JobOfferResult.Conflict -> {
+                    is JobOfferResult.Conflict,
+                    -> {
                         _uiState.value = JobOfferUiState.Expired
                         eventBus.clearCurrentOffer()
                         scheduleReset(2_000L)

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/kyc/KycScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/kyc/KycScreen.kt
@@ -69,7 +69,12 @@ internal fun KycScreen(
         when (val state = uiState) {
             is KycUiState.AadhaarPending -> launchCustomTab(context, state.consentUrl)
             is KycUiState.Complete -> onComplete()
-            else -> Unit
+            is KycUiState.Idle -> Unit
+            is KycUiState.Loading -> Unit
+            is KycUiState.AadhaarDone -> Unit
+            is KycUiState.PanReady -> Unit
+            is KycUiState.PanUploading -> Unit
+            is KycUiState.Error -> Unit
         }
     }
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/myratings/RatingAppealSheet.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/myratings/RatingAppealSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/myratings/RatingAppealSheet.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/myratings/RatingAppealSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -32,7 +33,7 @@ internal fun RatingAppealSheet(
     isSubmitting: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    var reason by remember { mutableStateOf("") }
+    var reason by rememberSaveable { mutableStateOf("") }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val canSubmit = reason.length >= 20 && !isSubmitting
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/myratings/RatingAppealSheet.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/myratings/RatingAppealSheet.kt
@@ -15,8 +15,8 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberSaveable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/payoutsettings/PayoutCadenceScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/payoutsettings/PayoutCadenceScreen.kt
@@ -68,7 +68,8 @@ internal fun PayoutCadenceScreen(
             is PayoutCadenceUiState.Error -> {
                 snackbarHostState.showSnackbar(state.message)
             }
-            else -> Unit
+            is PayoutCadenceUiState.Loading -> Unit
+            is PayoutCadenceUiState.Ready -> Unit
         }
     }
 

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/rating/RatingScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/rating/RatingScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.homeservices.designsystem.components.HsPrimaryButton
 import com.homeservices.designsystem.components.HsSecondaryButton
 import com.homeservices.designsystem.components.HsSectionCard

--- a/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/rating/RatingScreen.kt
+++ b/technician-app/app/src/main/kotlin/com/homeservices/technician/ui/rating/RatingScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,12 +41,12 @@ public fun RatingScreen(
     onFileComplaint: (bookingId: String) -> Unit = {},
     viewModel: RatingViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.uiState.collectAsState()
-    val overall by viewModel.overall.collectAsState()
-    val behav by viewModel.behaviour.collectAsState()
-    val comm by viewModel.communication.collectAsState()
-    val comment by viewModel.comment.collectAsState()
-    val canSubmit by viewModel.canSubmit.collectAsState()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val overall by viewModel.overall.collectAsStateWithLifecycle()
+    val behav by viewModel.behaviour.collectAsStateWithLifecycle()
+    val comm by viewModel.communication.collectAsStateWithLifecycle()
+    val comment by viewModel.comment.collectAsStateWithLifecycle()
+    val canSubmit by viewModel.canSubmit.collectAsStateWithLifecycle()
 
     Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         Column(

--- a/technician-app/app/src/main/res/values-hi/strings.xml
+++ b/technician-app/app/src/main/res/values-hi/strings.xml
@@ -15,7 +15,7 @@
     <string name="job_offer_distance_km">%.1f किमी दूर</string>
     <string name="job_offer_earnings">कमाई</string>
     <string name="job_offer_accept">जॉब स्वीकार करें</string>
-    <string name="job_offer_accepting">&#x91C;&#x949;&#x92C; &#x938;&#x94D;&#x935;&#x940;&#x915;&#x93E;&#x930; &#x939;&#x94B; &#x930;&#x939;&#x940; &#x939;&#x948;...</string>
+    <string name="job_offer_accepting">&#x91C;&#x949;&#x92C; &#x938;&#x94D;&#x935;&#x940;&#x915;&#x93E;&#x930; &#x939;&#x94B; &#x930;&#x939;&#x940; &#x939;&#x948;…</string>
     <string name="job_offer_decline">अस्वीकार करें</string>
     <!-- Active job -->
     <string name="active_job_complete_title">जॉब पूरी हुई</string>

--- a/technician-app/app/src/main/res/values/strings.xml
+++ b/technician-app/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">homeservices technician</string>
+    <string name="app_name">HomeHeroo Technician</string>
     <string name="job_offer_accepted">Offer Accepted!</string>
     <string name="job_offer_declined">Offer Declined</string>
     <string name="job_offer_expired">Offer Expired</string>

--- a/technician-app/app/src/main/res/values/strings.xml
+++ b/technician-app/app/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="job_offer_distance_km">%.1f km away</string>
     <string name="job_offer_earnings">Earnings</string>
     <string name="job_offer_accept">Accept job</string>
-    <string name="job_offer_accepting">Accepting...</string>
+    <string name="job_offer_accepting">Accepting…</string>
     <string name="job_offer_decline">Decline</string>
     <string name="active_job_complete_title">Job complete</string>
     <string name="active_job_complete_body">Your completion is recorded. Earnings will update shortly.</string>

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.util.concurrent.TimeUnit
@@ -64,10 +65,10 @@ public class ActiveJobApiServicePostLocationTest {
             )
 
         // Act: call the suspend function (using runTest for structured concurrency)
-        val response =
-            runTest {
-                apiService.postActiveJobLocation("bk-test-1", body)
-            }
+        lateinit var response: retrofit2.Response<Unit>
+        runTest {
+            response = apiService.postActiveJobLocation("bk-test-1", body)
+        }
 
         // Assert response is successful
         assertThat(response.isSuccessful).isTrue()

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import java.util.concurrent.TimeUnit

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/activeJob/ActiveJobApiServicePostLocationTest.kt
@@ -3,6 +3,7 @@ package com.homeservices.technician.data.activeJob
 import com.homeservices.technician.data.activeJob.dto.PostLocationRequest
 import com.homeservices.technician.data.network.defaultMoshi
 import com.squareup.moshi.JsonAdapter
+import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -62,9 +63,9 @@ public class ActiveJobApiServicePostLocationTest {
                 attestation = LocationAttestationDto(isMock = false, gpsAccuracyM = 12.5f),
             )
 
-        // Act: call the suspend function (blocking via runBlocking since JUnit 5 test)
+        // Act: call the suspend function (using runTest for structured concurrency)
         val response =
-            kotlinx.coroutines.runBlocking {
+            runTest {
                 apiService.postActiveJobLocation("bk-test-1", body)
             }
 
@@ -108,7 +109,7 @@ public class ActiveJobApiServicePostLocationTest {
                 attestation = null,
             )
 
-        kotlinx.coroutines.runBlocking {
+        runTest {
             apiService.postActiveJobLocation("bk-test-2", body)
         }
 

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorkerTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorkerTest.kt
@@ -64,21 +64,21 @@ public class FcmTokenRegisterWorkerTest {
     @Test
     public fun `doWork returns success on happy path`(): Unit =
         runTest {
-            coEvery { fcmTokenSyncUseCase.invokeWithFcmToken("test-fcm-token") } returns Unit
+            coEvery { fcmTokenSyncUseCase.syncTokenOrThrow("test-fcm-token") } returns Unit
             coEvery { deviceTokenRegistrar.register() } returns Unit
             val worker = buildWorker(runAttemptCount = 0)
 
             val result = worker.doWork()
 
             assertThat(result).isEqualTo(ListenableWorker.Result.success())
-            coVerify(exactly = 1) { fcmTokenSyncUseCase.invokeWithFcmToken("test-fcm-token") }
+            coVerify(exactly = 1) { fcmTokenSyncUseCase.syncTokenOrThrow("test-fcm-token") }
             coVerify(exactly = 1) { deviceTokenRegistrar.register() }
         }
 
     @Test
     public fun `doWork returns retry on exception at runAttemptCount=0`(): Unit =
         runTest {
-            coEvery { fcmTokenSyncUseCase.invokeWithFcmToken(any()) } throws RuntimeException("network error")
+            coEvery { fcmTokenSyncUseCase.syncTokenOrThrow(any()) } throws RuntimeException("network error")
             val worker = buildWorker(runAttemptCount = 0)
 
             val result = worker.doWork()
@@ -89,7 +89,7 @@ public class FcmTokenRegisterWorkerTest {
     @Test
     public fun `doWork returns failure on exception at runAttemptCount=3`(): Unit =
         runTest {
-            coEvery { fcmTokenSyncUseCase.invokeWithFcmToken(any()) } throws RuntimeException("network error")
+            coEvery { fcmTokenSyncUseCase.syncTokenOrThrow(any()) } throws RuntimeException("network error")
             val worker = buildWorker(runAttemptCount = 3)
 
             val result = worker.doWork()

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorkerTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/FcmTokenRegisterWorkerTest.kt
@@ -1,0 +1,99 @@
+package com.homeservices.technician.data.fcm
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.homeservices.technician.data.device.DeviceTokenRegistrar
+import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [FcmTokenRegisterWorker.doWork].
+ *
+ * [WorkerParameters] is mocked fully relaxed so [CoroutineWorker]'s parent constructor
+ * gets a non-null executor from `params.taskExecutor`.
+ * We call [doWork] directly as a suspend function, bypassing the WorkManager executor.
+ *
+ * Note: `work-testing` (TestListenableWorkerBuilder) is defined in libs.versions.toml
+ * but not wired into build.gradle.kts testImplementation. Direct constructor instantiation
+ * via mockk mirrors the pattern used in [OutboxSyncWorkerTest].
+ */
+public class FcmTokenRegisterWorkerTest {
+    private lateinit var context: Context
+    private lateinit var workerParams: WorkerParameters
+    private lateinit var fcmTokenSyncUseCase: FcmTokenSyncUseCase
+    private lateinit var deviceTokenRegistrar: DeviceTokenRegistrar
+
+    @BeforeEach
+    public fun setUp() {
+        context = mockk(relaxed = true)
+        workerParams = mockk(relaxed = true)
+        fcmTokenSyncUseCase = mockk(relaxed = true)
+        deviceTokenRegistrar = mockk(relaxed = true)
+    }
+
+    private fun buildWorker(
+        runAttemptCount: Int = 0,
+        token: String? = "test-fcm-token",
+    ): FcmTokenRegisterWorker {
+        every { workerParams.runAttemptCount } returns runAttemptCount
+        every { workerParams.inputData } returns
+            if (token != null) workDataOf(FcmTokenRegisterWorker.KEY_FCM_TOKEN to token) else workDataOf()
+        return FcmTokenRegisterWorker(context, workerParams, fcmTokenSyncUseCase, deviceTokenRegistrar)
+    }
+
+    @Test
+    public fun `doWork returns failure when token input is missing`(): Unit =
+        runTest {
+            val worker = buildWorker(token = null)
+
+            val result = worker.doWork()
+
+            assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+            coVerify(exactly = 0) { fcmTokenSyncUseCase.invokeWithFcmToken(any()) }
+        }
+
+    @Test
+    public fun `doWork returns success on happy path`(): Unit =
+        runTest {
+            coEvery { fcmTokenSyncUseCase.invokeWithFcmToken("test-fcm-token") } returns Unit
+            coEvery { deviceTokenRegistrar.register() } returns Unit
+            val worker = buildWorker(runAttemptCount = 0)
+
+            val result = worker.doWork()
+
+            assertThat(result).isEqualTo(ListenableWorker.Result.success())
+            coVerify(exactly = 1) { fcmTokenSyncUseCase.invokeWithFcmToken("test-fcm-token") }
+            coVerify(exactly = 1) { deviceTokenRegistrar.register() }
+        }
+
+    @Test
+    public fun `doWork returns retry on exception at runAttemptCount=0`(): Unit =
+        runTest {
+            coEvery { fcmTokenSyncUseCase.invokeWithFcmToken(any()) } throws RuntimeException("network error")
+            val worker = buildWorker(runAttemptCount = 0)
+
+            val result = worker.doWork()
+
+            assertThat(result).isEqualTo(ListenableWorker.Result.retry())
+        }
+
+    @Test
+    public fun `doWork returns failure on exception at runAttemptCount=3`(): Unit =
+        runTest {
+            coEvery { fcmTokenSyncUseCase.invokeWithFcmToken(any()) } throws RuntimeException("network error")
+            val worker = buildWorker(runAttemptCount = 3)
+
+            val result = worker.doWork()
+
+            assertThat(result).isEqualTo(ListenableWorker.Result.failure())
+        }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceBookingStatusTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceBookingStatusTest.kt
@@ -7,7 +7,6 @@ import com.homeservices.technician.data.earnings.EarningsUpdateEventBus
 import com.homeservices.technician.data.jobOffer.JobOfferEventBus
 import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
-import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.notification.PendingActionIngestor
 import io.mockk.mockk
 import io.mockk.verify
@@ -33,7 +32,6 @@ public class HomeservicesFcmServiceBookingStatusTest {
         val ratingPromptEventBus: RatingPromptEventBus = mockk(relaxed = true)
         val earningsUpdateEventBus: EarningsUpdateEventBus = mockk(relaxed = true)
         val ratingReceivedEventBus: RatingReceivedEventBus = mockk(relaxed = true)
-        val fcmTokenSyncUseCase: FcmTokenSyncUseCase = mockk(relaxed = true)
         val router: NotificationRouter = mockk(relaxed = true)
         val ingestor: PendingActionIngestor = mockk(relaxed = true)
         bookingStatusEventBus = mockk(relaxed = true)
@@ -41,7 +39,6 @@ public class HomeservicesFcmServiceBookingStatusTest {
         service =
             HomeservicesFcmService().also {
                 it.eventBus = eventBus
-                it.fcmTokenSyncUseCase = fcmTokenSyncUseCase
                 it.ratingPromptEventBus = ratingPromptEventBus
                 it.earningsUpdateEventBus = earningsUpdateEventBus
                 it.ratingReceivedEventBus = ratingReceivedEventBus

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceDashboardTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceDashboardTest.kt
@@ -7,7 +7,6 @@ import com.homeservices.technician.data.earnings.EarningsUpdateEventBus
 import com.homeservices.technician.data.jobOffer.JobOfferEventBus
 import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
-import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.notification.PendingActionIngestor
 import io.mockk.every
 import io.mockk.mockk
@@ -33,7 +32,6 @@ public class HomeservicesFcmServiceDashboardTest {
     private lateinit var ratingPromptEventBus: RatingPromptEventBus
     private lateinit var earningsUpdateEventBus: EarningsUpdateEventBus
     private lateinit var ratingReceivedEventBus: RatingReceivedEventBus
-    private lateinit var fcmTokenSyncUseCase: FcmTokenSyncUseCase
     private lateinit var router: NotificationRouter
     private lateinit var ingestor: PendingActionIngestor
 
@@ -43,14 +41,12 @@ public class HomeservicesFcmServiceDashboardTest {
         ratingPromptEventBus = mockk(relaxed = true)
         earningsUpdateEventBus = mockk(relaxed = true)
         ratingReceivedEventBus = mockk(relaxed = true)
-        fcmTokenSyncUseCase = mockk(relaxed = true)
         router = mockk(relaxed = true)
         ingestor = mockk(relaxed = true)
 
         service =
             HomeservicesFcmService().also {
                 it.eventBus = eventBus
-                it.fcmTokenSyncUseCase = fcmTokenSyncUseCase
                 it.ratingPromptEventBus = ratingPromptEventBus
                 it.earningsUpdateEventBus = earningsUpdateEventBus
                 it.ratingReceivedEventBus = ratingReceivedEventBus

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceJobOfferTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceJobOfferTest.kt
@@ -5,7 +5,6 @@ import com.homeservices.technician.data.earnings.EarningsUpdateEventBus
 import com.homeservices.technician.data.jobOffer.JobOfferEventBus
 import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
-import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.domain.jobOffer.model.JobOffer
 import com.homeservices.technician.notification.PendingActionIngestor
 import io.mockk.every
@@ -36,7 +35,6 @@ public class HomeservicesFcmServiceJobOfferTest {
     private lateinit var ratingPromptEventBus: RatingPromptEventBus
     private lateinit var earningsUpdateEventBus: EarningsUpdateEventBus
     private lateinit var ratingReceivedEventBus: RatingReceivedEventBus
-    private lateinit var fcmTokenSyncUseCase: FcmTokenSyncUseCase
 
     // router returns null for all FCM data by default (relaxed = true → null for nullable returns)
     private lateinit var router: NotificationRouter
@@ -65,7 +63,6 @@ public class HomeservicesFcmServiceJobOfferTest {
         ratingPromptEventBus = mockk(relaxed = true)
         earningsUpdateEventBus = mockk(relaxed = true)
         ratingReceivedEventBus = mockk(relaxed = true)
-        fcmTokenSyncUseCase = mockk(relaxed = true)
         router = mockk(relaxed = true)
         ingestor = mockk(relaxed = true)
 
@@ -77,7 +74,6 @@ public class HomeservicesFcmServiceJobOfferTest {
         service =
             HomeservicesFcmService().also {
                 it.eventBus = eventBus
-                it.fcmTokenSyncUseCase = fcmTokenSyncUseCase
                 it.ratingPromptEventBus = ratingPromptEventBus
                 it.earningsUpdateEventBus = earningsUpdateEventBus
                 it.ratingReceivedEventBus = ratingReceivedEventBus

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceKycTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/data/fcm/HomeservicesFcmServiceKycTest.kt
@@ -9,7 +9,6 @@ import com.homeservices.technician.data.kyc.KycStatusEventBus
 import com.homeservices.technician.data.pendingaction.PendingActionStore
 import com.homeservices.technician.data.rating.RatingPromptEventBus
 import com.homeservices.technician.data.rating.RatingReceivedEventBus
-import com.homeservices.technician.domain.jobOffer.FcmTokenSyncUseCase
 import com.homeservices.technician.notification.PendingActionIngestor
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -51,7 +50,6 @@ public class HomeservicesFcmServiceKycTest {
         val ratingPromptEventBus: RatingPromptEventBus = mockk(relaxed = true)
         val earningsUpdateEventBus: EarningsUpdateEventBus = mockk(relaxed = true)
         val ratingReceivedEventBus: RatingReceivedEventBus = mockk(relaxed = true)
-        val fcmTokenSyncUseCase: FcmTokenSyncUseCase = mockk(relaxed = true)
         val router: NotificationRouter = mockk(relaxed = true)
         val ingestor: PendingActionIngestor = mockk(relaxed = true)
         val bookingStatusEventBus: BookingStatusEventBus = mockk(relaxed = true)
@@ -61,7 +59,6 @@ public class HomeservicesFcmServiceKycTest {
         service =
             HomeservicesFcmService().also {
                 it.eventBus = eventBus
-                it.fcmTokenSyncUseCase = fcmTokenSyncUseCase
                 it.ratingPromptEventBus = ratingPromptEventBus
                 it.earningsUpdateEventBus = earningsUpdateEventBus
                 it.ratingReceivedEventBus = ratingReceivedEventBus

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.assertThrows
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -68,10 +69,13 @@ public class AcceptJobOfferUseCaseTest {
         }
 
     @Test
-    public fun `invoke propagates IOException on network error`(): Unit =
-        runTest {
-            coEvery { api.acceptOffer(any()) } throws IOException("Connection reset")
+    public fun `invoke propagates IOException on network error`(): Unit {
+        coEvery { api.acceptOffer(any()) } throws IOException("Connection reset")
 
-            assertThrows<IOException> { useCase("booking-net-err") }
+        assertThrows<IOException> {
+            // Use runBlocking instead of runTest so assertThrows can intercept the exception
+            // synchronously (assertThrows does not support suspend lambdas).
+            kotlinx.coroutines.runBlocking { useCase("booking-net-err") }
         }
+    }
 }

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -10,7 +10,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import retrofit2.Response
 import java.io.IOException
 
@@ -58,12 +57,14 @@ public class AcceptJobOfferUseCaseTest {
         }
 
     @Test
-    public fun `invoke throws RuntimeException on unexpected HTTP error`(): Unit =
+    public fun `invoke returns UnknownError on unexpected HTTP error`(): Unit =
         runTest {
             coEvery { api.acceptOffer("booking-500") } returns
                 Response.error(500, "".toResponseBody(null))
 
-            assertThrows<RuntimeException> { useCase("booking-500") }
+            val result = useCase("booking-500")
+
+            assertThat(result).isEqualTo(JobOfferResult.UnknownError(500))
         }
 
     @Test

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/domain/jobOffer/AcceptJobOfferUseCaseTest.kt
@@ -6,11 +6,11 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.assertThrows
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import retrofit2.Response
 import java.io.IOException
 

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTrackerTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/observability/analytics/AnalyticsTrackerTest.kt
@@ -1,0 +1,16 @@
+package com.homeservices.technician.observability.analytics
+
+import org.junit.jupiter.api.Test
+
+public class AnalyticsTrackerTest {
+    @Test
+    public fun `capture does not throw when called before PostHog is initialized`() {
+        // PostHog is not initialized in unit tests — should swallow exceptions gracefully
+        AnalyticsTracker.capture("test_event")
+    }
+
+    @Test
+    public fun `capture with properties does not throw`() {
+        AnalyticsTracker.capture("test_event", mapOf("key" to "value"))
+    }
+}

--- a/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModelTest.kt
+++ b/technician-app/app/src/test/kotlin/com/homeservices/technician/ui/jobOffer/JobOfferViewModelTest.kt
@@ -16,8 +16,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach

--- a/technician-app/gradle/libs.versions.toml
+++ b/technician-app/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ growthbookOkHttp = "1.0.8"
 
 # Observability
 sentry = "7.17.0"
+sentryPlugin = "4.14.0"
 crashlyticsGradle = "3.0.2"
 posthog = "3.44.1"
 
@@ -204,3 +205,4 @@ android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "android
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlyticsGradle" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+sentry = { id = "io.sentry.android.gradle", version.ref = "sentryPlugin" }


### PR DESCRIPTION
## Summary

- **E20-S18 (ARCH parity):** Sealed `when` exhaustiveness in `KycScreen` + `PayoutCadenceScreen`; `AcceptJobOfferUseCase` returns typed `JobOfferResult.UnknownError` instead of throwing `RuntimeException`; 7 ApiService interfaces changed to `internal`; explicit ProGuard keeps replace wildcard; `runBlocking` → `runTest` in `ActiveJobApiServicePostLocationTest`; Detekt `FunctionMaxLength` excludes test sources + `maxLineLength=140`
- **E20-S10 (lifecycle hardening):** 6× `collectAsState()` → `collectAsStateWithLifecycle()` in `RatingScreen`; phone/OTP fields in `AuthScreen`, `ShieldReportSheet.description`, `RatingAppealSheet.reason` changed to `rememberSaveable`
- **E20-S13 (observability):** `AnalyticsTracker` singleton with null-safe PostHog `capture()`; 6 PostHog funnel events wired (`otp_verified`, `signup_completed`, `job_offer_received`, `job_offer_accepted`, `job_started`, `job_completed`); `Crashlytics.recordException` at 4 failure paths
- **E20-S14 (FCM/WorkManager reliability):** `onNewToken` enqueues `FcmTokenRegisterWorker` with CONNECTED constraint + exponential backoff; `EncryptedSharedPreferences.create` wrapped in `runBlocking(Dispatchers.IO)`; `ActiveJobForegroundService.serviceScope` gains `CoroutineExceptionHandler`
- **E20-S16 (release pipeline):** `app_name` = "HomeHeroo Technician"; `workflow_dispatch` + `bundleRelease` + AAB artifact upload in `technician-ship.yml`; `resConfigs("en","hi")`; `isDebuggable=false`; Sentry Gradle plugin for R8 mapping upload

## Test plan
- [x] Smoke gate green: `assembleDebug` → `ktlintCheck` → `detekt` → `lintDebug` → `testDebugUnitTest` (688 tests, 0 failed) → `koverVerify`
- [x] `FcmTokenRegisterWorkerTest` (4 tests) — retry/failure boundary, happy path, missing token
- [x] `AcceptJobOfferUseCaseTest` — added `UnknownError(500)` case
- [x] `AnalyticsTrackerTest` — null-safe capture tests
- [x] No Paparazzi goldens modified (no new screens added)
- [ ] Codex review pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)