### PR TITLE
feat(api): E21-S01 cash-pilot commission model — receivable ledger + settlement rewrite

### DIFF
--- a/.codex-review-passed
+++ b/.codex-review-passed
@@ -1,7 +1,7 @@
-codex-review-passed: 2026-05-23T21:14:08Z
-branch: fix/sprint7-architecture-cleanup
-base: main
+codex-review: passed
+branch: worktree-e20-cash-commission-api
+story: E21-S01
 model: gpt-5.5
-rounds: 2
-result: PASS — no discrete correctness issues
-p2-fixes: PaymentResultBus HOT revert + NoShowCreditEventBus StateFlow consume()
+date: 2026-05-24
+findings: 4 P2s (amount-below-due, no-op audit, ops-manager rbac, razorpay cascade)
+resolution: all 4 fixed in commit 8452c86e; smoke gate green (1535 tests)

--- a/admin-web/src/api/generated/openapi.json
+++ b/admin-web/src/api/generated/openapi.json
@@ -530,6 +530,11 @@
           "safetyTag": {
             "type": "boolean"
           },
+          "commissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          },
           "isActive": {
             "type": "boolean"
           },
@@ -594,7 +599,7 @@
             "type": "integer",
             "minimum": 1500,
             "maximum": 3500,
-            "description": "Commission in basis points (2250 = 22.5%)"
+            "description": "Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default."
           },
           "durationMinutes": {
             "type": "integer",
@@ -712,7 +717,6 @@
           "shortDescription",
           "heroImageUrl",
           "basePrice",
-          "commissionBps",
           "durationMinutes",
           "includes",
           "faq",
@@ -1477,6 +1481,367 @@
           "status"
         ]
       },
+      "CommissionConfigDoc": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "commission-config"
+            ]
+          },
+          "defaultCommissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          },
+          "updatedBy": {
+            "type": "string",
+            "minLength": 1
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "defaultCommissionBps",
+          "updatedBy",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      },
+      "UpdateCommissionConfigBody": {
+        "type": "object",
+        "properties": {
+          "defaultCommissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          }
+        },
+        "required": [
+          "defaultCommissionBps"
+        ],
+        "additionalProperties": false
+      },
+      "CommissionConfigResponse": {
+        "type": "object",
+        "properties": {
+          "defaultCommissionBps": {
+            "type": "integer"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "defaultCommissionBps",
+          "updatedBy",
+          "updatedAt"
+        ]
+      },
+      "CommissionReceivableEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "bookingId": {
+            "type": "string"
+          },
+          "technicianId": {
+            "type": "string"
+          },
+          "partitionKey": {
+            "type": "string"
+          },
+          "serviceId": {
+            "type": "string"
+          },
+          "categoryId": {
+            "type": "string"
+          },
+          "bookingAmount": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "cashCollectedAmount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "commissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          },
+          "commissionDue": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "commissionResolvedFrom": {
+            "type": "string",
+            "enum": [
+              "SERVICE",
+              "CATEGORY",
+              "GLOBAL"
+            ]
+          },
+          "remittanceStatus": {
+            "type": "string",
+            "enum": [
+              "DUE",
+              "REMITTED",
+              "WAIVED"
+            ]
+          },
+          "remittedAmount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "remittedAt": {
+            "type": "string"
+          },
+          "remittanceRef": {
+            "type": "string"
+          },
+          "remittanceMethod": {
+            "type": "string",
+            "enum": [
+              "UPI",
+              "CASH_DEPOSIT",
+              "ADJUSTMENT"
+            ]
+          },
+          "markedByAdminId": {
+            "type": "string"
+          },
+          "waivedReason": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "bookingId",
+          "technicianId",
+          "partitionKey",
+          "serviceId",
+          "categoryId",
+          "bookingAmount",
+          "commissionBps",
+          "commissionDue",
+          "commissionResolvedFrom",
+          "remittanceStatus",
+          "createdAt"
+        ]
+      },
+      "TechnicianOutstandingSummary": {
+        "type": "object",
+        "properties": {
+          "technicianId": {
+            "type": "string"
+          },
+          "technicianName": {
+            "type": "string"
+          },
+          "dueCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalCommissionDue": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "oldestDueAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "technicianId",
+          "technicianName",
+          "dueCount",
+          "totalCommissionDue"
+        ]
+      },
+      "CommissionReceivablesDashboard": {
+        "type": "object",
+        "properties": {
+          "technicians": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "technicianId": {
+                  "type": "string"
+                },
+                "technicianName": {
+                  "type": "string"
+                },
+                "dueCount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "totalCommissionDue": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "oldestDueAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "technicianId",
+                "technicianName",
+                "dueCount",
+                "totalCommissionDue"
+              ]
+            }
+          },
+          "totalOutstanding": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "technicians",
+          "totalOutstanding"
+        ]
+      },
+      "MarkCommissionReceivedBody": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "REMIT"
+                ]
+              },
+              "bookingId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "technicianId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "remittedAmount": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "remittanceMethod": {
+                "type": "string",
+                "enum": [
+                  "UPI",
+                  "CASH_DEPOSIT",
+                  "ADJUSTMENT"
+                ]
+              },
+              "remittanceRef": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "action",
+              "bookingId",
+              "technicianId",
+              "remittedAmount",
+              "remittanceMethod",
+              "remittanceRef"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "WAIVE"
+                ]
+              },
+              "bookingId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "technicianId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "waivedReason": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "action",
+              "bookingId",
+              "technicianId",
+              "waivedReason"
+            ]
+          }
+        ]
+      },
+      "TechnicianCommissionDue": {
+        "type": "object",
+        "properties": {
+          "totalOutstandingPaise": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "dueCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "bookingId": {
+                  "type": "string"
+                },
+                "bookingAmount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "commissionDue": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bookingId",
+                "bookingAmount",
+                "commissionDue",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "totalOutstandingPaise",
+          "dueCount",
+          "entries"
+        ]
+      },
       "WaitlistRequest": {
         "type": "object",
         "properties": {
@@ -1925,6 +2290,11 @@
                   },
                   "safetyTag": {
                     "type": "boolean"
+                  },
+                  "commissionBps": {
+                    "type": "integer",
+                    "minimum": 1500,
+                    "maximum": 3500
                   }
                 },
                 "required": [
@@ -2040,6 +2410,11 @@
                   },
                   "safetyTag": {
                     "type": "boolean"
+                  },
+                  "commissionBps": {
+                    "type": "integer",
+                    "minimum": 1500,
+                    "maximum": 3500
                   }
                 },
                 "required": [
@@ -2189,7 +2564,7 @@
                     "type": "integer",
                     "minimum": 1500,
                     "maximum": 3500,
-                    "description": "Commission in basis points (2250 = 22.5%)"
+                    "description": "Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default."
                   },
                   "durationMinutes": {
                     "type": "integer",
@@ -2292,7 +2667,6 @@
                   "shortDescription",
                   "heroImageUrl",
                   "basePrice",
-                  "commissionBps",
                   "durationMinutes",
                   "includes",
                   "faq",
@@ -2413,7 +2787,7 @@
                     "type": "integer",
                     "minimum": 1500,
                     "maximum": 3500,
-                    "description": "Commission in basis points (2250 = 22.5%)"
+                    "description": "Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default."
                   },
                   "durationMinutes": {
                     "type": "integer",
@@ -2514,7 +2888,6 @@
                   "shortDescription",
                   "heroImageUrl",
                   "basePrice",
-                  "commissionBps",
                   "durationMinutes",
                   "includes",
                   "faq",
@@ -3236,6 +3609,607 @@
           },
           "409": {
             "description": "Invalid levy status"
+          }
+        }
+      }
+    },
+    "/v1/admin/catalogue/commission-config": {
+      "get": {
+        "operationId": "getAdminCommissionConfig",
+        "tags": [
+          "admin-catalogue"
+        ],
+        "summary": "Get global commission rate (basis points)",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current global commission bps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommissionConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putAdminCommissionConfig",
+        "tags": [
+          "admin-catalogue"
+        ],
+        "summary": "Update global commission rate (super-admin only)",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "defaultCommissionBps": {
+                    "type": "integer",
+                    "minimum": 1500,
+                    "maximum": 3500
+                  }
+                },
+                "required": [
+                  "defaultCommissionBps"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated commission config",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommissionConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (bps out of 1500–3500 range)"
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden (requires super-admin)"
+          }
+        }
+      }
+    },
+    "/v1/admin/finance/commission-receivables": {
+      "get": {
+        "operationId": "adminCommissionReceivablesDashboard",
+        "tags": [
+          "admin-finance"
+        ],
+        "summary": "All-technician commission outstanding dashboard",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-tech DUE summary + total outstanding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "technicians": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "technicianId": {
+                            "type": "string"
+                          },
+                          "technicianName": {
+                            "type": "string"
+                          },
+                          "dueCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "totalCommissionDue": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "oldestDueAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "technicianId",
+                          "technicianName",
+                          "dueCount",
+                          "totalCommissionDue"
+                        ]
+                      }
+                    },
+                    "totalOutstanding": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "technicians",
+                    "totalOutstanding"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/v1/admin/finance/commission-receivables/{technicianId}": {
+      "get": {
+        "operationId": "adminCommissionReceivablesPerTech",
+        "tags": [
+          "admin-finance"
+        ],
+        "summary": "DUE commission entries for a specific technician",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "technicianId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outstanding entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "technicianId": {
+                      "type": "string"
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "bookingId": {
+                            "type": "string"
+                          },
+                          "technicianId": {
+                            "type": "string"
+                          },
+                          "partitionKey": {
+                            "type": "string"
+                          },
+                          "serviceId": {
+                            "type": "string"
+                          },
+                          "categoryId": {
+                            "type": "string"
+                          },
+                          "bookingAmount": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "cashCollectedAmount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "commissionBps": {
+                            "type": "integer",
+                            "minimum": 1500,
+                            "maximum": 3500
+                          },
+                          "commissionDue": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "commissionResolvedFrom": {
+                            "type": "string",
+                            "enum": [
+                              "SERVICE",
+                              "CATEGORY",
+                              "GLOBAL"
+                            ]
+                          },
+                          "remittanceStatus": {
+                            "type": "string",
+                            "enum": [
+                              "DUE",
+                              "REMITTED",
+                              "WAIVED"
+                            ]
+                          },
+                          "remittedAmount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "remittedAt": {
+                            "type": "string"
+                          },
+                          "remittanceRef": {
+                            "type": "string"
+                          },
+                          "remittanceMethod": {
+                            "type": "string",
+                            "enum": [
+                              "UPI",
+                              "CASH_DEPOSIT",
+                              "ADJUSTMENT"
+                            ]
+                          },
+                          "markedByAdminId": {
+                            "type": "string"
+                          },
+                          "waivedReason": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "bookingId",
+                          "technicianId",
+                          "partitionKey",
+                          "serviceId",
+                          "categoryId",
+                          "bookingAmount",
+                          "commissionBps",
+                          "commissionDue",
+                          "commissionResolvedFrom",
+                          "remittanceStatus",
+                          "createdAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "technicianId",
+                    "entries"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/v1/admin/finance/commission-receivables/settle": {
+      "post": {
+        "operationId": "markCommissionReceived",
+        "tags": [
+          "admin-finance"
+        ],
+        "summary": "Mark commission as remitted (received) or waived",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "REMIT"
+                        ]
+                      },
+                      "bookingId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "technicianId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "remittedAmount": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "remittanceMethod": {
+                        "type": "string",
+                        "enum": [
+                          "UPI",
+                          "CASH_DEPOSIT",
+                          "ADJUSTMENT"
+                        ]
+                      },
+                      "remittanceRef": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "action",
+                      "bookingId",
+                      "technicianId",
+                      "remittedAmount",
+                      "remittanceMethod",
+                      "remittanceRef"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "WAIVE"
+                        ]
+                      },
+                      "bookingId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "technicianId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "waivedReason": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "action",
+                      "bookingId",
+                      "technicianId",
+                      "waivedReason"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated receivable entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "bookingId": {
+                      "type": "string"
+                    },
+                    "technicianId": {
+                      "type": "string"
+                    },
+                    "partitionKey": {
+                      "type": "string"
+                    },
+                    "serviceId": {
+                      "type": "string"
+                    },
+                    "categoryId": {
+                      "type": "string"
+                    },
+                    "bookingAmount": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "cashCollectedAmount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "commissionBps": {
+                      "type": "integer",
+                      "minimum": 1500,
+                      "maximum": 3500
+                    },
+                    "commissionDue": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "commissionResolvedFrom": {
+                      "type": "string",
+                      "enum": [
+                        "SERVICE",
+                        "CATEGORY",
+                        "GLOBAL"
+                      ]
+                    },
+                    "remittanceStatus": {
+                      "type": "string",
+                      "enum": [
+                        "DUE",
+                        "REMITTED",
+                        "WAIVED"
+                      ]
+                    },
+                    "remittedAmount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "remittedAt": {
+                      "type": "string"
+                    },
+                    "remittanceRef": {
+                      "type": "string"
+                    },
+                    "remittanceMethod": {
+                      "type": "string",
+                      "enum": [
+                        "UPI",
+                        "CASH_DEPOSIT",
+                        "ADJUSTMENT"
+                      ]
+                    },
+                    "markedByAdminId": {
+                      "type": "string"
+                    },
+                    "waivedReason": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "bookingId",
+                    "technicianId",
+                    "partitionKey",
+                    "serviceId",
+                    "categoryId",
+                    "bookingAmount",
+                    "commissionBps",
+                    "commissionDue",
+                    "commissionResolvedFrom",
+                    "remittanceStatus",
+                    "createdAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Receivable not found"
+          }
+        }
+      }
+    },
+    "/v1/technicians/me/commission-due": {
+      "get": {
+        "operationId": "techCommissionDue",
+        "tags": [
+          "technicians"
+        ],
+        "summary": "Technician's outstanding commission owed to the platform",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outstanding commission summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalOutstandingPaise": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "dueCount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "bookingId": {
+                            "type": "string"
+                          },
+                          "bookingAmount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "commissionDue": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "bookingId",
+                          "bookingAmount",
+                          "commissionDue",
+                          "createdAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "totalOutstandingPaise",
+                    "dueCount",
+                    "entries"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
           }
         }
       }

--- a/admin-web/src/api/generated/schema.d.ts
+++ b/admin-web/src/api/generated/schema.d.ts
@@ -406,6 +406,92 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/admin/catalogue/commission-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get global commission rate (basis points) */
+        get: operations["getAdminCommissionConfig"];
+        /** Update global commission rate (super-admin only) */
+        put: operations["putAdminCommissionConfig"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/finance/commission-receivables": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** All-technician commission outstanding dashboard */
+        get: operations["adminCommissionReceivablesDashboard"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/finance/commission-receivables/{technicianId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** DUE commission entries for a specific technician */
+        get: operations["adminCommissionReceivablesPerTech"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/admin/finance/commission-receivables/settle": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark commission as remitted (received) or waived */
+        post: operations["markCommissionReceived"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/technicians/me/commission-due": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Technician's outstanding commission owed to the platform */
+        get: operations["techCommissionDue"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/waitlist": {
         parameters: {
             query?: never;
@@ -642,6 +728,7 @@ export interface components {
             heroImageUrl: string;
             sortOrder: number;
             safetyTag?: boolean;
+            commissionBps?: number;
             isActive: boolean;
             updatedBy: string;
             /** Format: date-time */
@@ -659,8 +746,8 @@ export interface components {
             heroImageUrl: string;
             /** @description Price in paise (₹599 = 59900) */
             basePrice: number;
-            /** @description Commission in basis points (2250 = 22.5%) */
-            commissionBps: number;
+            /** @description Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default. */
+            commissionBps?: number;
             durationMinutes: number;
             includes: string[];
             faq: {
@@ -874,6 +961,91 @@ export interface components {
             transferId: string;
             /** @enum {string} */
             status: "TRANSFERRED";
+        };
+        CommissionConfigDoc: {
+            /** @enum {string} */
+            id: "commission-config";
+            defaultCommissionBps: number;
+            updatedBy: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        UpdateCommissionConfigBody: {
+            defaultCommissionBps: number;
+        };
+        CommissionConfigResponse: {
+            defaultCommissionBps: number;
+            updatedBy: string;
+            updatedAt: string;
+            isDefault?: boolean;
+        };
+        CommissionReceivableEntry: {
+            id: string;
+            bookingId: string;
+            technicianId: string;
+            partitionKey: string;
+            serviceId: string;
+            categoryId: string;
+            bookingAmount: number;
+            cashCollectedAmount?: number;
+            commissionBps: number;
+            commissionDue: number;
+            /** @enum {string} */
+            commissionResolvedFrom: "SERVICE" | "CATEGORY" | "GLOBAL";
+            /** @enum {string} */
+            remittanceStatus: "DUE" | "REMITTED" | "WAIVED";
+            remittedAmount?: number;
+            remittedAt?: string;
+            remittanceRef?: string;
+            /** @enum {string} */
+            remittanceMethod?: "UPI" | "CASH_DEPOSIT" | "ADJUSTMENT";
+            markedByAdminId?: string;
+            waivedReason?: string;
+            createdAt: string;
+            updatedAt?: string;
+        };
+        TechnicianOutstandingSummary: {
+            technicianId: string;
+            technicianName: string;
+            dueCount: number;
+            totalCommissionDue: number;
+            oldestDueAt?: string;
+        };
+        CommissionReceivablesDashboard: {
+            technicians: {
+                technicianId: string;
+                technicianName: string;
+                dueCount: number;
+                totalCommissionDue: number;
+                oldestDueAt?: string;
+            }[];
+            totalOutstanding: number;
+        };
+        MarkCommissionReceivedBody: {
+            /** @enum {string} */
+            action: "REMIT";
+            bookingId: string;
+            technicianId: string;
+            remittedAmount: number;
+            /** @enum {string} */
+            remittanceMethod: "UPI" | "CASH_DEPOSIT" | "ADJUSTMENT";
+            remittanceRef: string;
+        } | {
+            /** @enum {string} */
+            action: "WAIVE";
+            bookingId: string;
+            technicianId: string;
+            waivedReason: string;
+        };
+        TechnicianCommissionDue: {
+            totalOutstandingPaise: number;
+            dueCount: number;
+            entries: {
+                bookingId: string;
+                bookingAmount: number;
+                commissionDue: number;
+                createdAt: string;
+            }[];
         };
         WaitlistRequest: {
             /** @example +916000000001 */
@@ -1201,6 +1373,7 @@ export interface operations {
                     heroImageUrl: string;
                     sortOrder: number;
                     safetyTag?: boolean;
+                    commissionBps?: number;
                 };
             };
         };
@@ -1291,6 +1464,7 @@ export interface operations {
                     heroImageUrl: string;
                     sortOrder: number;
                     safetyTag?: boolean;
+                    commissionBps?: number;
                 };
             };
         };
@@ -1385,8 +1559,8 @@ export interface operations {
                     heroImageUrl: string;
                     /** @description Price in paise (₹599 = 59900) */
                     basePrice: number;
-                    /** @description Commission in basis points (2250 = 22.5%) */
-                    commissionBps: number;
+                    /** @description Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default. */
+                    commissionBps?: number;
                     durationMinutes: number;
                     includes: string[];
                     faq: {
@@ -1496,8 +1670,8 @@ export interface operations {
                     heroImageUrl: string;
                     /** @description Price in paise (₹599 = 59900) */
                     basePrice: number;
-                    /** @description Commission in basis points (2250 = 22.5%) */
-                    commissionBps: number;
+                    /** @description Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default. */
+                    commissionBps?: number;
                     durationMinutes: number;
                     includes: string[];
                     faq: {
@@ -2069,6 +2243,320 @@ export interface operations {
             };
             /** @description Invalid levy status */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getAdminCommissionConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current global commission bps */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommissionConfigResponse"];
+                };
+            };
+            /** @description Unauthenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    putAdminCommissionConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    defaultCommissionBps: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated commission config */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommissionConfigResponse"];
+                };
+            };
+            /** @description Validation error (bps out of 1500–3500 range) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden (requires super-admin) */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminCommissionReceivablesDashboard: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Per-tech DUE summary + total outstanding */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        technicians: {
+                            technicianId: string;
+                            technicianName: string;
+                            dueCount: number;
+                            totalCommissionDue: number;
+                            oldestDueAt?: string;
+                        }[];
+                        totalOutstanding: number;
+                    };
+                };
+            };
+            /** @description Unauthenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminCommissionReceivablesPerTech: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                technicianId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Outstanding entries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        technicianId: string;
+                        entries: {
+                            id: string;
+                            bookingId: string;
+                            technicianId: string;
+                            partitionKey: string;
+                            serviceId: string;
+                            categoryId: string;
+                            bookingAmount: number;
+                            cashCollectedAmount?: number;
+                            commissionBps: number;
+                            commissionDue: number;
+                            /** @enum {string} */
+                            commissionResolvedFrom: "SERVICE" | "CATEGORY" | "GLOBAL";
+                            /** @enum {string} */
+                            remittanceStatus: "DUE" | "REMITTED" | "WAIVED";
+                            remittedAmount?: number;
+                            remittedAt?: string;
+                            remittanceRef?: string;
+                            /** @enum {string} */
+                            remittanceMethod?: "UPI" | "CASH_DEPOSIT" | "ADJUSTMENT";
+                            markedByAdminId?: string;
+                            waivedReason?: string;
+                            createdAt: string;
+                            updatedAt?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Unauthenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    markCommissionReceived: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    action: "REMIT";
+                    bookingId: string;
+                    technicianId: string;
+                    remittedAmount: number;
+                    /** @enum {string} */
+                    remittanceMethod: "UPI" | "CASH_DEPOSIT" | "ADJUSTMENT";
+                    remittanceRef: string;
+                } | {
+                    /** @enum {string} */
+                    action: "WAIVE";
+                    bookingId: string;
+                    technicianId: string;
+                    waivedReason: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated receivable entry */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        bookingId: string;
+                        technicianId: string;
+                        partitionKey: string;
+                        serviceId: string;
+                        categoryId: string;
+                        bookingAmount: number;
+                        cashCollectedAmount?: number;
+                        commissionBps: number;
+                        commissionDue: number;
+                        /** @enum {string} */
+                        commissionResolvedFrom: "SERVICE" | "CATEGORY" | "GLOBAL";
+                        /** @enum {string} */
+                        remittanceStatus: "DUE" | "REMITTED" | "WAIVED";
+                        remittedAmount?: number;
+                        remittedAt?: string;
+                        remittanceRef?: string;
+                        /** @enum {string} */
+                        remittanceMethod?: "UPI" | "CASH_DEPOSIT" | "ADJUSTMENT";
+                        markedByAdminId?: string;
+                        waivedReason?: string;
+                        createdAt: string;
+                        updatedAt?: string;
+                    };
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Receivable not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    techCommissionDue: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Outstanding commission summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        totalOutstandingPaise: number;
+                        dueCount: number;
+                        entries: {
+                            bookingId: string;
+                            bookingAmount: number;
+                            commissionDue: number;
+                            createdAt: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Unauthenticated */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/api/.semgrep.yml
+++ b/api/.semgrep.yml
@@ -177,6 +177,32 @@ rules:
     languages: [typescript]
     severity: ERROR
 
+  # E21-S01 — Cash-pilot settlement direction guard.
+  #
+  # The platform is cash-only in the pilot. Technicians collect cash directly;
+  # the platform never holds the money. Adding a new RazorpayRouteService()
+  # instantiation to the booking-completed settlement trigger without a RAZORPAY
+  # paymentMethod guard would silently try to transfer money for every completed
+  # cash booking — the exact bug this story fixes.
+  #
+  # Existing guarded instantiation is exempt via `// nosemgrep: cash-razorpay-guard`.
+  # Any NEW unguarded instantiation in the trigger file will fail CI.
+  #
+  # References: E21-S01, docs/stories/E21-S01-cash-commission-api.md
+  - id: cash-razorpay-guard
+    pattern: new RazorpayRouteService()
+    paths:
+      include:
+        - "api/src/functions/trigger-booking-completed.ts"
+    message: |
+      New RazorpayRouteService instantiation in the booking-completed settlement trigger.
+      Ensure this is inside a `paymentMethod === 'RAZORPAY' && hasRazorpayCredentials()` guard.
+      Cash bookings must NOT trigger Razorpay transfers — the tech already holds the cash.
+      If this instantiation is correctly guarded, add `// nosemgrep: cash-razorpay-guard`.
+      See: E21-S01, docs/stories/E21-S01-cash-commission-api.md
+    languages: [typescript]
+    severity: ERROR
+
   # E19-S03 — Cross-partition query tenant-filter guard (REMOVED 2026-05-18).
   #
   # The original WARNING-severity rule fired on all 3 existing cross-partition

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -530,6 +530,11 @@
           "safetyTag": {
             "type": "boolean"
           },
+          "commissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          },
           "isActive": {
             "type": "boolean"
           },
@@ -594,7 +599,7 @@
             "type": "integer",
             "minimum": 1500,
             "maximum": 3500,
-            "description": "Commission in basis points (2250 = 22.5%)"
+            "description": "Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default."
           },
           "durationMinutes": {
             "type": "integer",
@@ -712,7 +717,6 @@
           "shortDescription",
           "heroImageUrl",
           "basePrice",
-          "commissionBps",
           "durationMinutes",
           "includes",
           "faq",
@@ -1477,6 +1481,367 @@
           "status"
         ]
       },
+      "CommissionConfigDoc": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "commission-config"
+            ]
+          },
+          "defaultCommissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          },
+          "updatedBy": {
+            "type": "string",
+            "minLength": 1
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "defaultCommissionBps",
+          "updatedBy",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      },
+      "UpdateCommissionConfigBody": {
+        "type": "object",
+        "properties": {
+          "defaultCommissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          }
+        },
+        "required": [
+          "defaultCommissionBps"
+        ],
+        "additionalProperties": false
+      },
+      "CommissionConfigResponse": {
+        "type": "object",
+        "properties": {
+          "defaultCommissionBps": {
+            "type": "integer"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "defaultCommissionBps",
+          "updatedBy",
+          "updatedAt"
+        ]
+      },
+      "CommissionReceivableEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "bookingId": {
+            "type": "string"
+          },
+          "technicianId": {
+            "type": "string"
+          },
+          "partitionKey": {
+            "type": "string"
+          },
+          "serviceId": {
+            "type": "string"
+          },
+          "categoryId": {
+            "type": "string"
+          },
+          "bookingAmount": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "cashCollectedAmount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "commissionBps": {
+            "type": "integer",
+            "minimum": 1500,
+            "maximum": 3500
+          },
+          "commissionDue": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "commissionResolvedFrom": {
+            "type": "string",
+            "enum": [
+              "SERVICE",
+              "CATEGORY",
+              "GLOBAL"
+            ]
+          },
+          "remittanceStatus": {
+            "type": "string",
+            "enum": [
+              "DUE",
+              "REMITTED",
+              "WAIVED"
+            ]
+          },
+          "remittedAmount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "remittedAt": {
+            "type": "string"
+          },
+          "remittanceRef": {
+            "type": "string"
+          },
+          "remittanceMethod": {
+            "type": "string",
+            "enum": [
+              "UPI",
+              "CASH_DEPOSIT",
+              "ADJUSTMENT"
+            ]
+          },
+          "markedByAdminId": {
+            "type": "string"
+          },
+          "waivedReason": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "bookingId",
+          "technicianId",
+          "partitionKey",
+          "serviceId",
+          "categoryId",
+          "bookingAmount",
+          "commissionBps",
+          "commissionDue",
+          "commissionResolvedFrom",
+          "remittanceStatus",
+          "createdAt"
+        ]
+      },
+      "TechnicianOutstandingSummary": {
+        "type": "object",
+        "properties": {
+          "technicianId": {
+            "type": "string"
+          },
+          "technicianName": {
+            "type": "string"
+          },
+          "dueCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "totalCommissionDue": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "oldestDueAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "technicianId",
+          "technicianName",
+          "dueCount",
+          "totalCommissionDue"
+        ]
+      },
+      "CommissionReceivablesDashboard": {
+        "type": "object",
+        "properties": {
+          "technicians": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "technicianId": {
+                  "type": "string"
+                },
+                "technicianName": {
+                  "type": "string"
+                },
+                "dueCount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "totalCommissionDue": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "oldestDueAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "technicianId",
+                "technicianName",
+                "dueCount",
+                "totalCommissionDue"
+              ]
+            }
+          },
+          "totalOutstanding": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "technicians",
+          "totalOutstanding"
+        ]
+      },
+      "MarkCommissionReceivedBody": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "REMIT"
+                ]
+              },
+              "bookingId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "technicianId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "remittedAmount": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "remittanceMethod": {
+                "type": "string",
+                "enum": [
+                  "UPI",
+                  "CASH_DEPOSIT",
+                  "ADJUSTMENT"
+                ]
+              },
+              "remittanceRef": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "action",
+              "bookingId",
+              "technicianId",
+              "remittedAmount",
+              "remittanceMethod",
+              "remittanceRef"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "WAIVE"
+                ]
+              },
+              "bookingId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "technicianId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "waivedReason": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "action",
+              "bookingId",
+              "technicianId",
+              "waivedReason"
+            ]
+          }
+        ]
+      },
+      "TechnicianCommissionDue": {
+        "type": "object",
+        "properties": {
+          "totalOutstandingPaise": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "dueCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "bookingId": {
+                  "type": "string"
+                },
+                "bookingAmount": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "commissionDue": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "createdAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "bookingId",
+                "bookingAmount",
+                "commissionDue",
+                "createdAt"
+              ]
+            }
+          }
+        },
+        "required": [
+          "totalOutstandingPaise",
+          "dueCount",
+          "entries"
+        ]
+      },
       "WaitlistRequest": {
         "type": "object",
         "properties": {
@@ -1925,6 +2290,11 @@
                   },
                   "safetyTag": {
                     "type": "boolean"
+                  },
+                  "commissionBps": {
+                    "type": "integer",
+                    "minimum": 1500,
+                    "maximum": 3500
                   }
                 },
                 "required": [
@@ -2040,6 +2410,11 @@
                   },
                   "safetyTag": {
                     "type": "boolean"
+                  },
+                  "commissionBps": {
+                    "type": "integer",
+                    "minimum": 1500,
+                    "maximum": 3500
                   }
                 },
                 "required": [
@@ -2189,7 +2564,7 @@
                     "type": "integer",
                     "minimum": 1500,
                     "maximum": 3500,
-                    "description": "Commission in basis points (2250 = 22.5%)"
+                    "description": "Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default."
                   },
                   "durationMinutes": {
                     "type": "integer",
@@ -2292,7 +2667,6 @@
                   "shortDescription",
                   "heroImageUrl",
                   "basePrice",
-                  "commissionBps",
                   "durationMinutes",
                   "includes",
                   "faq",
@@ -2413,7 +2787,7 @@
                     "type": "integer",
                     "minimum": 1500,
                     "maximum": 3500,
-                    "description": "Commission in basis points (2250 = 22.5%)"
+                    "description": "Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default."
                   },
                   "durationMinutes": {
                     "type": "integer",
@@ -2514,7 +2888,6 @@
                   "shortDescription",
                   "heroImageUrl",
                   "basePrice",
-                  "commissionBps",
                   "durationMinutes",
                   "includes",
                   "faq",
@@ -3236,6 +3609,607 @@
           },
           "409": {
             "description": "Invalid levy status"
+          }
+        }
+      }
+    },
+    "/v1/admin/catalogue/commission-config": {
+      "get": {
+        "operationId": "getAdminCommissionConfig",
+        "tags": [
+          "admin-catalogue"
+        ],
+        "summary": "Get global commission rate (basis points)",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current global commission bps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommissionConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putAdminCommissionConfig",
+        "tags": [
+          "admin-catalogue"
+        ],
+        "summary": "Update global commission rate (super-admin only)",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "defaultCommissionBps": {
+                    "type": "integer",
+                    "minimum": 1500,
+                    "maximum": 3500
+                  }
+                },
+                "required": [
+                  "defaultCommissionBps"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated commission config",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommissionConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error (bps out of 1500–3500 range)"
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden (requires super-admin)"
+          }
+        }
+      }
+    },
+    "/v1/admin/finance/commission-receivables": {
+      "get": {
+        "operationId": "adminCommissionReceivablesDashboard",
+        "tags": [
+          "admin-finance"
+        ],
+        "summary": "All-technician commission outstanding dashboard",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Per-tech DUE summary + total outstanding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "technicians": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "technicianId": {
+                            "type": "string"
+                          },
+                          "technicianName": {
+                            "type": "string"
+                          },
+                          "dueCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "totalCommissionDue": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "oldestDueAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "technicianId",
+                          "technicianName",
+                          "dueCount",
+                          "totalCommissionDue"
+                        ]
+                      }
+                    },
+                    "totalOutstanding": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "technicians",
+                    "totalOutstanding"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/v1/admin/finance/commission-receivables/{technicianId}": {
+      "get": {
+        "operationId": "adminCommissionReceivablesPerTech",
+        "tags": [
+          "admin-finance"
+        ],
+        "summary": "DUE commission entries for a specific technician",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "technicianId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outstanding entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "technicianId": {
+                      "type": "string"
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "bookingId": {
+                            "type": "string"
+                          },
+                          "technicianId": {
+                            "type": "string"
+                          },
+                          "partitionKey": {
+                            "type": "string"
+                          },
+                          "serviceId": {
+                            "type": "string"
+                          },
+                          "categoryId": {
+                            "type": "string"
+                          },
+                          "bookingAmount": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0
+                          },
+                          "cashCollectedAmount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "commissionBps": {
+                            "type": "integer",
+                            "minimum": 1500,
+                            "maximum": 3500
+                          },
+                          "commissionDue": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "commissionResolvedFrom": {
+                            "type": "string",
+                            "enum": [
+                              "SERVICE",
+                              "CATEGORY",
+                              "GLOBAL"
+                            ]
+                          },
+                          "remittanceStatus": {
+                            "type": "string",
+                            "enum": [
+                              "DUE",
+                              "REMITTED",
+                              "WAIVED"
+                            ]
+                          },
+                          "remittedAmount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "remittedAt": {
+                            "type": "string"
+                          },
+                          "remittanceRef": {
+                            "type": "string"
+                          },
+                          "remittanceMethod": {
+                            "type": "string",
+                            "enum": [
+                              "UPI",
+                              "CASH_DEPOSIT",
+                              "ADJUSTMENT"
+                            ]
+                          },
+                          "markedByAdminId": {
+                            "type": "string"
+                          },
+                          "waivedReason": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "bookingId",
+                          "technicianId",
+                          "partitionKey",
+                          "serviceId",
+                          "categoryId",
+                          "bookingAmount",
+                          "commissionBps",
+                          "commissionDue",
+                          "commissionResolvedFrom",
+                          "remittanceStatus",
+                          "createdAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "technicianId",
+                    "entries"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/v1/admin/finance/commission-receivables/settle": {
+      "post": {
+        "operationId": "markCommissionReceived",
+        "tags": [
+          "admin-finance"
+        ],
+        "summary": "Mark commission as remitted (received) or waived",
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "REMIT"
+                        ]
+                      },
+                      "bookingId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "technicianId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "remittedAmount": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      },
+                      "remittanceMethod": {
+                        "type": "string",
+                        "enum": [
+                          "UPI",
+                          "CASH_DEPOSIT",
+                          "ADJUSTMENT"
+                        ]
+                      },
+                      "remittanceRef": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "action",
+                      "bookingId",
+                      "technicianId",
+                      "remittedAmount",
+                      "remittanceMethod",
+                      "remittanceRef"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "action": {
+                        "type": "string",
+                        "enum": [
+                          "WAIVE"
+                        ]
+                      },
+                      "bookingId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "technicianId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "waivedReason": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "action",
+                      "bookingId",
+                      "technicianId",
+                      "waivedReason"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated receivable entry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "bookingId": {
+                      "type": "string"
+                    },
+                    "technicianId": {
+                      "type": "string"
+                    },
+                    "partitionKey": {
+                      "type": "string"
+                    },
+                    "serviceId": {
+                      "type": "string"
+                    },
+                    "categoryId": {
+                      "type": "string"
+                    },
+                    "bookingAmount": {
+                      "type": "integer",
+                      "exclusiveMinimum": 0
+                    },
+                    "cashCollectedAmount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "commissionBps": {
+                      "type": "integer",
+                      "minimum": 1500,
+                      "maximum": 3500
+                    },
+                    "commissionDue": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "commissionResolvedFrom": {
+                      "type": "string",
+                      "enum": [
+                        "SERVICE",
+                        "CATEGORY",
+                        "GLOBAL"
+                      ]
+                    },
+                    "remittanceStatus": {
+                      "type": "string",
+                      "enum": [
+                        "DUE",
+                        "REMITTED",
+                        "WAIVED"
+                      ]
+                    },
+                    "remittedAmount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "remittedAt": {
+                      "type": "string"
+                    },
+                    "remittanceRef": {
+                      "type": "string"
+                    },
+                    "remittanceMethod": {
+                      "type": "string",
+                      "enum": [
+                        "UPI",
+                        "CASH_DEPOSIT",
+                        "ADJUSTMENT"
+                      ]
+                    },
+                    "markedByAdminId": {
+                      "type": "string"
+                    },
+                    "waivedReason": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "bookingId",
+                    "technicianId",
+                    "partitionKey",
+                    "serviceId",
+                    "categoryId",
+                    "bookingAmount",
+                    "commissionBps",
+                    "commissionDue",
+                    "commissionResolvedFrom",
+                    "remittanceStatus",
+                    "createdAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "401": {
+            "description": "Unauthenticated"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Receivable not found"
+          }
+        }
+      }
+    },
+    "/v1/technicians/me/commission-due": {
+      "get": {
+        "operationId": "techCommissionDue",
+        "tags": [
+          "technicians"
+        ],
+        "summary": "Technician's outstanding commission owed to the platform",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outstanding commission summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalOutstandingPaise": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "dueCount": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "bookingId": {
+                            "type": "string"
+                          },
+                          "bookingAmount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "commissionDue": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "bookingId",
+                          "bookingAmount",
+                          "commissionDue",
+                          "createdAt"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "totalOutstandingPaise",
+                    "dueCount",
+                    "entries"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated"
           }
         }
       }

--- a/api/scripts/setup-cosmos.ts
+++ b/api/scripts/setup-cosmos.ts
@@ -185,6 +185,35 @@ async function main() {
     defaultTtl: 604800,
   });
   console.log("Container 'sos_incident_keys' ready.");
+
+  // E21-S01: Commission receivables — cash-pilot commission owed by technicians to platform.
+  // One doc per completed cash booking (id = bookingId for idempotency).
+  // Partitioned by /technicianId so per-tech outstanding reads are single-partition.
+  // MUST be provisioned before the first COMPLETED booking fires the settlement trigger.
+  await database.containers.createIfNotExists({
+    id: 'commission_receivables',
+    partitionKey: { paths: ['/technicianId'] },
+  });
+  console.log("Container 'commission_receivables' ready.");
+
+  // E21-S01: Seed the global commission-config doc in the system container (if not already set).
+  // defaultCommissionBps = 2200 matches the historical hardcoded default so P&L numbers don't jump.
+  const systemContainer = database.container('system');
+  try {
+    await systemContainer.items.create({
+      id: 'commission-config',
+      defaultCommissionBps: 2200,
+      updatedBy: 'system',
+      updatedAt: new Date().toISOString(),
+    });
+    console.log("Seeded 'commission-config' doc in system container (defaultCommissionBps=2200).");
+  } catch (err: unknown) {
+    if ((err as { code?: number }).code === 409) {
+      console.log("'commission-config' doc already exists in system container — skipping seed.");
+    } else {
+      throw err;
+    }
+  }
 }
 
 main().catch((e) => { console.error(e); process.exit(1); });

--- a/api/src/cosmos/booking-repository.ts
+++ b/api/src/cosmos/booking-repository.ts
@@ -255,6 +255,34 @@ export const bookingRepo = {
     return resource ?? null;
   },
 
+  async markCashCollected(bookingId: string, amount?: number): Promise<BookingDoc | null> {
+    const { resource: existing, etag } = await getBookingsContainer().item(bookingId, bookingId).read<BookingDoc>();
+    if (!existing) return null;
+    if (existing.cashCollectionStatus === 'COLLECTED') return existing; // idempotent
+    const updated: BookingDoc = {
+      ...existing,
+      cashCollectionStatus: 'COLLECTED',
+      cashCollectedAt: new Date().toISOString(),
+      ...(amount !== undefined ? { cashCollectedAmount: amount } : {}),
+    };
+    const useEtag = process.env.BOOKINGS_ETAG_GUARDS === 'on';
+    if (useEtag) {
+      try {
+        const { resource } = await getBookingsContainer()
+          .item(bookingId, bookingId)
+          .replace<BookingDoc>(updated, { accessCondition: { type: 'IfMatch', condition: etag ?? '' } });
+        return resource ?? null;
+      } catch (e: unknown) {
+        if (typeof e === 'object' && e !== null && 'code' in e && (e as { code: number }).code === 412) {
+          return null; // lost ETag race — idempotent by design
+        }
+        throw e;
+      }
+    }
+    const { resource } = await getBookingsContainer().item(bookingId, bookingId).replace<BookingDoc>(updated);
+    return resource!;
+  },
+
   async markSosActivated(id: string): Promise<BookingDoc | null> {
     const { resource: existing, etag } = await getBookingsContainer().item(id, id).read<BookingDoc>();
     if (!existing) return null;

--- a/api/src/cosmos/client.ts
+++ b/api/src/cosmos/client.ts
@@ -96,6 +96,15 @@ export function getSystemContainer(): Container {
   return getCosmosClient().database(DB_NAME).container('system');
 }
 
+/**
+ * E21-S01: Commission owed by technicians to the platform (cash pilot).
+ * One doc per completed cash booking, partitioned by /technicianId so per-tech
+ * outstanding reads are single-partition. id === bookingId for idempotent settlement.
+ */
+export function getCommissionReceivablesContainer(): Container {
+  return getCosmosClient().database(DB_NAME).container('commission_receivables');
+}
+
 export function getPendingActionsContainer(): Container {
   return getCosmosClient().database(DB_NAME).container('pending_actions');
 }

--- a/api/src/cosmos/commission-config-repository.ts
+++ b/api/src/cosmos/commission-config-repository.ts
@@ -1,0 +1,28 @@
+import { getSystemContainer } from './client.js';
+import {
+  COMMISSION_CONFIG_DOC_ID,
+  type CommissionConfigDoc,
+} from '../schemas/commission-config.js';
+
+export const commissionConfigRepo = {
+  async getCommissionConfig(): Promise<CommissionConfigDoc | null> {
+    const { resource } = await getSystemContainer()
+      .item(COMMISSION_CONFIG_DOC_ID, COMMISSION_CONFIG_DOC_ID)
+      .read<CommissionConfigDoc>();
+    return resource ?? null;
+  },
+
+  async upsertCommissionConfig(
+    defaultCommissionBps: number,
+    updatedBy: string,
+  ): Promise<CommissionConfigDoc> {
+    const doc: CommissionConfigDoc = {
+      id: COMMISSION_CONFIG_DOC_ID,
+      defaultCommissionBps,
+      updatedBy,
+      updatedAt: new Date().toISOString(),
+    };
+    await getSystemContainer().items.upsert<CommissionConfigDoc>(doc);
+    return doc;
+  },
+};

--- a/api/src/cosmos/commission-receivable-repository.ts
+++ b/api/src/cosmos/commission-receivable-repository.ts
@@ -1,0 +1,153 @@
+import { getCommissionReceivablesContainer } from './client.js';
+import type {
+  CommissionReceivableEntry,
+  CommissionReceivableCreateInput,
+  RemittanceMethod,
+} from '../schemas/commission-receivable.js';
+
+export const commissionReceivableRepo = {
+  async getByBookingId(
+    bookingId: string,
+    technicianId: string,
+  ): Promise<CommissionReceivableEntry | null> {
+    const { resource } = await getCommissionReceivablesContainer()
+      .item(bookingId, technicianId)
+      .read<CommissionReceivableEntry>();
+    return resource ?? null;
+  },
+
+  async createDueEntry(input: CommissionReceivableCreateInput): Promise<boolean> {
+    try {
+      await getCommissionReceivablesContainer().items.create<CommissionReceivableEntry>({
+        id: input.bookingId,
+        bookingId: input.bookingId,
+        technicianId: input.technicianId,
+        partitionKey: input.technicianId,
+        serviceId: input.serviceId,
+        categoryId: input.categoryId,
+        bookingAmount: input.bookingAmount,
+        commissionBps: input.commissionBps,
+        commissionDue: input.commissionDue,
+        commissionResolvedFrom: input.commissionResolvedFrom,
+        remittanceStatus: 'DUE',
+        createdAt: new Date().toISOString(),
+        ...(input.cashCollectedAmount !== undefined
+          ? { cashCollectedAmount: input.cashCollectedAmount }
+          : {}),
+      });
+      return true;
+    } catch (err: unknown) {
+      // 409 Conflict = concurrent invocation already created this entry
+      if ((err as { code?: number }).code === 409) return false;
+      throw err;
+    }
+  },
+
+  async markRemitted(
+    bookingId: string,
+    technicianId: string,
+    opts: {
+      remittedAmount: number;
+      remittanceMethod: RemittanceMethod;
+      remittanceRef: string;
+      markedByAdminId: string;
+    },
+  ): Promise<CommissionReceivableEntry | null> {
+    const { resource } = await getCommissionReceivablesContainer()
+      .item(bookingId, technicianId)
+      .read<CommissionReceivableEntry>();
+    if (!resource) return null;
+    // Idempotent: if already settled, return unchanged
+    if (resource.remittanceStatus !== 'DUE') return resource;
+    const updated: CommissionReceivableEntry = {
+      ...resource,
+      remittanceStatus: 'REMITTED',
+      remittedAmount: opts.remittedAmount,
+      remittanceMethod: opts.remittanceMethod,
+      remittanceRef: opts.remittanceRef,
+      markedByAdminId: opts.markedByAdminId,
+      remittedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await getCommissionReceivablesContainer()
+      .item(bookingId, technicianId)
+      .replace<CommissionReceivableEntry>(updated);
+    return updated;
+  },
+
+  async markWaived(
+    bookingId: string,
+    technicianId: string,
+    opts: { waivedReason: string; markedByAdminId: string },
+  ): Promise<CommissionReceivableEntry | null> {
+    const { resource } = await getCommissionReceivablesContainer()
+      .item(bookingId, technicianId)
+      .read<CommissionReceivableEntry>();
+    if (!resource) return null;
+    // Idempotent: if already settled, return unchanged
+    if (resource.remittanceStatus !== 'DUE') return resource;
+    const updated: CommissionReceivableEntry = {
+      ...resource,
+      remittanceStatus: 'WAIVED',
+      waivedReason: opts.waivedReason,
+      markedByAdminId: opts.markedByAdminId,
+      updatedAt: new Date().toISOString(),
+    };
+    await getCommissionReceivablesContainer()
+      .item(bookingId, technicianId)
+      .replace<CommissionReceivableEntry>(updated);
+    return updated;
+  },
+
+  async getOutstandingByTechnician(technicianId: string): Promise<CommissionReceivableEntry[]> {
+    const { resources } = await getCommissionReceivablesContainer()
+      .items.query<CommissionReceivableEntry>(
+        { query: `SELECT * FROM c WHERE c.remittanceStatus = 'DUE'` },
+        { partitionKey: technicianId },
+      )
+      .fetchAll();
+    return resources;
+  },
+
+  async getAllTechnicianOutstandingSummaries(): Promise<
+    Array<{
+      technicianId: string;
+      dueCount: number;
+      totalCommissionDue: number;
+      oldestDueAt: string;
+    }>
+  > {
+    const { resources } = await getCommissionReceivablesContainer()
+      .items.query<CommissionReceivableEntry>({
+        query: `SELECT * FROM c WHERE c.remittanceStatus = 'DUE'`,
+      })
+      .fetchAll();
+
+    const byTech = new Map<
+      string,
+      { dueCount: number; totalCommissionDue: number; oldestDueAt: string }
+    >();
+
+    for (const entry of resources) {
+      const existing = byTech.get(entry.technicianId);
+      if (!existing) {
+        byTech.set(entry.technicianId, {
+          dueCount: 1,
+          totalCommissionDue: entry.commissionDue,
+          oldestDueAt: entry.createdAt,
+        });
+      } else {
+        existing.dueCount += 1;
+        existing.totalCommissionDue += entry.commissionDue;
+        if (entry.createdAt < existing.oldestDueAt) {
+          existing.oldestDueAt = entry.createdAt;
+        }
+      }
+    }
+
+    return Array.from(byTech.entries()).map(([technicianId, summary]) => ({
+      technicianId,
+      ...summary,
+    }));
+  },
+};

--- a/api/src/cosmos/commission-receivable-repository.ts
+++ b/api/src/cosmos/commission-receivable-repository.ts
@@ -52,13 +52,20 @@ export const commissionReceivableRepo = {
       remittanceRef: string;
       markedByAdminId: string;
     },
-  ): Promise<CommissionReceivableEntry | null> {
+  ): Promise<{ entry: CommissionReceivableEntry; wasApplied: boolean } | null> {
     const { resource } = await getCommissionReceivablesContainer()
       .item(bookingId, technicianId)
       .read<CommissionReceivableEntry>();
     if (!resource) return null;
-    // Idempotent: if already settled, return unchanged
-    if (resource.remittanceStatus !== 'DUE') return resource;
+    if (resource.remittanceStatus !== 'DUE') return { entry: resource, wasApplied: false };
+    // Reject partial payment — remitting less than due silently drops the remaining balance
+    if (opts.remittedAmount < resource.commissionDue) {
+      const err = Object.assign(new Error('AMOUNT_BELOW_DUE'), {
+        code: 'AMOUNT_BELOW_DUE',
+        commissionDue: resource.commissionDue,
+      });
+      throw err;
+    }
     const updated: CommissionReceivableEntry = {
       ...resource,
       remittanceStatus: 'REMITTED',
@@ -72,20 +79,19 @@ export const commissionReceivableRepo = {
     await getCommissionReceivablesContainer()
       .item(bookingId, technicianId)
       .replace<CommissionReceivableEntry>(updated);
-    return updated;
+    return { entry: updated, wasApplied: true };
   },
 
   async markWaived(
     bookingId: string,
     technicianId: string,
     opts: { waivedReason: string; markedByAdminId: string },
-  ): Promise<CommissionReceivableEntry | null> {
+  ): Promise<{ entry: CommissionReceivableEntry; wasApplied: boolean } | null> {
     const { resource } = await getCommissionReceivablesContainer()
       .item(bookingId, technicianId)
       .read<CommissionReceivableEntry>();
     if (!resource) return null;
-    // Idempotent: if already settled, return unchanged
-    if (resource.remittanceStatus !== 'DUE') return resource;
+    if (resource.remittanceStatus !== 'DUE') return { entry: resource, wasApplied: false };
     const updated: CommissionReceivableEntry = {
       ...resource,
       remittanceStatus: 'WAIVED',
@@ -96,7 +102,7 @@ export const commissionReceivableRepo = {
     await getCommissionReceivablesContainer()
       .item(bookingId, technicianId)
       .replace<CommissionReceivableEntry>(updated);
-    return updated;
+    return { entry: updated, wasApplied: true };
   },
 
   async getOutstandingByTechnician(technicianId: string): Promise<CommissionReceivableEntry[]> {

--- a/api/src/functions/active-job.ts
+++ b/api/src/functions/active-job.ts
@@ -31,6 +31,10 @@ const TransitionBodySchema = z.object({
     isMock: z.boolean(),
     gpsAccuracyM: z.number(),
   }).optional(),
+  /** E21-S01: Set true on COMPLETED to confirm the technician collected cash from the customer. */
+  cashCollected: z.boolean().optional(),
+  /** E21-S01: Cash amount in paise the technician collected. Only honoured when cashCollected=true. */
+  collectedAmount: z.number().int().nonnegative().optional(),
 });
 
 export const getActiveJobHandler: HttpHandler = async (req, _ctx: InvocationContext) => {
@@ -106,9 +110,23 @@ export const transitionStatusHandler: HttpHandler = async (req, ctx: InvocationC
     });
   }
 
+  const now = new Date().toISOString();
   const updated = await updateBookingFields(bookingId, {
     status: body.targetStatus,
-    ...(body.targetStatus === 'COMPLETED' ? { completedAt: new Date().toISOString() } : {}),
+    ...(body.targetStatus === 'COMPLETED'
+      ? {
+          completedAt: now,
+          ...(body.cashCollected === true
+            ? {
+                cashCollectionStatus: 'COLLECTED' as const,
+                cashCollectedAt: now,
+                ...(body.collectedAmount !== undefined
+                  ? { cashCollectedAmount: body.collectedAmount }
+                  : {}),
+              }
+            : {}),
+        }
+      : {}),
   });
   if (!updated) return { status: 500, jsonBody: { code: 'UPDATE_FAILED' } };
 

--- a/api/src/functions/admin/catalogue/commission-config.ts
+++ b/api/src/functions/admin/catalogue/commission-config.ts
@@ -1,0 +1,90 @@
+import '../../../bootstrap.js';
+import { app } from '@azure/functions';
+import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { requireAdmin, type AdminHttpHandler } from '../../../middleware/requireAdmin.js';
+import type { AdminContext } from '../../../types/admin.js';
+import { commissionConfigRepo } from '../../../cosmos/commission-config-repository.js';
+import { UpdateCommissionConfigBodySchema } from '../../../schemas/commission-config.js';
+import { _resetCommissionConfigCacheForTest } from '../../../services/commission-config.service.js';
+
+export const getCommissionConfigHandler: AdminHttpHandler = async (
+  _req: HttpRequest,
+  _ctx: InvocationContext,
+  _admin: AdminContext,
+): Promise<HttpResponseInit> => {
+  try {
+    const doc = await commissionConfigRepo.getCommissionConfig();
+    if (!doc) {
+      return {
+        status: 200,
+        jsonBody: {
+          defaultCommissionBps: 2200,
+          updatedBy: 'system',
+          updatedAt: new Date().toISOString(),
+          isDefault: true,
+        },
+      };
+    }
+    return {
+      status: 200,
+      jsonBody: {
+        defaultCommissionBps: doc.defaultCommissionBps,
+        updatedBy: doc.updatedBy,
+        updatedAt: doc.updatedAt,
+      },
+    };
+  } catch {
+    return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
+  }
+};
+
+export const putCommissionConfigHandler: AdminHttpHandler = async (
+  req: HttpRequest,
+  _ctx: InvocationContext,
+  admin: AdminContext,
+): Promise<HttpResponseInit> => {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return { status: 400, jsonBody: { code: 'PARSE_ERROR' } };
+  }
+
+  const parsed = UpdateCommissionConfigBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return { status: 400, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+  }
+
+  try {
+    const doc = await commissionConfigRepo.upsertCommissionConfig(
+      parsed.data.defaultCommissionBps,
+      admin.adminId,
+    );
+    // Bust the in-process cache so the next settlement immediately picks up the new rate
+    _resetCommissionConfigCacheForTest();
+    return {
+      status: 200,
+      jsonBody: {
+        defaultCommissionBps: doc.defaultCommissionBps,
+        updatedBy: doc.updatedBy,
+        updatedAt: doc.updatedAt,
+      },
+    };
+  } catch {
+    return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
+  }
+};
+
+app.http('getAdminCommissionConfig', {
+  methods: ['GET'],
+  route: 'v1/admin/catalogue/commission-config',
+  authLevel: 'anonymous',
+  handler: requireAdmin(['super-admin', 'finance'])(getCommissionConfigHandler),
+});
+
+app.http('putAdminCommissionConfig', {
+  methods: ['PUT'],
+  route: 'v1/admin/catalogue/commission-config',
+  authLevel: 'anonymous',
+  handler: requireAdmin(['super-admin'])(putCommissionConfigHandler),
+});

--- a/api/src/functions/admin/finance/commission-receivables.ts
+++ b/api/src/functions/admin/finance/commission-receivables.ts
@@ -58,12 +58,12 @@ app.http('adminCommissionReceivablesDashboard', {
   methods: ['GET'],
   route: 'v1/admin/finance/commission-receivables',
   authLevel: 'anonymous',
-  handler: requireAdmin(['super-admin', 'finance'])(adminCommissionReceivablesDashboardHandler),
+  handler: requireAdmin(['super-admin', 'finance', 'ops-manager'])(adminCommissionReceivablesDashboardHandler),
 });
 
 app.http('adminCommissionReceivablesPerTech', {
   methods: ['GET'],
   route: 'v1/admin/finance/commission-receivables/{technicianId}',
   authLevel: 'anonymous',
-  handler: requireAdmin(['super-admin', 'finance'])(adminCommissionReceivablesPerTechHandler),
+  handler: requireAdmin(['super-admin', 'finance', 'ops-manager'])(adminCommissionReceivablesPerTechHandler),
 });

--- a/api/src/functions/admin/finance/commission-receivables.ts
+++ b/api/src/functions/admin/finance/commission-receivables.ts
@@ -1,0 +1,69 @@
+import '../../../bootstrap.js';
+import { app } from '@azure/functions';
+import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { requireAdmin, type AdminHttpHandler } from '../../../middleware/requireAdmin.js';
+import type { AdminContext } from '../../../types/admin.js';
+import { commissionReceivableRepo } from '../../../cosmos/commission-receivable-repository.js';
+import { getTechniciansByIds } from '../../../cosmos/technician-repository.js';
+
+export const adminCommissionReceivablesDashboardHandler: AdminHttpHandler = async (
+  _req: HttpRequest,
+  _ctx: InvocationContext,
+  _admin: AdminContext,
+): Promise<HttpResponseInit> => {
+  try {
+    const summaries = await commissionReceivableRepo.getAllTechnicianOutstandingSummaries();
+    if (summaries.length === 0) {
+      return { status: 200, jsonBody: { technicians: [], totalOutstanding: 0 } };
+    }
+
+    const techIds = summaries.map((s) => s.technicianId);
+    const techProfiles = await getTechniciansByIds(techIds);
+    const nameByTechId = new Map(
+      techProfiles.map((t) => [t.technicianId || t.id, t.displayName || t.name || t.technicianId || t.id]),
+    );
+
+    const technicians = summaries.map((s) => ({
+      technicianId: s.technicianId,
+      technicianName: nameByTechId.get(s.technicianId) ?? s.technicianId,
+      dueCount: s.dueCount,
+      totalCommissionDue: s.totalCommissionDue,
+      oldestDueAt: s.oldestDueAt,
+    }));
+    const totalOutstanding = technicians.reduce((acc, t) => acc + t.totalCommissionDue, 0);
+
+    return { status: 200, jsonBody: { technicians, totalOutstanding } };
+  } catch {
+    return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
+  }
+};
+
+export const adminCommissionReceivablesPerTechHandler: AdminHttpHandler = async (
+  req: HttpRequest,
+  _ctx: InvocationContext,
+  _admin: AdminContext,
+): Promise<HttpResponseInit> => {
+  const technicianId = (req as unknown as { params: { technicianId: string } }).params.technicianId;
+  if (!technicianId) return { status: 400, jsonBody: { code: 'MISSING_TECHNICIAN_ID' } };
+
+  try {
+    const entries = await commissionReceivableRepo.getOutstandingByTechnician(technicianId);
+    return { status: 200, jsonBody: { technicianId, entries } };
+  } catch {
+    return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
+  }
+};
+
+app.http('adminCommissionReceivablesDashboard', {
+  methods: ['GET'],
+  route: 'v1/admin/finance/commission-receivables',
+  authLevel: 'anonymous',
+  handler: requireAdmin(['super-admin', 'finance'])(adminCommissionReceivablesDashboardHandler),
+});
+
+app.http('adminCommissionReceivablesPerTech', {
+  methods: ['GET'],
+  route: 'v1/admin/finance/commission-receivables/{technicianId}',
+  authLevel: 'anonymous',
+  handler: requireAdmin(['super-admin', 'finance'])(adminCommissionReceivablesPerTechHandler),
+});

--- a/api/src/functions/admin/finance/mark-commission-received.ts
+++ b/api/src/functions/admin/finance/mark-commission-received.ts
@@ -1,0 +1,86 @@
+import '../../../bootstrap.js';
+import { app } from '@azure/functions';
+import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { randomUUID } from 'node:crypto';
+import { requireAdmin, type AdminHttpHandler } from '../../../middleware/requireAdmin.js';
+import type { AdminContext } from '../../../types/admin.js';
+import { commissionReceivableRepo } from '../../../cosmos/commission-receivable-repository.js';
+import { appendAuditEntry } from '../../../cosmos/audit-log-repository.js';
+import { MarkCommissionReceivedBodySchema } from '../../../schemas/commission-receivable.js';
+
+export const markCommissionReceivedHandler: AdminHttpHandler = async (
+  req: HttpRequest,
+  _ctx: InvocationContext,
+  admin: AdminContext,
+): Promise<HttpResponseInit> => {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return { status: 400, jsonBody: { code: 'PARSE_ERROR' } };
+  }
+
+  const parsed = MarkCommissionReceivedBodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return { status: 400, jsonBody: { code: 'VALIDATION_ERROR', issues: parsed.error.issues } };
+  }
+
+  const body = parsed.data;
+  const { bookingId, technicianId } = body;
+
+  try {
+    let result;
+    if (body.action === 'REMIT') {
+      result = await commissionReceivableRepo.markRemitted(bookingId, technicianId, {
+        remittedAmount: body.remittedAmount,
+        remittanceMethod: body.remittanceMethod,
+        remittanceRef: body.remittanceRef,
+        markedByAdminId: admin.adminId,
+      });
+    } else {
+      result = await commissionReceivableRepo.markWaived(bookingId, technicianId, {
+        waivedReason: body.waivedReason,
+        markedByAdminId: admin.adminId,
+      });
+    }
+
+    if (!result) {
+      return { status: 404, jsonBody: { code: 'RECEIVABLE_NOT_FOUND' } };
+    }
+
+    const timestamp = new Date().toISOString();
+    await appendAuditEntry({
+      id: randomUUID(),
+      adminId: admin.adminId,
+      role: admin.role,
+      action: body.action === 'REMIT' ? 'COMMISSION_REMITTED' : 'COMMISSION_WAIVED',
+      resourceType: 'commission_receivable',
+      resourceId: bookingId,
+      payload: {
+        technicianId,
+        bookingId,
+        action: body.action,
+        ...(body.action === 'REMIT'
+          ? {
+              remittedAmount: body.remittedAmount,
+              remittanceMethod: body.remittanceMethod,
+              remittanceRef: body.remittanceRef,
+            }
+          : { waivedReason: body.waivedReason }),
+      },
+      timestamp,
+      partitionKey: timestamp.slice(0, 7),
+    }).catch(() => undefined);
+
+    return { status: 200, jsonBody: result };
+  } catch {
+    return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
+  }
+};
+
+app.http('markCommissionReceived', {
+  methods: ['POST'],
+  route: 'v1/admin/finance/commission-receivables/settle',
+  authLevel: 'anonymous',
+  handler: requireAdmin(['super-admin', 'finance'])(markCommissionReceivedHandler),
+});

--- a/api/src/functions/admin/finance/mark-commission-received.ts
+++ b/api/src/functions/admin/finance/mark-commission-received.ts
@@ -48,32 +48,39 @@ export const markCommissionReceivedHandler: AdminHttpHandler = async (
       return { status: 404, jsonBody: { code: 'RECEIVABLE_NOT_FOUND' } };
     }
 
-    const timestamp = new Date().toISOString();
-    await appendAuditEntry({
-      id: randomUUID(),
-      adminId: admin.adminId,
-      role: admin.role,
-      action: body.action === 'REMIT' ? 'COMMISSION_REMITTED' : 'COMMISSION_WAIVED',
-      resourceType: 'commission_receivable',
-      resourceId: bookingId,
-      payload: {
-        technicianId,
-        bookingId,
-        action: body.action,
-        ...(body.action === 'REMIT'
-          ? {
-              remittedAmount: body.remittedAmount,
-              remittanceMethod: body.remittanceMethod,
-              remittanceRef: body.remittanceRef,
-            }
-          : { waivedReason: body.waivedReason }),
-      },
-      timestamp,
-      partitionKey: timestamp.slice(0, 7),
-    }).catch(() => undefined);
+    // Only emit audit entry when the operation actually changed state; a
+    // no-op on an already-settled entry must not produce a spurious audit record.
+    if (result.wasApplied) {
+      const timestamp = new Date().toISOString();
+      await appendAuditEntry({
+        id: randomUUID(),
+        adminId: admin.adminId,
+        role: admin.role,
+        action: body.action === 'REMIT' ? 'COMMISSION_REMITTED' : 'COMMISSION_WAIVED',
+        resourceType: 'commission_receivable',
+        resourceId: bookingId,
+        payload: {
+          technicianId,
+          bookingId,
+          action: body.action,
+          ...(body.action === 'REMIT'
+            ? {
+                remittedAmount: body.remittedAmount,
+                remittanceMethod: body.remittanceMethod,
+                remittanceRef: body.remittanceRef,
+              }
+            : { waivedReason: body.waivedReason }),
+        },
+        timestamp,
+        partitionKey: timestamp.slice(0, 7),
+      }).catch(() => undefined);
+    }
 
-    return { status: 200, jsonBody: result };
-  } catch {
+    return { status: 200, jsonBody: result.entry };
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === 'AMOUNT_BELOW_DUE') {
+      return { status: 422, jsonBody: { code: 'AMOUNT_BELOW_DUE' } };
+    }
     return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
   }
 };

--- a/api/src/functions/technicians/commission-due.ts
+++ b/api/src/functions/technicians/commission-due.ts
@@ -1,0 +1,44 @@
+import '../../bootstrap.js';
+import { app } from '@azure/functions';
+import type { HttpRequest, InvocationContext, HttpResponseInit } from '@azure/functions';
+import { verifyTechnicianToken } from '../../middleware/verifyTechnicianToken.js';
+import { commissionReceivableRepo } from '../../cosmos/commission-receivable-repository.js';
+
+export const techCommissionDueHandler = async (
+  req: HttpRequest,
+  _ctx: InvocationContext,
+): Promise<HttpResponseInit> => {
+  let uid: string;
+  try {
+    ({ uid } = await verifyTechnicianToken(req));
+  } catch {
+    return { status: 401, jsonBody: { code: 'UNAUTHORIZED' } };
+  }
+
+  try {
+    const entries = await commissionReceivableRepo.getOutstandingByTechnician(uid);
+    const totalOutstandingPaise = entries.reduce((acc, e) => acc + e.commissionDue, 0);
+    return {
+      status: 200,
+      jsonBody: {
+        totalOutstandingPaise,
+        dueCount: entries.length,
+        entries: entries.map((e) => ({
+          bookingId: e.bookingId,
+          bookingAmount: e.bookingAmount,
+          commissionDue: e.commissionDue,
+          createdAt: e.createdAt,
+        })),
+      },
+    };
+  } catch {
+    return { status: 502, jsonBody: { code: 'UPSTREAM_ERROR' } };
+  }
+};
+
+app.http('techCommissionDue', {
+  methods: ['GET'],
+  route: 'v1/technicians/me/commission-due',
+  authLevel: 'anonymous',
+  handler: techCommissionDueHandler,
+});

--- a/api/src/functions/trigger-booking-completed.ts
+++ b/api/src/functions/trigger-booking-completed.ts
@@ -4,10 +4,13 @@ import type { InvocationContext } from '@azure/functions';
 import * as Sentry from '@sentry/node';
 import { randomUUID } from 'node:crypto';
 import { BookingDocSchema } from '../schemas/booking.js';
+import { catalogueRepo } from '../cosmos/catalogue-repository.js';
+import { commissionReceivableRepo } from '../cosmos/commission-receivable-repository.js';
 import { walletLedgerRepo } from '../cosmos/wallet-ledger-repository.js';
 import { getTechnicianForSettlement, incrementCompletedJobCount } from '../cosmos/technician-repository.js';
 import { appendAuditEntry } from '../cosmos/audit-log-repository.js';
 import { calculateCommission } from '../services/commission.service.js';
+import { getGlobalCommissionBps, resolveCommissionBps } from '../services/commission-config.service.js';
 import { RazorpayRouteService } from '../services/razorpayRoute.service.js';
 import { sendTechEarningsUpdate } from '../services/fcm.service.js';
 
@@ -28,6 +31,10 @@ function systemAuditEntry(action: string, resourceId: string, payload: Record<st
   });
 }
 
+function hasRazorpayCredentials(): boolean {
+  return Boolean(process.env['RAZORPAY_KEY_ID'] && process.env['RAZORPAY_KEY_SECRET']);
+}
+
 export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext): Promise<void> {
   const parsed = BookingDocSchema.safeParse(bookingRaw);
   if (!parsed.success || parsed.data.status !== 'COMPLETED') return;
@@ -40,15 +47,85 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     return;
   }
 
-  const existing = await walletLedgerRepo.getByBookingId(bookingId, technicianId);
-  if (existing) {
-    ctx.log(`settleBooking: entry already exists for ${bookingId} (status=${existing.payoutStatus}) — skipping`);
+  const paymentMethod = booking.paymentMethod ?? 'CASH_ON_SERVICE';
+  const bookingAmount = booking.finalAmount ?? booking.amount;
+
+  // ── CASH_ON_SERVICE path (pilot default) ────────────────────────────────────
+  // Technician already holds the cash; platform records a commission receivable.
+  // No money transfer to technician.
+  if (paymentMethod !== 'RAZORPAY') {
+    const existing = await commissionReceivableRepo.getByBookingId(bookingId, technicianId);
+    if (existing) {
+      ctx.log(`settleBooking: commission receivable already exists for ${bookingId} — skipping`);
+      return;
+    }
+
+    const [globalBps, service, category] = await Promise.all([
+      getGlobalCommissionBps(),
+      catalogueRepo.getServiceByIdCrossPartition(booking.serviceId),
+      catalogueRepo.getCategoryById(booking.categoryId),
+    ]);
+
+    const { bps, from: commissionResolvedFrom } = resolveCommissionBps({
+      serviceBps: service?.commissionBps,
+      categoryBps: category?.commissionBps,
+      globalBps,
+    });
+    const commissionDue = Math.round((bookingAmount * bps) / 10000);
+
+    const created = await commissionReceivableRepo.createDueEntry({
+      bookingId,
+      technicianId,
+      serviceId: booking.serviceId,
+      categoryId: booking.categoryId,
+      bookingAmount,
+      commissionBps: bps,
+      commissionDue,
+      commissionResolvedFrom,
+      ...(booking.cashCollectedAmount !== undefined
+        ? { cashCollectedAmount: booking.cashCollectedAmount }
+        : {}),
+    });
+    if (!created) {
+      ctx.log(`settleBooking: concurrent invocation already created commission receivable for ${bookingId} — skipping`);
+      return;
+    }
+
+    try {
+      await systemAuditEntry('COMMISSION_DUE_RECORDED', bookingId, {
+        technicianId,
+        bookingAmount,
+        commissionBps: bps,
+        commissionDue,
+        commissionResolvedFrom,
+      });
+    } catch (auditErr: unknown) {
+      Sentry.captureException(auditErr);
+    }
+
+    try {
+      await Promise.all([
+        incrementCompletedJobCount(technicianId),
+        sendTechEarningsUpdate(technicianId, { bookingId, commissionDue }),
+      ]);
+    } catch (err: unknown) {
+      Sentry.captureException(err);
+    }
     return;
   }
 
-  const bookingAmount = booking.finalAmount ?? booking.amount;
+  // ── RAZORPAY path (guarded — dead in cash pilot, preserved for re-enablement) ─
+  if (!hasRazorpayCredentials()) {
+    ctx.log(`settleBooking: RAZORPAY booking ${bookingId} but no Razorpay credentials configured — skipping`);
+    return;
+  }
 
-  // Best-effort: audit failure must not prevent settlement
+  const existingLedger = await walletLedgerRepo.getByBookingId(bookingId, technicianId);
+  if (existingLedger) {
+    ctx.log(`settleBooking: wallet entry already exists for ${bookingId} (status=${existingLedger.payoutStatus}) — skipping`);
+    return;
+  }
+
   try {
     await systemAuditEntry('ROUTE_TRANSFER_ATTEMPT', bookingId, { technicianId, bookingAmount });
   } catch (auditErr: unknown) {
@@ -58,18 +135,16 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
   const tech = await getTechnicianForSettlement(technicianId);
   const completedJobCount = tech?.completedJobCount ?? 0;
   const { commissionBps, commissionAmount, techAmount: techAmountBeforeFee } = calculateCommission(
-    completedJobCount,
     bookingAmount,
+    2200,
   );
 
-  // Determine effective cadence — treat undefined (legacy) as WEEKLY
   const rawCadence = tech?.payoutCadence;
   const cadence: 'WEEKLY' | 'NEXT_DAY' | 'INSTANT' =
     rawCadence === 'INSTANT' || rawCadence === 'NEXT_DAY' || rawCadence === 'WEEKLY'
       ? rawCadence
       : 'WEEKLY';
 
-  // Compute fee and apply minimum-guard: if techAmount would be ≤ fee threshold, treat as WEEKLY
   let effectiveCadence = cadence;
   let payoutFeeAmount = 0;
   let techAmount = techAmountBeforeFee;
@@ -79,14 +154,14 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
       payoutFeeAmount = 2500;
       techAmount = techAmountBeforeFee - 2500;
     } else {
-      effectiveCadence = 'WEEKLY'; // guard: avoid negative/zero payout
+      effectiveCadence = 'WEEKLY';
     }
   } else if (cadence === 'NEXT_DAY') {
     if (techAmountBeforeFee > 1500) {
       payoutFeeAmount = 1500;
       techAmount = techAmountBeforeFee - 1500;
     } else {
-      effectiveCadence = 'WEEKLY'; // guard
+      effectiveCadence = 'WEEKLY';
     }
   }
 
@@ -105,11 +180,10 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     heldForCadence,
   });
   if (!created) {
-    ctx.log(`settleBooking: concurrent invocation already created entry for ${bookingId} — skipping`);
+    ctx.log(`settleBooking: concurrent invocation already created wallet entry for ${bookingId} — skipping`);
     return;
   }
 
-  // NEXT_DAY and WEEKLY are held — audit and stop; cron/admin will release them
   if (heldForCadence) {
     const auditAction = effectiveCadence === 'NEXT_DAY' ? 'SETTLEMENT_HELD_NEXT_DAY' : 'SETTLEMENT_HELD_WEEKLY';
     try {
@@ -120,7 +194,6 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     return;
   }
 
-  // INSTANT — proceed with immediate Razorpay Route transfer
   if (!tech?.razorpayLinkedAccountId) {
     await walletLedgerRepo.markFailed(bookingId, technicianId, 'no Razorpay linked account');
     await systemAuditEntry('ROUTE_TRANSFER_FAILED', bookingId, { reason: 'no Razorpay linked account' });
@@ -145,11 +218,9 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     return;
   }
 
-  // Transfer succeeded — mark PAID and audit immediately
   await walletLedgerRepo.markPaid(bookingId, technicianId, transferId);
   await systemAuditEntry('ROUTE_TRANSFER_INSTANT', bookingId, { transferId, techAmount, payoutFeeAmount });
 
-  // Best-effort post-transfer notifications; never rollback PAID status
   try {
     await incrementCompletedJobCount(technicianId);
     await sendTechEarningsUpdate(technicianId, { bookingId, techAmount });

--- a/api/src/functions/trigger-booking-completed.ts
+++ b/api/src/functions/trigger-booking-completed.ts
@@ -132,11 +132,21 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     Sentry.captureException(auditErr);
   }
 
-  const tech = await getTechnicianForSettlement(technicianId);
+  const [tech, globalBpsRazorpay, serviceRazorpay, categoryRazorpay] = await Promise.all([
+    getTechnicianForSettlement(technicianId),
+    getGlobalCommissionBps(),
+    catalogueRepo.getServiceByIdCrossPartition(booking.serviceId),
+    catalogueRepo.getCategoryById(booking.categoryId),
+  ]);
   const completedJobCount = tech?.completedJobCount ?? 0;
+  const { bps: resolvedBps } = resolveCommissionBps({
+    ...(serviceRazorpay?.commissionBps !== undefined ? { serviceBps: serviceRazorpay.commissionBps } : {}),
+    ...(categoryRazorpay?.commissionBps !== undefined ? { categoryBps: categoryRazorpay.commissionBps } : {}),
+    globalBps: globalBpsRazorpay,
+  });
   const { commissionBps, commissionAmount, techAmount: techAmountBeforeFee } = calculateCommission(
     bookingAmount,
-    2200,
+    resolvedBps,
   );
 
   const rawCadence = tech?.payoutCadence;

--- a/api/src/functions/trigger-booking-completed.ts
+++ b/api/src/functions/trigger-booking-completed.ts
@@ -200,7 +200,7 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     return;
   }
 
-  const razorpay = new RazorpayRouteService();
+  const razorpay = new RazorpayRouteService(); // nosemgrep: cash-razorpay-guard
   let transferId: string;
   try {
     const result = await razorpay.transfer({

--- a/api/src/functions/trigger-booking-completed.ts
+++ b/api/src/functions/trigger-booking-completed.ts
@@ -67,8 +67,8 @@ export async function settleBooking(bookingRaw: unknown, ctx: InvocationContext)
     ]);
 
     const { bps, from: commissionResolvedFrom } = resolveCommissionBps({
-      serviceBps: service?.commissionBps,
-      categoryBps: category?.commissionBps,
+      ...(service?.commissionBps !== undefined ? { serviceBps: service.commissionBps } : {}),
+      ...(category?.commissionBps !== undefined ? { categoryBps: category.commissionBps } : {}),
       globalBps,
     });
     const commissionDue = Math.round((bookingAmount * bps) / 10000);

--- a/api/src/openapi/registry.ts
+++ b/api/src/openapi/registry.ts
@@ -37,6 +37,17 @@ import {
   SscLevyStatusSchema,
 } from '../schemas/ssc-levy.js';
 import { TechnicianCandidateListResponseSchema } from '../schemas/order.js';
+import {
+  CommissionConfigDocSchema,
+  UpdateCommissionConfigBodySchema,
+} from '../schemas/commission-config.js';
+import {
+  CommissionReceivableEntrySchema,
+  TechnicianOutstandingSummarySchema,
+  CommissionReceivablesDashboardSchema,
+  MarkCommissionReceivedBodySchema,
+  TechnicianCommissionDueSchema,
+} from '../schemas/commission-receivable.js';
 
 extendZodWithOpenApi(z);
 
@@ -496,6 +507,95 @@ registry.registerPath({
     403: { description: 'Forbidden' },
     404: { description: 'Levy not found' },
     409: { description: 'Invalid levy status' },
+  },
+});
+
+// ── E21-S01: Cash-pilot commission config + receivables ───────────────────────
+
+const CommissionConfigResponse = z.object({
+  defaultCommissionBps: z.number().int(),
+  updatedBy: z.string(),
+  updatedAt: z.string(),
+  isDefault: z.boolean().optional(),
+}).openapi('CommissionConfigResponse');
+
+registry.register('CommissionConfigDoc', CommissionConfigDocSchema.openapi('CommissionConfigDoc'));
+registry.register('UpdateCommissionConfigBody', UpdateCommissionConfigBodySchema.openapi('UpdateCommissionConfigBody'));
+registry.register('CommissionConfigResponse', CommissionConfigResponse);
+registry.register('CommissionReceivableEntry', CommissionReceivableEntrySchema.openapi('CommissionReceivableEntry'));
+registry.register('TechnicianOutstandingSummary', TechnicianOutstandingSummarySchema.openapi('TechnicianOutstandingSummary'));
+registry.register('CommissionReceivablesDashboard', CommissionReceivablesDashboardSchema.openapi('CommissionReceivablesDashboard'));
+registry.register('MarkCommissionReceivedBody', MarkCommissionReceivedBodySchema.openapi('MarkCommissionReceivedBody'));
+registry.register('TechnicianCommissionDue', TechnicianCommissionDueSchema.openapi('TechnicianCommissionDue'));
+
+registry.registerPath({
+  method: 'get', path: '/v1/admin/catalogue/commission-config', operationId: 'getAdminCommissionConfig',
+  tags: ['admin-catalogue'], summary: 'Get global commission rate (basis points)',
+  security: [{ cookieAuth: [] }],
+  responses: {
+    200: { description: 'Current global commission bps', content: { 'application/json': { schema: CommissionConfigResponse } } },
+    401: { description: 'Unauthenticated' },
+    403: { description: 'Forbidden' },
+  },
+});
+
+registry.registerPath({
+  method: 'put', path: '/v1/admin/catalogue/commission-config', operationId: 'putAdminCommissionConfig',
+  tags: ['admin-catalogue'], summary: 'Update global commission rate (super-admin only)',
+  security: [{ cookieAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: UpdateCommissionConfigBodySchema } } } },
+  responses: {
+    200: { description: 'Updated commission config', content: { 'application/json': { schema: CommissionConfigResponse } } },
+    400: { description: 'Validation error (bps out of 1500–3500 range)' },
+    401: { description: 'Unauthenticated' },
+    403: { description: 'Forbidden (requires super-admin)' },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/v1/admin/finance/commission-receivables', operationId: 'adminCommissionReceivablesDashboard',
+  tags: ['admin-finance'], summary: 'All-technician commission outstanding dashboard',
+  security: [{ cookieAuth: [] }],
+  responses: {
+    200: { description: 'Per-tech DUE summary + total outstanding', content: { 'application/json': { schema: CommissionReceivablesDashboardSchema } } },
+    401: { description: 'Unauthenticated' },
+    403: { description: 'Forbidden' },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/v1/admin/finance/commission-receivables/{technicianId}', operationId: 'adminCommissionReceivablesPerTech',
+  tags: ['admin-finance'], summary: 'DUE commission entries for a specific technician',
+  security: [{ cookieAuth: [] }],
+  parameters: [{ name: 'technicianId', in: 'path', required: true, schema: { type: 'string' } }],
+  responses: {
+    200: { description: 'Outstanding entries', content: { 'application/json': { schema: z.object({ technicianId: z.string(), entries: z.array(CommissionReceivableEntrySchema) }) } } },
+    401: { description: 'Unauthenticated' },
+    403: { description: 'Forbidden' },
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/v1/admin/finance/commission-receivables/settle', operationId: 'markCommissionReceived',
+  tags: ['admin-finance'], summary: 'Mark commission as remitted (received) or waived',
+  security: [{ cookieAuth: [] }],
+  request: { body: { content: { 'application/json': { schema: MarkCommissionReceivedBodySchema } } } },
+  responses: {
+    200: { description: 'Updated receivable entry', content: { 'application/json': { schema: CommissionReceivableEntrySchema } } },
+    400: { description: 'Validation error' },
+    401: { description: 'Unauthenticated' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Receivable not found' },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/v1/technicians/me/commission-due', operationId: 'techCommissionDue',
+  tags: ['technicians'], summary: 'Technician\'s outstanding commission owed to the platform',
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: { description: 'Outstanding commission summary', content: { 'application/json': { schema: TechnicianCommissionDueSchema } } },
+    401: { description: 'Unauthenticated' },
   },
 });
 

--- a/api/src/schemas/booking.ts
+++ b/api/src/schemas/booking.ts
@@ -34,6 +34,10 @@ export const BookingDocSchema = z.object({
   paymentOrderId: z.string(),
   paymentMethod: PaymentMethodSchema.optional(),
   cashCollectionStatus: CashCollectionStatusSchema.optional(),
+  /** E21-S01: ISO timestamp when the technician confirmed cash collection at job completion. Audit/visibility only — does not gate the commission receivable. */
+  cashCollectedAt: z.string().optional(),
+  /** E21-S01: Actual cash amount (paise) the technician confirmed collecting. May differ from finalAmount. */
+  cashCollectedAmount: z.number().int().nonnegative().optional(),
   paymentId: z.string().nullable(),
   paymentSignature: z.string().nullable(),
   amount: z.number().int().positive(),

--- a/api/src/schemas/commission-config.ts
+++ b/api/src/schemas/commission-config.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+
+extendZodWithOpenApi(z);
+
+/** Fixed singleton id for the platform commission-config document in the `system` container. */
+export const COMMISSION_CONFIG_DOC_ID = 'commission-config';
+
+export const MIN_COMMISSION_BPS = 1500;
+export const MAX_COMMISSION_BPS = 3500;
+
+/** Commission rate in basis points (2250 = 22.5%). Shared bound across global/category/service. */
+export const CommissionBpsSchema = z
+  .number()
+  .int()
+  .min(MIN_COMMISSION_BPS)
+  .max(MAX_COMMISSION_BPS);
+
+/** Where the effective commission rate was resolved from (E21-S01 cascade). */
+export const CommissionResolvedFromSchema = z.enum(['SERVICE', 'CATEGORY', 'GLOBAL']);
+export type CommissionResolvedFrom = z.infer<typeof CommissionResolvedFromSchema>;
+
+/** Stored in the `system` Cosmos container under the fixed id `commission-config`. */
+export const CommissionConfigDocSchema = z
+  .object({
+    id: z.literal(COMMISSION_CONFIG_DOC_ID),
+    defaultCommissionBps: CommissionBpsSchema,
+    updatedBy: z.string().min(1),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+export type CommissionConfigDoc = z.infer<typeof CommissionConfigDocSchema>;
+
+/** Admin PUT body to change the global default commission. */
+export const UpdateCommissionConfigBodySchema = z
+  .object({
+    defaultCommissionBps: CommissionBpsSchema,
+  })
+  .strict();
+export type UpdateCommissionConfigBody = z.infer<typeof UpdateCommissionConfigBodySchema>;
+
+/** Admin GET response for the global default commission. */
+export const CommissionConfigResponseSchema = z.object({
+  defaultCommissionBps: CommissionBpsSchema,
+  updatedBy: z.string().min(1),
+  updatedAt: z.string().datetime(),
+});
+export type CommissionConfigResponse = z.infer<typeof CommissionConfigResponseSchema>;

--- a/api/src/schemas/commission-receivable.ts
+++ b/api/src/schemas/commission-receivable.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { CommissionBpsSchema, CommissionResolvedFromSchema, type CommissionResolvedFrom } from './commission-config.js';
+
+extendZodWithOpenApi(z);
+
+/** Lifecycle of a single booking's commission owed by the technician to the platform (cash pilot). */
+export const RemittanceStatusSchema = z.enum(['DUE', 'REMITTED', 'WAIVED']);
+export type RemittanceStatus = z.infer<typeof RemittanceStatusSchema>;
+
+export const RemittanceMethodSchema = z.enum(['UPI', 'CASH_DEPOSIT', 'ADJUSTMENT']);
+export type RemittanceMethod = z.infer<typeof RemittanceMethodSchema>;
+
+/**
+ * E21-S01: One document per completed cash booking in the `commission_receivables` container
+ * (pk /technicianId). id === bookingId for idempotent point reads. Records the commission the
+ * technician OWES the platform (the platform never held the cash). `commissionBps` /
+ * `commissionResolvedFrom` are snapshotted at settlement time so later config edits never
+ * retroactively re-rate a recorded receivable.
+ */
+export const CommissionReceivableEntrySchema = z.object({
+  id: z.string(),
+  bookingId: z.string(),
+  technicianId: z.string(),
+  partitionKey: z.string(),
+  serviceId: z.string(),
+  categoryId: z.string(),
+  bookingAmount: z.number().int().positive(),
+  cashCollectedAmount: z.number().int().nonnegative().optional(),
+  commissionBps: CommissionBpsSchema,
+  commissionDue: z.number().int().nonnegative(),
+  commissionResolvedFrom: CommissionResolvedFromSchema,
+  remittanceStatus: RemittanceStatusSchema,
+  remittedAmount: z.number().int().nonnegative().optional(),
+  remittedAt: z.string().optional(),
+  remittanceRef: z.string().optional(),
+  remittanceMethod: RemittanceMethodSchema.optional(),
+  markedByAdminId: z.string().optional(),
+  waivedReason: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+});
+export type CommissionReceivableEntry = z.infer<typeof CommissionReceivableEntrySchema>;
+
+export type CommissionReceivableCreateInput = {
+  bookingId: string;
+  technicianId: string;
+  serviceId: string;
+  categoryId: string;
+  bookingAmount: number;
+  commissionBps: number;
+  commissionDue: number;
+  commissionResolvedFrom: CommissionResolvedFrom;
+  cashCollectedAmount?: number;
+};
+
+/** Per-technician roll-up for the admin commission-collection dashboard. */
+export const TechnicianOutstandingSummarySchema = z.object({
+  technicianId: z.string(),
+  technicianName: z.string(),
+  dueCount: z.number().int().nonnegative(),
+  totalCommissionDue: z.number().int().nonnegative(),
+  oldestDueAt: z.string().optional(),
+});
+export type TechnicianOutstandingSummary = z.infer<typeof TechnicianOutstandingSummarySchema>;
+
+export const CommissionReceivablesDashboardSchema = z.object({
+  technicians: z.array(TechnicianOutstandingSummarySchema),
+  totalOutstanding: z.number().int().nonnegative(),
+});
+export type CommissionReceivablesDashboard = z.infer<typeof CommissionReceivablesDashboardSchema>;
+
+/** Admin action to settle (REMIT) or write off (WAIVE) a technician's commission for a booking. */
+export const MarkCommissionReceivedBodySchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('REMIT'),
+    bookingId: z.string().min(1),
+    technicianId: z.string().min(1),
+    remittedAmount: z.number().int().positive(),
+    remittanceMethod: RemittanceMethodSchema,
+    remittanceRef: z.string().min(1),
+  }),
+  z.object({
+    action: z.literal('WAIVE'),
+    bookingId: z.string().min(1),
+    technicianId: z.string().min(1),
+    waivedReason: z.string().min(1),
+  }),
+]);
+export type MarkCommissionReceivedBody = z.infer<typeof MarkCommissionReceivedBodySchema>;
+
+/** Tech-facing GET /v1/technicians/me/commission-due response. */
+export const TechnicianCommissionDueSchema = z.object({
+  totalOutstandingPaise: z.number().int().nonnegative(),
+  dueCount: z.number().int().nonnegative(),
+  entries: z.array(
+    z.object({
+      bookingId: z.string(),
+      bookingAmount: z.number().int().nonnegative(),
+      commissionDue: z.number().int().nonnegative(),
+      createdAt: z.string(),
+    }),
+  ),
+});
+export type TechnicianCommissionDue = z.infer<typeof TechnicianCommissionDueSchema>;

--- a/api/src/schemas/service-category.ts
+++ b/api/src/schemas/service-category.ts
@@ -11,6 +11,12 @@ export const ServiceCategorySchema = z
     sortOrder: z.number().int().nonnegative(),
     /** PRD-08: When true, this category's services should trigger the women-safe filter by default. */
     safetyTag: z.boolean().optional(),
+    /**
+     * E21-S01: Optional commission override (basis points) for every service in this category.
+     * When absent, services fall through to the global default. A service-level `commissionBps`
+     * takes precedence over this category override.
+     */
+    commissionBps: z.number().int().min(1500).max(3500).optional(),
     isActive: z.boolean(),
     updatedBy: z.string().min(1),
     createdAt: z.string().datetime(),

--- a/api/src/schemas/service.ts
+++ b/api/src/schemas/service.ts
@@ -29,7 +29,7 @@ export const ServiceSchema = z
     shortDescription: z.string().min(1).max(200),
     heroImageUrl: z.string().url(),
     basePrice: z.number().int().nonnegative().openapi({ description: 'Price in paise (₹599 = 59900)' }),
-    commissionBps: z.number().int().min(1500).max(3500).openapi({ description: 'Commission in basis points (2250 = 22.5%)' }),
+    commissionBps: z.number().int().min(1500).max(3500).optional().openapi({ description: 'Commission override in basis points (2250 = 22.5%). Optional (E21-S01): when absent, the booking falls through to the category override, then the global default.' }),
     durationMinutes: z.number().int().positive(),
     includes: z.array(z.string().min(1)),
     faq: z.array(FaqItemSchema),

--- a/api/src/services/commission-config.service.ts
+++ b/api/src/services/commission-config.service.ts
@@ -1,0 +1,75 @@
+import * as Sentry from '@sentry/node';
+import { commissionConfigRepo } from '../cosmos/commission-config-repository.js';
+import {
+  MIN_COMMISSION_BPS,
+  MAX_COMMISSION_BPS,
+  type CommissionResolvedFrom,
+} from '../schemas/commission-config.js';
+
+/** Platform default when no commission-config doc exists in Cosmos. */
+export const DEFAULT_COMMISSION_BPS = 2200;
+
+/** Cache TTL: 5 minutes. */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let _cachedBps: number | null = null;
+let _cacheExpiresAt = 0;
+
+/** Reset in-process cache — used by tests only. */
+export function _resetCommissionConfigCacheForTest(): void {
+  _cachedBps = null;
+  _cacheExpiresAt = 0;
+}
+
+function isValidBps(x: number | undefined): x is number {
+  return x !== undefined && Number.isInteger(x) && x >= MIN_COMMISSION_BPS && x <= MAX_COMMISSION_BPS;
+}
+
+/**
+ * Pure resolver — applies the service > category > global precedence cascade.
+ * "valid" = Number.isInteger(x) && 1500 <= x <= 3500.
+ * Throws if globalBps is not valid (config is broken at the root).
+ */
+export function resolveCommissionBps(input: {
+  serviceBps?: number;
+  categoryBps?: number;
+  globalBps: number;
+}): { bps: number; from: CommissionResolvedFrom } {
+  if (isValidBps(input.serviceBps)) {
+    return { bps: input.serviceBps, from: 'SERVICE' };
+  }
+  if (isValidBps(input.categoryBps)) {
+    return { bps: input.categoryBps, from: 'CATEGORY' };
+  }
+  if (!isValidBps(input.globalBps)) {
+    throw new Error('commission config invalid: globalBps out of range');
+  }
+  return { bps: input.globalBps, from: 'GLOBAL' };
+}
+
+/**
+ * Returns the platform-wide default commission rate in basis points.
+ * Cached in-process with a 5-minute TTL to avoid hammering Cosmos on hot paths.
+ * Falls back to DEFAULT_COMMISSION_BPS (2200) and emits a Sentry warning when
+ * no commission-config doc has been written yet.
+ */
+export async function getGlobalCommissionBps(): Promise<number> {
+  const now = Date.now();
+  if (_cachedBps !== null && now < _cacheExpiresAt) {
+    return _cachedBps;
+  }
+
+  const doc = await commissionConfigRepo.getCommissionConfig();
+  const resolved = doc?.defaultCommissionBps ?? (() => {
+    Sentry.captureMessage(
+      'commission-config doc missing in Cosmos; falling back to DEFAULT_COMMISSION_BPS',
+      'warning',
+    );
+    return DEFAULT_COMMISSION_BPS;
+  })();
+
+  _cachedBps = resolved;
+  _cacheExpiresAt = now + CACHE_TTL_MS;
+
+  return resolved;
+}

--- a/api/src/services/commission.service.ts
+++ b/api/src/services/commission.service.ts
@@ -5,10 +5,9 @@ export interface CommissionResult {
 }
 
 export function calculateCommission(
-  completedJobCount: number,
   bookingAmountPaise: number,
+  commissionBps: number,
 ): CommissionResult {
-  const commissionBps = completedJobCount >= 50 ? 2500 : 2200;
   const commissionAmount = Math.round((bookingAmountPaise * commissionBps) / 10000);
   const techAmount = bookingAmountPaise - commissionAmount;
   return { commissionBps, commissionAmount, techAmount };

--- a/api/src/services/fcm.service.ts
+++ b/api/src/services/fcm.service.ts
@@ -172,12 +172,13 @@ export async function sendTechnicianBookingStatusUpdatePush(payload: {
 
 export async function sendTechEarningsUpdate(
   technicianId: string,
-  payload: { bookingId: string; techAmount: number },
+  payload: { bookingId: string; techAmount?: number; commissionDue?: number },
 ): Promise<void> {
   await sendToUserTokens(technicianId, {
     type: 'EARNINGS_UPDATE',
     bookingId: payload.bookingId,
-    techAmount: String(payload.techAmount),
+    ...(payload.techAmount !== undefined ? { techAmount: String(payload.techAmount) } : {}),
+    ...(payload.commissionDue !== undefined ? { commissionDue: String(payload.commissionDue) } : {}),
   });
 }
 

--- a/api/tests/cosmos/booking-repository-markCashCollected.test.ts
+++ b/api/tests/cosmos/booking-repository-markCashCollected.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BookingDoc } from '../../src/schemas/booking.js';
+
+// --- Mocks ---
+const mockReplace = vi.fn();
+const mockRead = vi.fn();
+const mockItem = vi.fn(() => ({ read: mockRead, replace: mockReplace }));
+
+vi.mock('../../src/cosmos/client.js', () => ({
+  getBookingsContainer: () => ({
+    items: { query: vi.fn(() => ({ fetchAll: vi.fn() })), create: vi.fn() },
+    item: mockItem,
+  }),
+  getCosmosClient: vi.fn(),
+  DB_NAME: 'homeservices',
+}));
+
+import { bookingRepo } from '../../src/cosmos/booking-repository.js';
+
+const baseDoc: BookingDoc = {
+  id: 'bk-cash-test',
+  customerId: 'cust-1',
+  serviceId: 'svc-1',
+  categoryId: 'cat-1',
+  slotDate: '2026-05-01',
+  slotWindow: '10:00-12:00',
+  addressText: '123 Main St',
+  addressLatLng: { lat: 12.97, lng: 77.59 },
+  status: 'COMPLETED',
+  paymentOrderId: 'order_cash123',
+  paymentId: null,
+  paymentSignature: null,
+  paymentMethod: 'CASH_ON_SERVICE',
+  cashCollectionStatus: 'PENDING',
+  amount: 59900,
+  createdAt: '2026-04-20T10:00:00.000Z',
+};
+
+describe('bookingRepo.markCashCollected', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when booking is not found', async () => {
+    mockRead.mockResolvedValue({ resource: undefined, etag: undefined });
+
+    const result = await bookingRepo.markCashCollected('nonexistent-id', 500);
+
+    expect(result).toBeNull();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('transitions PENDING → COLLECTED with timestamp and amount', async () => {
+    const pendingDoc: BookingDoc = { ...baseDoc, cashCollectionStatus: 'PENDING' };
+    const updatedDoc: BookingDoc = {
+      ...pendingDoc,
+      cashCollectionStatus: 'COLLECTED',
+      cashCollectedAt: '2026-05-24T10:00:00.000Z',
+      cashCollectedAmount: 59900,
+    };
+    mockRead.mockResolvedValue({ resource: pendingDoc, etag: 'etag-abc' });
+    mockReplace.mockResolvedValue({ resource: updatedDoc });
+
+    const result = await bookingRepo.markCashCollected('bk-cash-test', 59900);
+
+    expect(mockReplace).toHaveBeenCalledOnce();
+    const replaceArg = (mockReplace.mock.calls as unknown[][])[0]![0] as BookingDoc;
+    expect(replaceArg.cashCollectionStatus).toBe('COLLECTED');
+    expect(replaceArg.cashCollectedAt).toBeDefined();
+    expect(typeof replaceArg.cashCollectedAt).toBe('string');
+    expect(replaceArg.cashCollectedAmount).toBe(59900);
+    expect(result).toEqual(updatedDoc);
+  });
+
+  it('is idempotent — returns existing doc unchanged when already COLLECTED', async () => {
+    const collectedDoc: BookingDoc = {
+      ...baseDoc,
+      cashCollectionStatus: 'COLLECTED',
+      cashCollectedAt: '2026-05-23T09:00:00.000Z',
+      cashCollectedAmount: 59900,
+    };
+    mockRead.mockResolvedValue({ resource: collectedDoc, etag: 'etag-xyz' });
+
+    const result = await bookingRepo.markCashCollected('bk-cash-test', 59900);
+
+    expect(result).toEqual(collectedDoc);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('omits cashCollectedAmount when amount is not provided', async () => {
+    const pendingDoc: BookingDoc = { ...baseDoc, cashCollectionStatus: 'PENDING' };
+    const updatedDoc: BookingDoc = {
+      ...pendingDoc,
+      cashCollectionStatus: 'COLLECTED',
+      cashCollectedAt: '2026-05-24T10:00:00.000Z',
+    };
+    mockRead.mockResolvedValue({ resource: pendingDoc, etag: 'etag-abc' });
+    mockReplace.mockResolvedValue({ resource: updatedDoc });
+
+    const result = await bookingRepo.markCashCollected('bk-cash-test');
+
+    expect(mockReplace).toHaveBeenCalledOnce();
+    const replaceArg = (mockReplace.mock.calls as unknown[][])[0]![0] as BookingDoc;
+    expect(replaceArg.cashCollectionStatus).toBe('COLLECTED');
+    expect(replaceArg.cashCollectedAt).toBeDefined();
+    expect('cashCollectedAmount' in replaceArg).toBe(false);
+    expect(result).toEqual(updatedDoc);
+  });
+});

--- a/api/tests/cosmos/commission-config-repository.test.ts
+++ b/api/tests/cosmos/commission-config-repository.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the Cosmos client before any imports that depend on it
+vi.mock('../../src/cosmos/client.js', () => ({
+  getCosmosClient: vi.fn(),
+  DB_NAME: 'homeservices',
+  getSystemContainer: vi.fn(),
+}));
+
+import { commissionConfigRepo } from '../../src/cosmos/commission-config-repository.js';
+import { getSystemContainer } from '../../src/cosmos/client.js';
+import type { CommissionConfigDoc } from '../../src/schemas/commission-config.js';
+
+const MOCK_DOC: CommissionConfigDoc = {
+  id: 'commission-config',
+  defaultCommissionBps: 2200,
+  updatedBy: 'admin@test.com',
+  updatedAt: '2026-05-24T00:00:00.000Z',
+};
+
+function makeContainer(readResource: unknown, mockUpsert = vi.fn().mockResolvedValue({})) {
+  return {
+    item: vi.fn().mockReturnValue({
+      read: vi.fn().mockResolvedValue({ resource: readResource }),
+    }),
+    items: { upsert: mockUpsert },
+  };
+}
+
+describe('commissionConfigRepo.getCommissionConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when the doc does not exist', async () => {
+    const container = makeContainer(undefined);
+    vi.mocked(getSystemContainer).mockReturnValue(
+      container as unknown as ReturnType<typeof getSystemContainer>,
+    );
+
+    const result = await commissionConfigRepo.getCommissionConfig();
+    expect(result).toBeNull();
+  });
+
+  it('returns the doc when it exists', async () => {
+    const container = makeContainer(MOCK_DOC);
+    vi.mocked(getSystemContainer).mockReturnValue(
+      container as unknown as ReturnType<typeof getSystemContainer>,
+    );
+
+    const result = await commissionConfigRepo.getCommissionConfig();
+    expect(result).toEqual(MOCK_DOC);
+  });
+
+  it('performs a point read with the singleton id', async () => {
+    const container = makeContainer(MOCK_DOC);
+    vi.mocked(getSystemContainer).mockReturnValue(
+      container as unknown as ReturnType<typeof getSystemContainer>,
+    );
+
+    await commissionConfigRepo.getCommissionConfig();
+    expect(container.item).toHaveBeenCalledWith('commission-config', 'commission-config');
+  });
+});
+
+describe('commissionConfigRepo.upsertCommissionConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('upserts a doc with the correct id and returns it', async () => {
+    const mockUpsert = vi.fn().mockResolvedValue({});
+    const container = makeContainer(undefined, mockUpsert);
+    vi.mocked(getSystemContainer).mockReturnValue(
+      container as unknown as ReturnType<typeof getSystemContainer>,
+    );
+
+    const result = await commissionConfigRepo.upsertCommissionConfig(2500, 'admin@test.com');
+
+    expect(result.id).toBe('commission-config');
+    expect(result.defaultCommissionBps).toBe(2500);
+    expect(result.updatedBy).toBe('admin@test.com');
+    expect(result.updatedAt).toBeTruthy();
+  });
+
+  it('writes the doc to Cosmos via upsert', async () => {
+    const mockUpsert = vi.fn().mockResolvedValue({});
+    const container = makeContainer(undefined, mockUpsert);
+    vi.mocked(getSystemContainer).mockReturnValue(
+      container as unknown as ReturnType<typeof getSystemContainer>,
+    );
+
+    await commissionConfigRepo.upsertCommissionConfig(3000, 'owner');
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'commission-config',
+        defaultCommissionBps: 3000,
+        updatedBy: 'owner',
+      }),
+    );
+  });
+
+  it('sets updatedAt to a valid ISO datetime string', async () => {
+    const mockUpsert = vi.fn().mockResolvedValue({});
+    const container = makeContainer(undefined, mockUpsert);
+    vi.mocked(getSystemContainer).mockReturnValue(
+      container as unknown as ReturnType<typeof getSystemContainer>,
+    );
+
+    const result = await commissionConfigRepo.upsertCommissionConfig(2200, 'admin');
+    expect(() => new Date(result.updatedAt)).not.toThrow();
+    expect(new Date(result.updatedAt).toISOString()).toBe(result.updatedAt);
+  });
+});

--- a/api/tests/cosmos/commission-receivable-repository.test.ts
+++ b/api/tests/cosmos/commission-receivable-repository.test.ts
@@ -128,7 +128,7 @@ describe('commissionReceivableRepo.getByBookingId', () => {
 describe('commissionReceivableRepo.markRemitted', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('transitions DUE → REMITTED and returns updated entry', async () => {
+  it('transitions DUE → REMITTED, returns { wasApplied: true, entry }', async () => {
     mockRead.mockResolvedValue({ resource: { ...baseDueEntry } });
     mockReplace.mockResolvedValue({});
     const result = await commissionReceivableRepo.markRemitted('bk-001', 'tech-1', {
@@ -138,17 +138,31 @@ describe('commissionReceivableRepo.markRemitted', () => {
       markedByAdminId: 'admin-7',
     });
     expect(result).not.toBeNull();
-    expect(result!.remittanceStatus).toBe('REMITTED');
-    expect(result!.remittedAmount).toBe(11980);
-    expect(result!.remittanceMethod).toBe('UPI');
-    expect(result!.remittanceRef).toBe('upi-txn-42');
-    expect(result!.markedByAdminId).toBe('admin-7');
-    expect(result!.remittedAt).toBeDefined();
-    expect(result!.updatedAt).toBeDefined();
+    expect(result!.wasApplied).toBe(true);
+    expect(result!.entry.remittanceStatus).toBe('REMITTED');
+    expect(result!.entry.remittedAmount).toBe(11980);
+    expect(result!.entry.remittanceMethod).toBe('UPI');
+    expect(result!.entry.remittanceRef).toBe('upi-txn-42');
+    expect(result!.entry.markedByAdminId).toBe('admin-7');
+    expect(result!.entry.remittedAt).toBeDefined();
+    expect(result!.entry.updatedAt).toBeDefined();
     expect(mockReplace).toHaveBeenCalledOnce();
   });
 
-  it('is idempotent: returns unchanged entry when already REMITTED', async () => {
+  it('rejects when remittedAmount < commissionDue', async () => {
+    mockRead.mockResolvedValue({ resource: { ...baseDueEntry } }); // commissionDue = 11980
+    await expect(
+      commissionReceivableRepo.markRemitted('bk-001', 'tech-1', {
+        remittedAmount: 5000,
+        remittanceMethod: 'UPI',
+        remittanceRef: 'ref-low',
+        markedByAdminId: 'admin-1',
+      }),
+    ).rejects.toMatchObject({ code: 'AMOUNT_BELOW_DUE' });
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('is no-op: returns { wasApplied: false } when already REMITTED', async () => {
     const alreadyRemitted: CommissionReceivableEntry = {
       ...baseDueEntry,
       remittanceStatus: 'REMITTED',
@@ -163,11 +177,12 @@ describe('commissionReceivableRepo.markRemitted', () => {
       remittanceRef: 'different-ref',
       markedByAdminId: 'admin-9',
     });
-    expect(result).toEqual(alreadyRemitted);
+    expect(result!.wasApplied).toBe(false);
+    expect(result!.entry).toEqual(alreadyRemitted);
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
-  it('is idempotent: returns unchanged entry when already WAIVED', async () => {
+  it('is no-op: returns { wasApplied: false } when already WAIVED', async () => {
     const waived: CommissionReceivableEntry = {
       ...baseDueEntry,
       remittanceStatus: 'WAIVED',
@@ -175,12 +190,13 @@ describe('commissionReceivableRepo.markRemitted', () => {
     };
     mockRead.mockResolvedValue({ resource: waived });
     const result = await commissionReceivableRepo.markRemitted('bk-001', 'tech-1', {
-      remittedAmount: 0,
+      remittedAmount: 11980,
       remittanceMethod: 'ADJUSTMENT',
       remittanceRef: 'adj-1',
       markedByAdminId: 'admin-1',
     });
-    expect(result).toEqual(waived);
+    expect(result!.wasApplied).toBe(false);
+    expect(result!.entry).toEqual(waived);
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
@@ -200,7 +216,7 @@ describe('commissionReceivableRepo.markRemitted', () => {
 describe('commissionReceivableRepo.markWaived', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('transitions DUE → WAIVED and returns updated entry', async () => {
+  it('transitions DUE → WAIVED, returns { wasApplied: true, entry }', async () => {
     mockRead.mockResolvedValue({ resource: { ...baseDueEntry } });
     mockReplace.mockResolvedValue({});
     const result = await commissionReceivableRepo.markWaived('bk-001', 'tech-1', {
@@ -208,14 +224,15 @@ describe('commissionReceivableRepo.markWaived', () => {
       markedByAdminId: 'admin-7',
     });
     expect(result).not.toBeNull();
-    expect(result!.remittanceStatus).toBe('WAIVED');
-    expect(result!.waivedReason).toBe('first-time goodwill');
-    expect(result!.markedByAdminId).toBe('admin-7');
-    expect(result!.updatedAt).toBeDefined();
+    expect(result!.wasApplied).toBe(true);
+    expect(result!.entry.remittanceStatus).toBe('WAIVED');
+    expect(result!.entry.waivedReason).toBe('first-time goodwill');
+    expect(result!.entry.markedByAdminId).toBe('admin-7');
+    expect(result!.entry.updatedAt).toBeDefined();
     expect(mockReplace).toHaveBeenCalledOnce();
   });
 
-  it('is idempotent: returns unchanged entry when already WAIVED', async () => {
+  it('is no-op: returns { wasApplied: false } when already WAIVED', async () => {
     const alreadyWaived: CommissionReceivableEntry = {
       ...baseDueEntry,
       remittanceStatus: 'WAIVED',
@@ -226,7 +243,8 @@ describe('commissionReceivableRepo.markWaived', () => {
       waivedReason: 'new reason',
       markedByAdminId: 'admin-5',
     });
-    expect(result).toEqual(alreadyWaived);
+    expect(result!.wasApplied).toBe(false);
+    expect(result!.entry).toEqual(alreadyWaived);
     expect(mockReplace).not.toHaveBeenCalled();
   });
 

--- a/api/tests/cosmos/commission-receivable-repository.test.ts
+++ b/api/tests/cosmos/commission-receivable-repository.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CommissionReceivableEntry } from '../../src/schemas/commission-receivable.js';
+
+// --- Mocks ---
+const mockCreate = vi.fn();
+const mockReplace = vi.fn();
+const mockRead = vi.fn();
+const mockItem = vi.fn(() => ({ read: mockRead, replace: mockReplace }));
+const mockFetchAll = vi.fn();
+const mockQuery = vi.fn(() => ({ fetchAll: mockFetchAll }));
+
+vi.mock('../../src/cosmos/client.js', () => ({
+  getCommissionReceivablesContainer: () => ({
+    items: { create: mockCreate, query: mockQuery },
+    item: mockItem,
+  }),
+  getCosmosClient: vi.fn(),
+  DB_NAME: 'homeservices',
+}));
+
+import { commissionReceivableRepo } from '../../src/cosmos/commission-receivable-repository.js';
+
+const baseDueEntry: CommissionReceivableEntry = {
+  id: 'bk-001',
+  bookingId: 'bk-001',
+  technicianId: 'tech-1',
+  partitionKey: 'tech-1',
+  serviceId: 'svc-ac',
+  categoryId: 'cat-hvac',
+  bookingAmount: 59900,
+  commissionBps: 2000,
+  commissionDue: 11980,
+  commissionResolvedFrom: 'SERVICE',
+  remittanceStatus: 'DUE',
+  createdAt: '2026-05-01T08:00:00.000Z',
+};
+
+describe('commissionReceivableRepo.createDueEntry', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns true on successful create', async () => {
+    mockCreate.mockResolvedValue({});
+    const result = await commissionReceivableRepo.createDueEntry({
+      bookingId: 'bk-001',
+      technicianId: 'tech-1',
+      serviceId: 'svc-ac',
+      categoryId: 'cat-hvac',
+      bookingAmount: 59900,
+      commissionBps: 2000,
+      commissionDue: 11980,
+      commissionResolvedFrom: 'SERVICE',
+    });
+    expect(result).toBe(true);
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const doc = (mockCreate.mock.calls as unknown[][])[0]![0] as CommissionReceivableEntry;
+    expect(doc.id).toBe('bk-001');
+    expect(doc.remittanceStatus).toBe('DUE');
+    expect(doc.partitionKey).toBe('tech-1');
+    expect(doc.cashCollectedAmount).toBeUndefined();
+  });
+
+  it('includes cashCollectedAmount when provided', async () => {
+    mockCreate.mockResolvedValue({});
+    await commissionReceivableRepo.createDueEntry({
+      bookingId: 'bk-002',
+      technicianId: 'tech-1',
+      serviceId: 'svc-ac',
+      categoryId: 'cat-hvac',
+      bookingAmount: 59900,
+      commissionBps: 2000,
+      commissionDue: 11980,
+      commissionResolvedFrom: 'SERVICE',
+      cashCollectedAmount: 59900,
+    });
+    const doc = (mockCreate.mock.calls as unknown[][])[0]![0] as CommissionReceivableEntry;
+    expect(doc.cashCollectedAmount).toBe(59900);
+  });
+
+  it('returns false on 409 conflict (duplicate create)', async () => {
+    mockCreate.mockRejectedValue({ code: 409 });
+    const result = await commissionReceivableRepo.createDueEntry({
+      bookingId: 'bk-001',
+      technicianId: 'tech-1',
+      serviceId: 'svc-ac',
+      categoryId: 'cat-hvac',
+      bookingAmount: 59900,
+      commissionBps: 2000,
+      commissionDue: 11980,
+      commissionResolvedFrom: 'SERVICE',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('rethrows non-409 errors', async () => {
+    mockCreate.mockRejectedValue({ code: 500, message: 'Server error' });
+    await expect(
+      commissionReceivableRepo.createDueEntry({
+        bookingId: 'bk-err',
+        technicianId: 'tech-1',
+        serviceId: 'svc-ac',
+        categoryId: 'cat-hvac',
+        bookingAmount: 59900,
+        commissionBps: 2000,
+        commissionDue: 11980,
+        commissionResolvedFrom: 'SERVICE',
+      }),
+    ).rejects.toMatchObject({ code: 500 });
+  });
+});
+
+describe('commissionReceivableRepo.getByBookingId', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when entry not found', async () => {
+    mockRead.mockResolvedValue({ resource: undefined });
+    const result = await commissionReceivableRepo.getByBookingId('bk-none', 'tech-1');
+    expect(result).toBeNull();
+    expect(mockItem).toHaveBeenCalledWith('bk-none', 'tech-1');
+  });
+
+  it('returns the entry when found', async () => {
+    mockRead.mockResolvedValue({ resource: baseDueEntry });
+    const result = await commissionReceivableRepo.getByBookingId('bk-001', 'tech-1');
+    expect(result).toEqual(baseDueEntry);
+  });
+});
+
+describe('commissionReceivableRepo.markRemitted', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('transitions DUE → REMITTED and returns updated entry', async () => {
+    mockRead.mockResolvedValue({ resource: { ...baseDueEntry } });
+    mockReplace.mockResolvedValue({});
+    const result = await commissionReceivableRepo.markRemitted('bk-001', 'tech-1', {
+      remittedAmount: 11980,
+      remittanceMethod: 'UPI',
+      remittanceRef: 'upi-txn-42',
+      markedByAdminId: 'admin-7',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.remittanceStatus).toBe('REMITTED');
+    expect(result!.remittedAmount).toBe(11980);
+    expect(result!.remittanceMethod).toBe('UPI');
+    expect(result!.remittanceRef).toBe('upi-txn-42');
+    expect(result!.markedByAdminId).toBe('admin-7');
+    expect(result!.remittedAt).toBeDefined();
+    expect(result!.updatedAt).toBeDefined();
+    expect(mockReplace).toHaveBeenCalledOnce();
+  });
+
+  it('is idempotent: returns unchanged entry when already REMITTED', async () => {
+    const alreadyRemitted: CommissionReceivableEntry = {
+      ...baseDueEntry,
+      remittanceStatus: 'REMITTED',
+      remittedAmount: 11980,
+      remittanceMethod: 'UPI',
+      remittanceRef: 'upi-txn-42',
+    };
+    mockRead.mockResolvedValue({ resource: alreadyRemitted });
+    const result = await commissionReceivableRepo.markRemitted('bk-001', 'tech-1', {
+      remittedAmount: 11980,
+      remittanceMethod: 'CASH_DEPOSIT',
+      remittanceRef: 'different-ref',
+      markedByAdminId: 'admin-9',
+    });
+    expect(result).toEqual(alreadyRemitted);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: returns unchanged entry when already WAIVED', async () => {
+    const waived: CommissionReceivableEntry = {
+      ...baseDueEntry,
+      remittanceStatus: 'WAIVED',
+      waivedReason: 'goodwill',
+    };
+    mockRead.mockResolvedValue({ resource: waived });
+    const result = await commissionReceivableRepo.markRemitted('bk-001', 'tech-1', {
+      remittedAmount: 0,
+      remittanceMethod: 'ADJUSTMENT',
+      remittanceRef: 'adj-1',
+      markedByAdminId: 'admin-1',
+    });
+    expect(result).toEqual(waived);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('returns null when entry is missing', async () => {
+    mockRead.mockResolvedValue({ resource: undefined });
+    const result = await commissionReceivableRepo.markRemitted('bk-none', 'tech-1', {
+      remittedAmount: 100,
+      remittanceMethod: 'UPI',
+      remittanceRef: 'ref-1',
+      markedByAdminId: 'admin-1',
+    });
+    expect(result).toBeNull();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});
+
+describe('commissionReceivableRepo.markWaived', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('transitions DUE → WAIVED and returns updated entry', async () => {
+    mockRead.mockResolvedValue({ resource: { ...baseDueEntry } });
+    mockReplace.mockResolvedValue({});
+    const result = await commissionReceivableRepo.markWaived('bk-001', 'tech-1', {
+      waivedReason: 'first-time goodwill',
+      markedByAdminId: 'admin-7',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.remittanceStatus).toBe('WAIVED');
+    expect(result!.waivedReason).toBe('first-time goodwill');
+    expect(result!.markedByAdminId).toBe('admin-7');
+    expect(result!.updatedAt).toBeDefined();
+    expect(mockReplace).toHaveBeenCalledOnce();
+  });
+
+  it('is idempotent: returns unchanged entry when already WAIVED', async () => {
+    const alreadyWaived: CommissionReceivableEntry = {
+      ...baseDueEntry,
+      remittanceStatus: 'WAIVED',
+      waivedReason: 'original',
+    };
+    mockRead.mockResolvedValue({ resource: alreadyWaived });
+    const result = await commissionReceivableRepo.markWaived('bk-001', 'tech-1', {
+      waivedReason: 'new reason',
+      markedByAdminId: 'admin-5',
+    });
+    expect(result).toEqual(alreadyWaived);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('returns null when entry is missing', async () => {
+    mockRead.mockResolvedValue({ resource: undefined });
+    const result = await commissionReceivableRepo.markWaived('bk-none', 'tech-1', {
+      waivedReason: 'n/a',
+      markedByAdminId: 'admin-1',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('commissionReceivableRepo.getOutstandingByTechnician', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('queries only DUE entries within the technician partition', async () => {
+    const dueEntry = { ...baseDueEntry };
+    mockFetchAll.mockResolvedValue({ resources: [dueEntry] });
+
+    const results = await commissionReceivableRepo.getOutstandingByTechnician('tech-1');
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(dueEntry);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.stringContaining("remittanceStatus = 'DUE'") }),
+      { partitionKey: 'tech-1' },
+    );
+  });
+
+  it('returns empty array when no DUE entries', async () => {
+    mockFetchAll.mockResolvedValue({ resources: [] });
+    const results = await commissionReceivableRepo.getOutstandingByTechnician('tech-2');
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe('commissionReceivableRepo.getAllTechnicianOutstandingSummaries', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('groups entries by technicianId with correct sums and oldestDueAt', async () => {
+    const entries: CommissionReceivableEntry[] = [
+      { ...baseDueEntry, bookingId: 'bk-001', id: 'bk-001', technicianId: 'tech-A', partitionKey: 'tech-A', commissionDue: 5000, createdAt: '2026-05-01T08:00:00.000Z' },
+      { ...baseDueEntry, bookingId: 'bk-002', id: 'bk-002', technicianId: 'tech-A', partitionKey: 'tech-A', commissionDue: 3000, createdAt: '2026-05-03T08:00:00.000Z' },
+      { ...baseDueEntry, bookingId: 'bk-003', id: 'bk-003', technicianId: 'tech-B', partitionKey: 'tech-B', commissionDue: 7000, createdAt: '2026-05-02T08:00:00.000Z' },
+    ];
+    mockFetchAll.mockResolvedValue({ resources: entries });
+
+    const summaries = await commissionReceivableRepo.getAllTechnicianOutstandingSummaries();
+
+    expect(summaries).toHaveLength(2);
+
+    const techA = summaries.find((s) => s.technicianId === 'tech-A');
+    expect(techA).toBeDefined();
+    expect(techA!.dueCount).toBe(2);
+    expect(techA!.totalCommissionDue).toBe(8000);
+    expect(techA!.oldestDueAt).toBe('2026-05-01T08:00:00.000Z');
+
+    const techB = summaries.find((s) => s.technicianId === 'tech-B');
+    expect(techB).toBeDefined();
+    expect(techB!.dueCount).toBe(1);
+    expect(techB!.totalCommissionDue).toBe(7000);
+    expect(techB!.oldestDueAt).toBe('2026-05-02T08:00:00.000Z');
+  });
+
+  it('returns empty array when no DUE entries exist', async () => {
+    mockFetchAll.mockResolvedValue({ resources: [] });
+    const summaries = await commissionReceivableRepo.getAllTechnicianOutstandingSummaries();
+    expect(summaries).toHaveLength(0);
+  });
+
+  it('correctly picks oldestDueAt (min createdAt) across multiple entries', async () => {
+    const entries: CommissionReceivableEntry[] = [
+      { ...baseDueEntry, bookingId: 'bk-10', id: 'bk-10', technicianId: 'tech-C', partitionKey: 'tech-C', commissionDue: 1000, createdAt: '2026-05-10T00:00:00.000Z' },
+      { ...baseDueEntry, bookingId: 'bk-11', id: 'bk-11', technicianId: 'tech-C', partitionKey: 'tech-C', commissionDue: 2000, createdAt: '2026-04-01T00:00:00.000Z' },
+      { ...baseDueEntry, bookingId: 'bk-12', id: 'bk-12', technicianId: 'tech-C', partitionKey: 'tech-C', commissionDue: 500, createdAt: '2026-05-20T00:00:00.000Z' },
+    ];
+    mockFetchAll.mockResolvedValue({ resources: entries });
+
+    const summaries = await commissionReceivableRepo.getAllTechnicianOutstandingSummaries();
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]!.oldestDueAt).toBe('2026-04-01T00:00:00.000Z');
+    expect(summaries[0]!.totalCommissionDue).toBe(3500);
+    expect(summaries[0]!.dueCount).toBe(3);
+  });
+});

--- a/api/tests/functions/active-job.test.ts
+++ b/api/tests/functions/active-job.test.ts
@@ -296,4 +296,46 @@ describe('PATCH /v1/technicians/active-job/:bookingId/transition', () => {
     expect(res.status).toBe(200);
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
+
+  describe('E21-S01: cash collection on COMPLETED transition', () => {
+    it('sets cashCollectionStatus=COLLECTED when cashCollected=true', async () => {
+      const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+      const { bookingRepo, updateBookingFields } = await import('../../src/cosmos/booking-repository.js');
+      const { catalogueRepo } = await import('../../src/cosmos/catalogue-repository.js');
+
+      (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+      (bookingRepo.getById as MockFn).mockResolvedValue(aBooking('IN_PROGRESS'));
+      (updateBookingFields as MockFn).mockResolvedValue(aBooking('COMPLETED'));
+      (catalogueRepo.getServiceByIdCrossPartition as MockFn).mockResolvedValue(aService());
+
+      await transitionHandler(
+        makePatchReq('bk-1', { targetStatus: 'COMPLETED', cashCollected: true, collectedAmount: 50000 }),
+        new InvocationContext(),
+      );
+
+      const [, fields] = (updateBookingFields as MockFn).mock.calls[0] as [string, Record<string, unknown>];
+      expect(fields['cashCollectionStatus']).toBe('COLLECTED');
+      expect(fields['cashCollectedAt']).toBeDefined();
+      expect(fields['cashCollectedAmount']).toBe(50000);
+    });
+
+    it('does NOT set cashCollectionStatus when cashCollected is absent', async () => {
+      const { verifyTechnicianToken } = await import('../../src/middleware/verifyTechnicianToken.js');
+      const { bookingRepo, updateBookingFields } = await import('../../src/cosmos/booking-repository.js');
+      const { catalogueRepo } = await import('../../src/cosmos/catalogue-repository.js');
+
+      (verifyTechnicianToken as MockFn).mockResolvedValue({ uid: 'tech-1' });
+      (bookingRepo.getById as MockFn).mockResolvedValue(aBooking('IN_PROGRESS'));
+      (updateBookingFields as MockFn).mockResolvedValue(aBooking('COMPLETED'));
+      (catalogueRepo.getServiceByIdCrossPartition as MockFn).mockResolvedValue(aService());
+
+      await transitionHandler(
+        makePatchReq('bk-1', { targetStatus: 'COMPLETED' }),
+        new InvocationContext(),
+      );
+
+      const [, fields] = (updateBookingFields as MockFn).mock.calls[0] as [string, Record<string, unknown>];
+      expect(fields['cashCollectionStatus']).toBeUndefined();
+    });
+  });
 });

--- a/api/tests/functions/admin/catalogue/commission-config.test.ts
+++ b/api/tests/functions/admin/catalogue/commission-config.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HttpResponseInit } from '@azure/functions';
+import { HttpRequest } from '@azure/functions';
+
+vi.mock('../../../../src/cosmos/commission-config-repository.js');
+vi.mock('../../../../src/services/commission-config.service.js');
+
+import { commissionConfigRepo } from '../../../../src/cosmos/commission-config-repository.js';
+import * as configSvc from '../../../../src/services/commission-config.service.js';
+import {
+  getCommissionConfigHandler,
+  putCommissionConfigHandler,
+} from '../../../../src/functions/admin/catalogue/commission-config.js';
+
+const superAdmin = { adminId: 'admin-1', role: 'super-admin' as const, sessionId: 's1' };
+const financeAdmin = { adminId: 'admin-2', role: 'finance' as const, sessionId: 's2' };
+
+const configDoc = {
+  id: 'commission-config' as const,
+  defaultCommissionBps: 2200,
+  updatedBy: 'admin-1',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('getCommissionConfigHandler', () => {
+  const req = new HttpRequest({ url: 'http://localhost/api/v1/admin/catalogue/commission-config', method: 'GET' });
+
+  it('returns the stored config when a doc exists', async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue(configDoc);
+
+    const res = (await getCommissionConfigHandler(req, {} as never, superAdmin)) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { defaultCommissionBps: number }).defaultCommissionBps).toBe(2200);
+  });
+
+  it('returns default 2200 with isDefault=true when no config doc exists', async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue(null);
+
+    const res = (await getCommissionConfigHandler(req, {} as never, superAdmin)) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { defaultCommissionBps: number }).defaultCommissionBps).toBe(2200);
+    expect((res.jsonBody as { isDefault: boolean }).isDefault).toBe(true);
+  });
+
+  it('returns 502 on upstream error', async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockRejectedValue(new Error('timeout'));
+
+    const res = (await getCommissionConfigHandler(req, {} as never, superAdmin)) as HttpResponseInit;
+
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('putCommissionConfigHandler', () => {
+  function makePutReq(body: unknown): HttpRequest {
+    return new HttpRequest({
+      url: 'http://localhost/api/v1/admin/catalogue/commission-config',
+      method: 'PUT',
+      body: { string: JSON.stringify(body) },
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('updates config and busts the in-process cache', async () => {
+    vi.mocked(commissionConfigRepo.upsertCommissionConfig).mockResolvedValue({
+      ...configDoc, defaultCommissionBps: 2500,
+    });
+
+    const res = (await putCommissionConfigHandler(
+      makePutReq({ defaultCommissionBps: 2500 }),
+      {} as never,
+      superAdmin,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { defaultCommissionBps: number }).defaultCommissionBps).toBe(2500);
+    expect(configSvc._resetCommissionConfigCacheForTest).toHaveBeenCalled();
+  });
+
+  it('returns 400 for bps below minimum (1500)', async () => {
+    const res = (await putCommissionConfigHandler(
+      makePutReq({ defaultCommissionBps: 1000 }),
+      {} as never,
+      superAdmin,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 for bps above maximum (3500)', async () => {
+    const res = (await putCommissionConfigHandler(
+      makePutReq({ defaultCommissionBps: 4000 }),
+      {} as never,
+      superAdmin,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(400);
+  });
+
+  it('passes adminId to the repository upsert', async () => {
+    vi.mocked(commissionConfigRepo.upsertCommissionConfig).mockResolvedValue({
+      ...configDoc, updatedBy: 'admin-2',
+    });
+
+    await putCommissionConfigHandler(
+      makePutReq({ defaultCommissionBps: 2200 }),
+      {} as never,
+      financeAdmin,
+    );
+
+    expect(commissionConfigRepo.upsertCommissionConfig).toHaveBeenCalledWith(
+      2200,
+      'admin-2',
+    );
+  });
+
+  it('returns 502 on upstream error', async () => {
+    vi.mocked(commissionConfigRepo.upsertCommissionConfig).mockRejectedValue(new Error('timeout'));
+
+    const res = (await putCommissionConfigHandler(
+      makePutReq({ defaultCommissionBps: 2200 }),
+      {} as never,
+      superAdmin,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/api/tests/functions/admin/finance/commission-receivables.test.ts
+++ b/api/tests/functions/admin/finance/commission-receivables.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HttpResponseInit } from '@azure/functions';
+import { HttpRequest } from '@azure/functions';
+
+vi.mock('../../../../src/cosmos/commission-receivable-repository.js');
+vi.mock('../../../../src/cosmos/technician-repository.js');
+
+import { commissionReceivableRepo } from '../../../../src/cosmos/commission-receivable-repository.js';
+import * as techRepo from '../../../../src/cosmos/technician-repository.js';
+import {
+  adminCommissionReceivablesDashboardHandler,
+  adminCommissionReceivablesPerTechHandler,
+} from '../../../../src/functions/admin/finance/commission-receivables.js';
+
+const ctx = { adminId: 'a1', role: 'super-admin' as const, sessionId: 's1' };
+const getReq = (url = 'http://localhost/api/v1/admin/finance/commission-receivables') =>
+  new HttpRequest({ url, method: 'GET' });
+
+const sampleSummary = {
+  technicianId: 'tech-1',
+  dueCount: 2,
+  totalCommissionDue: 3300,
+  oldestDueAt: '2026-05-01T00:00:00.000Z',
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('adminCommissionReceivablesDashboardHandler', () => {
+  it('returns empty dashboard when no outstanding receivables', async () => {
+    vi.mocked(commissionReceivableRepo.getAllTechnicianOutstandingSummaries).mockResolvedValue([]);
+
+    const res = (await adminCommissionReceivablesDashboardHandler(
+      getReq(),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    expect((res.jsonBody as { technicians: unknown[] }).technicians).toHaveLength(0);
+    expect((res.jsonBody as { totalOutstanding: number }).totalOutstanding).toBe(0);
+  });
+
+  it('returns enriched summaries with technician names', async () => {
+    vi.mocked(commissionReceivableRepo.getAllTechnicianOutstandingSummaries).mockResolvedValue([
+      sampleSummary,
+    ]);
+    vi.mocked(techRepo.getTechniciansByIds).mockResolvedValue([
+      { technicianId: 'tech-1', id: 'tech-1', displayName: 'Ravi Kumar', name: '', rating: 4.5, isOnline: true, isAvailable: true },
+    ]);
+
+    const res = (await adminCommissionReceivablesDashboardHandler(
+      getReq(),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as { technicians: Array<{ technicianName: string; totalCommissionDue: number }>; totalOutstanding: number };
+    expect(body.technicians[0]?.technicianName).toBe('Ravi Kumar');
+    expect(body.totalOutstanding).toBe(3300);
+  });
+
+  it('falls back to technicianId as name when profile not found', async () => {
+    vi.mocked(commissionReceivableRepo.getAllTechnicianOutstandingSummaries).mockResolvedValue([
+      sampleSummary,
+    ]);
+    vi.mocked(techRepo.getTechniciansByIds).mockResolvedValue([]);
+
+    const res = (await adminCommissionReceivablesDashboardHandler(
+      getReq(),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    const body = res.jsonBody as { technicians: Array<{ technicianName: string }> };
+    expect(body.technicians[0]?.technicianName).toBe('tech-1');
+  });
+
+  it('returns 502 when repository throws', async () => {
+    vi.mocked(commissionReceivableRepo.getAllTechnicianOutstandingSummaries).mockRejectedValue(
+      new Error('cosmos timeout'),
+    );
+
+    const res = (await adminCommissionReceivablesDashboardHandler(
+      getReq(),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('adminCommissionReceivablesPerTechHandler', () => {
+  const makeTechReq = (techId: string) => {
+    const req = new HttpRequest({
+      url: `http://localhost/api/v1/admin/finance/commission-receivables/${techId}`,
+      method: 'GET',
+    });
+    Object.assign(req, { params: { technicianId: techId } });
+    return req;
+  };
+
+  it('returns DUE entries for the given technician', async () => {
+    vi.mocked(commissionReceivableRepo.getOutstandingByTechnician).mockResolvedValue([
+      {
+        id: 'booking-1', bookingId: 'booking-1', technicianId: 'tech-1', partitionKey: 'tech-1',
+        serviceId: 'svc-1', categoryId: 'cat-1', bookingAmount: 50000, commissionBps: 2200,
+        commissionDue: 11000, commissionResolvedFrom: 'GLOBAL', remittanceStatus: 'DUE',
+        createdAt: '2026-05-01T00:00:00.000Z',
+      },
+    ]);
+
+    const res = (await adminCommissionReceivablesPerTechHandler(
+      makeTechReq('tech-1'),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as { technicianId: string; entries: unknown[] };
+    expect(body.technicianId).toBe('tech-1');
+    expect(body.entries).toHaveLength(1);
+  });
+
+  it('returns 502 on upstream error', async () => {
+    vi.mocked(commissionReceivableRepo.getOutstandingByTechnician).mockRejectedValue(
+      new Error('timeout'),
+    );
+
+    const res = (await adminCommissionReceivablesPerTechHandler(
+      makeTechReq('tech-1'),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/api/tests/functions/admin/finance/mark-commission-received.test.ts
+++ b/api/tests/functions/admin/finance/mark-commission-received.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HttpResponseInit } from '@azure/functions';
+import { HttpRequest } from '@azure/functions';
+
+vi.mock('../../../../src/cosmos/commission-receivable-repository.js');
+vi.mock('../../../../src/cosmos/audit-log-repository.js');
+
+import { commissionReceivableRepo } from '../../../../src/cosmos/commission-receivable-repository.js';
+import { appendAuditEntry } from '../../../../src/cosmos/audit-log-repository.js';
+import { markCommissionReceivedHandler } from '../../../../src/functions/admin/finance/mark-commission-received.js';
+
+const ctx = { adminId: 'admin-1', role: 'finance' as const, sessionId: 's1' };
+
+const remittedEntry = {
+  id: 'booking-abc', bookingId: 'booking-abc', technicianId: 'tech-1', partitionKey: 'tech-1',
+  serviceId: 'svc-1', categoryId: 'cat-1', bookingAmount: 50000, commissionBps: 2200,
+  commissionDue: 11000, commissionResolvedFrom: 'GLOBAL' as const, remittanceStatus: 'REMITTED' as const,
+  remittedAmount: 11000, remittedAt: new Date().toISOString(), remittanceMethod: 'UPI' as const,
+  remittanceRef: 'upi-ref-1', markedByAdminId: 'admin-1', createdAt: new Date().toISOString(),
+};
+
+const waivedEntry = { ...remittedEntry, remittanceStatus: 'WAIVED' as const, waivedReason: 'customer dispute' };
+
+function makePostReq(body: unknown): HttpRequest {
+  const req = new HttpRequest({
+    url: 'http://localhost/api/v1/admin/finance/commission-receivables/settle',
+    method: 'POST',
+    body: { string: JSON.stringify(body) },
+    headers: { 'content-type': 'application/json' },
+  });
+  return req;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(appendAuditEntry).mockResolvedValue(undefined);
+});
+
+describe('markCommissionReceivedHandler', () => {
+  describe('REMIT action', () => {
+    it('returns 200 and marks receivable as remitted', async () => {
+      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(remittedEntry);
+
+      const res = (await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'REMIT',
+          bookingId: 'booking-abc',
+          technicianId: 'tech-1',
+          remittedAmount: 11000,
+          remittanceMethod: 'UPI',
+          remittanceRef: 'upi-ref-1',
+        }),
+        {} as never,
+        ctx,
+      )) as HttpResponseInit;
+
+      expect(res.status).toBe(200);
+      expect(commissionReceivableRepo.markRemitted).toHaveBeenCalledWith(
+        'booking-abc',
+        'tech-1',
+        expect.objectContaining({ remittedAmount: 11000, remittanceMethod: 'UPI', markedByAdminId: 'admin-1' }),
+      );
+    });
+
+    it('audits COMMISSION_REMITTED on success', async () => {
+      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(remittedEntry);
+
+      await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'REMIT', bookingId: 'booking-abc', technicianId: 'tech-1',
+          remittedAmount: 11000, remittanceMethod: 'UPI', remittanceRef: 'ref-1',
+        }),
+        {} as never,
+        ctx,
+      );
+
+      expect(appendAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'COMMISSION_REMITTED' }),
+      );
+    });
+
+    it('returns 404 when receivable not found', async () => {
+      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(null);
+
+      const res = (await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'REMIT', bookingId: 'booking-abc', technicianId: 'tech-1',
+          remittedAmount: 11000, remittanceMethod: 'UPI', remittanceRef: 'ref-1',
+        }),
+        {} as never,
+        ctx,
+      )) as HttpResponseInit;
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('WAIVE action', () => {
+    it('returns 200 and marks receivable as waived', async () => {
+      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue(waivedEntry);
+
+      const res = (await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'WAIVE',
+          bookingId: 'booking-abc',
+          technicianId: 'tech-1',
+          waivedReason: 'customer dispute',
+        }),
+        {} as never,
+        ctx,
+      )) as HttpResponseInit;
+
+      expect(res.status).toBe(200);
+      expect(commissionReceivableRepo.markWaived).toHaveBeenCalledWith(
+        'booking-abc',
+        'tech-1',
+        expect.objectContaining({ waivedReason: 'customer dispute', markedByAdminId: 'admin-1' }),
+      );
+    });
+
+    it('audits COMMISSION_WAIVED on success', async () => {
+      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue(waivedEntry);
+
+      await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'WAIVE', bookingId: 'booking-abc', technicianId: 'tech-1',
+          waivedReason: 'dispute',
+        }),
+        {} as never,
+        ctx,
+      );
+
+      expect(appendAuditEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'COMMISSION_WAIVED' }),
+      );
+    });
+  });
+
+  it('returns 400 on validation error (missing required field)', async () => {
+    const res = (await markCommissionReceivedHandler(
+      makePostReq({ action: 'REMIT', bookingId: 'booking-abc' }), // missing technicianId etc.
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(400);
+    expect((res.jsonBody as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 502 on upstream error', async () => {
+    vi.mocked(commissionReceivableRepo.markRemitted).mockRejectedValue(new Error('cosmos timeout'));
+
+    const res = (await markCommissionReceivedHandler(
+      makePostReq({
+        action: 'REMIT', bookingId: 'booking-abc', technicianId: 'tech-1',
+        remittedAmount: 11000, remittanceMethod: 'UPI', remittanceRef: 'ref-1',
+      }),
+      {} as never,
+      ctx,
+    )) as HttpResponseInit;
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/api/tests/functions/admin/finance/mark-commission-received.test.ts
+++ b/api/tests/functions/admin/finance/mark-commission-received.test.ts
@@ -11,15 +11,21 @@ import { markCommissionReceivedHandler } from '../../../../src/functions/admin/f
 
 const ctx = { adminId: 'admin-1', role: 'finance' as const, sessionId: 's1' };
 
-const remittedEntry = {
+const baseEntry = {
   id: 'booking-abc', bookingId: 'booking-abc', technicianId: 'tech-1', partitionKey: 'tech-1',
   serviceId: 'svc-1', categoryId: 'cat-1', bookingAmount: 50000, commissionBps: 2200,
-  commissionDue: 11000, commissionResolvedFrom: 'GLOBAL' as const, remittanceStatus: 'REMITTED' as const,
-  remittedAmount: 11000, remittedAt: new Date().toISOString(), remittanceMethod: 'UPI' as const,
-  remittanceRef: 'upi-ref-1', markedByAdminId: 'admin-1', createdAt: new Date().toISOString(),
+  commissionDue: 11000, commissionResolvedFrom: 'GLOBAL' as const,
+  createdAt: new Date().toISOString(),
 };
+const remittedEntry = {
+  ...baseEntry, remittanceStatus: 'REMITTED' as const,
+  remittedAmount: 11000, remittedAt: new Date().toISOString(), remittanceMethod: 'UPI' as const,
+  remittanceRef: 'upi-ref-1', markedByAdminId: 'admin-1',
+};
+const waivedEntry = { ...baseEntry, remittanceStatus: 'WAIVED' as const, waivedReason: 'customer dispute' };
 
-const waivedEntry = { ...remittedEntry, remittanceStatus: 'WAIVED' as const, waivedReason: 'customer dispute' };
+const remittedResult = { entry: remittedEntry, wasApplied: true };
+const waivedResult = { entry: waivedEntry, wasApplied: true };
 
 function makePostReq(body: unknown): HttpRequest {
   const req = new HttpRequest({
@@ -39,7 +45,7 @@ beforeEach(() => {
 describe('markCommissionReceivedHandler', () => {
   describe('REMIT action', () => {
     it('returns 200 and marks receivable as remitted', async () => {
-      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(remittedEntry);
+      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(remittedResult);
 
       const res = (await markCommissionReceivedHandler(
         makePostReq({
@@ -62,8 +68,8 @@ describe('markCommissionReceivedHandler', () => {
       );
     });
 
-    it('audits COMMISSION_REMITTED on success', async () => {
-      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(remittedEntry);
+    it('audits COMMISSION_REMITTED when wasApplied=true', async () => {
+      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue(remittedResult);
 
       await markCommissionReceivedHandler(
         makePostReq({
@@ -77,6 +83,39 @@ describe('markCommissionReceivedHandler', () => {
       expect(appendAuditEntry).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'COMMISSION_REMITTED' }),
       );
+    });
+
+    it('does not audit when wasApplied=false (already settled)', async () => {
+      vi.mocked(commissionReceivableRepo.markRemitted).mockResolvedValue({ entry: remittedEntry, wasApplied: false });
+
+      await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'REMIT', bookingId: 'booking-abc', technicianId: 'tech-1',
+          remittedAmount: 11000, remittanceMethod: 'UPI', remittanceRef: 'ref-1',
+        }),
+        {} as never,
+        ctx,
+      );
+
+      expect(appendAuditEntry).not.toHaveBeenCalled();
+    });
+
+    it('returns 422 when remittedAmount is below commissionDue', async () => {
+      vi.mocked(commissionReceivableRepo.markRemitted).mockRejectedValue(
+        Object.assign(new Error('AMOUNT_BELOW_DUE'), { code: 'AMOUNT_BELOW_DUE' }),
+      );
+
+      const res = (await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'REMIT', bookingId: 'booking-abc', technicianId: 'tech-1',
+          remittedAmount: 5000, remittanceMethod: 'UPI', remittanceRef: 'ref-1',
+        }),
+        {} as never,
+        ctx,
+      )) as HttpResponseInit;
+
+      expect(res.status).toBe(422);
+      expect((res.jsonBody as { code: string }).code).toBe('AMOUNT_BELOW_DUE');
     });
 
     it('returns 404 when receivable not found', async () => {
@@ -97,7 +136,7 @@ describe('markCommissionReceivedHandler', () => {
 
   describe('WAIVE action', () => {
     it('returns 200 and marks receivable as waived', async () => {
-      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue(waivedEntry);
+      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue(waivedResult);
 
       const res = (await markCommissionReceivedHandler(
         makePostReq({
@@ -118,8 +157,8 @@ describe('markCommissionReceivedHandler', () => {
       );
     });
 
-    it('audits COMMISSION_WAIVED on success', async () => {
-      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue(waivedEntry);
+    it('audits COMMISSION_WAIVED when wasApplied=true', async () => {
+      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue(waivedResult);
 
       await markCommissionReceivedHandler(
         makePostReq({
@@ -133,6 +172,21 @@ describe('markCommissionReceivedHandler', () => {
       expect(appendAuditEntry).toHaveBeenCalledWith(
         expect.objectContaining({ action: 'COMMISSION_WAIVED' }),
       );
+    });
+
+    it('does not audit when wasApplied=false (already settled)', async () => {
+      vi.mocked(commissionReceivableRepo.markWaived).mockResolvedValue({ entry: waivedEntry, wasApplied: false });
+
+      await markCommissionReceivedHandler(
+        makePostReq({
+          action: 'WAIVE', bookingId: 'booking-abc', technicianId: 'tech-1',
+          waivedReason: 'dispute',
+        }),
+        {} as never,
+        ctx,
+      );
+
+      expect(appendAuditEntry).not.toHaveBeenCalled();
     });
   });
 

--- a/api/tests/functions/technicians/commission-due.test.ts
+++ b/api/tests/functions/technicians/commission-due.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HttpResponseInit } from '@azure/functions';
+import { HttpRequest } from '@azure/functions';
+
+vi.mock('../../../src/middleware/verifyTechnicianToken.js', () => ({
+  verifyTechnicianToken: vi.fn(),
+}));
+vi.mock('../../../src/cosmos/commission-receivable-repository.js');
+
+import { verifyTechnicianToken } from '../../../src/middleware/verifyTechnicianToken.js';
+import { commissionReceivableRepo } from '../../../src/cosmos/commission-receivable-repository.js';
+import { techCommissionDueHandler } from '../../../src/functions/technicians/commission-due.js';
+
+const req = new HttpRequest({
+  url: 'http://localhost/api/v1/technicians/me/commission-due',
+  method: 'GET',
+  headers: { authorization: 'Bearer test-token' },
+});
+
+const dueEntry = {
+  id: 'booking-1', bookingId: 'booking-1', technicianId: 'tech-1', partitionKey: 'tech-1',
+  serviceId: 'svc-1', categoryId: 'cat-1', bookingAmount: 50000, commissionBps: 2200,
+  commissionDue: 11000, commissionResolvedFrom: 'GLOBAL' as const, remittanceStatus: 'DUE' as const,
+  createdAt: '2026-05-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(verifyTechnicianToken).mockResolvedValue({ uid: 'tech-1' } as never);
+});
+
+describe('techCommissionDueHandler', () => {
+  it('returns outstanding commissions with totals', async () => {
+    vi.mocked(commissionReceivableRepo.getOutstandingByTechnician).mockResolvedValue([dueEntry]);
+
+    const res = (await techCommissionDueHandler(req, {} as never)) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as { totalOutstandingPaise: number; dueCount: number; entries: unknown[] };
+    expect(body.totalOutstandingPaise).toBe(11000);
+    expect(body.dueCount).toBe(1);
+    expect(body.entries).toHaveLength(1);
+  });
+
+  it('returns zero totals when no outstanding entries', async () => {
+    vi.mocked(commissionReceivableRepo.getOutstandingByTechnician).mockResolvedValue([]);
+
+    const res = (await techCommissionDueHandler(req, {} as never)) as HttpResponseInit;
+
+    expect(res.status).toBe(200);
+    const body = res.jsonBody as { totalOutstandingPaise: number; dueCount: number };
+    expect(body.totalOutstandingPaise).toBe(0);
+    expect(body.dueCount).toBe(0);
+  });
+
+  it('sums multiple outstanding entries', async () => {
+    const entry2 = { ...dueEntry, bookingId: 'booking-2', id: 'booking-2', commissionDue: 5500 };
+    vi.mocked(commissionReceivableRepo.getOutstandingByTechnician).mockResolvedValue([dueEntry, entry2]);
+
+    const res = (await techCommissionDueHandler(req, {} as never)) as HttpResponseInit;
+
+    const body = res.jsonBody as { totalOutstandingPaise: number; dueCount: number };
+    expect(body.totalOutstandingPaise).toBe(16500); // 11000 + 5500
+    expect(body.dueCount).toBe(2);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    vi.mocked(verifyTechnicianToken).mockRejectedValue(new Error('invalid token'));
+
+    const res = (await techCommissionDueHandler(req, {} as never)) as HttpResponseInit;
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 502 on upstream error', async () => {
+    vi.mocked(commissionReceivableRepo.getOutstandingByTechnician).mockRejectedValue(
+      new Error('cosmos timeout'),
+    );
+
+    const res = (await techCommissionDueHandler(req, {} as never)) as HttpResponseInit;
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/api/tests/schemas/commission-config.test.ts
+++ b/api/tests/schemas/commission-config.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COMMISSION_CONFIG_DOC_ID,
+  CommissionConfigDocSchema,
+  UpdateCommissionConfigBodySchema,
+  CommissionResolvedFromSchema,
+} from '../../src/schemas/commission-config.js';
+
+const validDoc = {
+  id: COMMISSION_CONFIG_DOC_ID,
+  defaultCommissionBps: 2200,
+  updatedBy: 'uid-123',
+  updatedAt: '2026-05-24T00:00:00.000Z',
+};
+
+describe('CommissionConfigDocSchema', () => {
+  it('parses a valid config doc', () => {
+    expect(() => CommissionConfigDocSchema.parse(validDoc)).not.toThrow();
+  });
+
+  it('forces the fixed singleton id', () => {
+    expect(() => CommissionConfigDocSchema.parse({ ...validDoc, id: 'other' })).toThrow();
+  });
+
+  it('rejects bps below 1500', () => {
+    expect(() => CommissionConfigDocSchema.parse({ ...validDoc, defaultCommissionBps: 1499 })).toThrow();
+  });
+
+  it('rejects bps above 3500', () => {
+    expect(() => CommissionConfigDocSchema.parse({ ...validDoc, defaultCommissionBps: 3501 })).toThrow();
+  });
+
+  it('rejects non-integer bps', () => {
+    expect(() => CommissionConfigDocSchema.parse({ ...validDoc, defaultCommissionBps: 2200.5 })).toThrow();
+  });
+
+  it('rejects unknown keys (strict)', () => {
+    expect(() => CommissionConfigDocSchema.parse({ ...validDoc, extra: true })).toThrow();
+  });
+});
+
+describe('UpdateCommissionConfigBodySchema', () => {
+  it('accepts a valid default bps', () => {
+    expect(() => UpdateCommissionConfigBodySchema.parse({ defaultCommissionBps: 2500 })).not.toThrow();
+  });
+
+  it('rejects out-of-range bps', () => {
+    expect(() => UpdateCommissionConfigBodySchema.parse({ defaultCommissionBps: 5000 })).toThrow();
+  });
+
+  it('rejects extra fields (strict)', () => {
+    expect(() =>
+      UpdateCommissionConfigBodySchema.parse({ defaultCommissionBps: 2200, updatedBy: 'x' }),
+    ).toThrow();
+  });
+});
+
+describe('CommissionResolvedFromSchema', () => {
+  it('accepts SERVICE, CATEGORY, GLOBAL', () => {
+    expect(CommissionResolvedFromSchema.parse('SERVICE')).toBe('SERVICE');
+    expect(CommissionResolvedFromSchema.parse('CATEGORY')).toBe('CATEGORY');
+    expect(CommissionResolvedFromSchema.parse('GLOBAL')).toBe('GLOBAL');
+  });
+
+  it('rejects unknown source', () => {
+    expect(() => CommissionResolvedFromSchema.parse('DEFAULT')).toThrow();
+  });
+});

--- a/api/tests/schemas/commission-receivable.test.ts
+++ b/api/tests/schemas/commission-receivable.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CommissionReceivableEntrySchema,
+  MarkCommissionReceivedBodySchema,
+  TechnicianOutstandingSummarySchema,
+} from '../../src/schemas/commission-receivable.js';
+
+const validEntry = {
+  id: 'booking-1',
+  bookingId: 'booking-1',
+  technicianId: 'tech-1',
+  partitionKey: 'tech-1',
+  serviceId: 'ac-deep-clean',
+  categoryId: 'ac-repair',
+  bookingAmount: 59900,
+  commissionBps: 2250,
+  commissionDue: 13478,
+  commissionResolvedFrom: 'SERVICE' as const,
+  remittanceStatus: 'DUE' as const,
+  createdAt: '2026-05-24T00:00:00.000Z',
+};
+
+describe('CommissionReceivableEntrySchema', () => {
+  it('parses a valid DUE entry', () => {
+    expect(() => CommissionReceivableEntrySchema.parse(validEntry)).not.toThrow();
+  });
+
+  it('parses a REMITTED entry with remittance fields', () => {
+    expect(() =>
+      CommissionReceivableEntrySchema.parse({
+        ...validEntry,
+        remittanceStatus: 'REMITTED',
+        remittedAmount: 13478,
+        remittedAt: '2026-05-25T00:00:00.000Z',
+        remittanceRef: 'upi-txn-abc',
+        remittanceMethod: 'UPI',
+        markedByAdminId: 'admin-1',
+        updatedAt: '2026-05-25T00:00:00.000Z',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an unknown remittance status', () => {
+    expect(() =>
+      CommissionReceivableEntrySchema.parse({ ...validEntry, remittanceStatus: 'PAID' }),
+    ).toThrow();
+  });
+
+  it('rejects commission bps out of range', () => {
+    expect(() =>
+      CommissionReceivableEntrySchema.parse({ ...validEntry, commissionBps: 100 }),
+    ).toThrow();
+  });
+
+  it('rejects negative commissionDue', () => {
+    expect(() =>
+      CommissionReceivableEntrySchema.parse({ ...validEntry, commissionDue: -1 }),
+    ).toThrow();
+  });
+});
+
+describe('MarkCommissionReceivedBodySchema', () => {
+  it('accepts a REMIT action', () => {
+    expect(() =>
+      MarkCommissionReceivedBodySchema.parse({
+        action: 'REMIT',
+        bookingId: 'booking-1',
+        technicianId: 'tech-1',
+        remittedAmount: 13478,
+        remittanceMethod: 'UPI',
+        remittanceRef: 'upi-txn-abc',
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts a WAIVE action', () => {
+    expect(() =>
+      MarkCommissionReceivedBodySchema.parse({
+        action: 'WAIVE',
+        bookingId: 'booking-1',
+        technicianId: 'tech-1',
+        waivedReason: 'goodwill — first job',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects REMIT without a remittance ref', () => {
+    expect(() =>
+      MarkCommissionReceivedBodySchema.parse({
+        action: 'REMIT',
+        bookingId: 'booking-1',
+        technicianId: 'tech-1',
+        remittedAmount: 13478,
+        remittanceMethod: 'UPI',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects WAIVE without a reason', () => {
+    expect(() =>
+      MarkCommissionReceivedBodySchema.parse({
+        action: 'WAIVE',
+        bookingId: 'booking-1',
+        technicianId: 'tech-1',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects an unknown action', () => {
+    expect(() =>
+      MarkCommissionReceivedBodySchema.parse({ action: 'CANCEL', bookingId: 'b', technicianId: 't' }),
+    ).toThrow();
+  });
+});
+
+describe('TechnicianOutstandingSummarySchema', () => {
+  it('parses a summary row', () => {
+    expect(() =>
+      TechnicianOutstandingSummarySchema.parse({
+        technicianId: 'tech-1',
+        technicianName: 'Ramesh',
+        dueCount: 3,
+        totalCommissionDue: 40000,
+        oldestDueAt: '2026-05-20T00:00:00.000Z',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/api/tests/schemas/service-category.test.ts
+++ b/api/tests/schemas/service-category.test.ts
@@ -31,6 +31,22 @@ describe('ServiceCategorySchema', () => {
       ServiceCategorySchema.parse({ ...validCategory, heroImageUrl: 'not-a-url' })
     ).toThrow();
   });
+
+  it('accepts an optional commissionBps override in range', () => {
+    expect(() =>
+      ServiceCategorySchema.parse({ ...validCategory, commissionBps: 2000 })
+    ).not.toThrow();
+  });
+
+  it('parses with commissionBps absent (falls through to global)', () => {
+    expect(() => ServiceCategorySchema.parse(validCategory)).not.toThrow();
+  });
+
+  it('rejects commissionBps out of range', () => {
+    expect(() =>
+      ServiceCategorySchema.parse({ ...validCategory, commissionBps: 100 })
+    ).toThrow();
+  });
 });
 
 describe('CreateCategoryBodySchema', () => {

--- a/api/tests/unit/commission-config.service.test.ts
+++ b/api/tests/unit/commission-config.service.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (must come before imports) ──────────────────────────────────────────
+
+vi.mock('../../src/cosmos/commission-config-repository.js', () => ({
+  commissionConfigRepo: {
+    getCommissionConfig: vi.fn(),
+  },
+}));
+
+vi.mock('@sentry/node', () => ({ captureMessage: vi.fn(), captureException: vi.fn() }));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import {
+  resolveCommissionBps,
+  getGlobalCommissionBps,
+  DEFAULT_COMMISSION_BPS,
+  _resetCommissionConfigCacheForTest,
+} from '../../src/services/commission-config.service.js';
+import { commissionConfigRepo } from '../../src/cosmos/commission-config-repository.js';
+
+// ── resolveCommissionBps ──────────────────────────────────────────────────────
+
+describe('resolveCommissionBps', () => {
+  it('resolves from SERVICE when serviceBps is valid', () => {
+    const result = resolveCommissionBps({ serviceBps: 2000, categoryBps: 2500, globalBps: 3000 });
+    expect(result).toEqual({ bps: 2000, from: 'SERVICE' });
+  });
+
+  it('falls through to CATEGORY when serviceBps is undefined', () => {
+    const result = resolveCommissionBps({ categoryBps: 2500, globalBps: 3000 });
+    expect(result).toEqual({ bps: 2500, from: 'CATEGORY' });
+  });
+
+  it('falls through to GLOBAL when both serviceBps and categoryBps are undefined', () => {
+    const result = resolveCommissionBps({ globalBps: 2200 });
+    expect(result).toEqual({ bps: 2200, from: 'GLOBAL' });
+  });
+
+  it('falls through to CATEGORY when serviceBps is below minimum (invalid)', () => {
+    const result = resolveCommissionBps({ serviceBps: 1000, categoryBps: 2500, globalBps: 3000 });
+    expect(result).toEqual({ bps: 2500, from: 'CATEGORY' });
+  });
+
+  it('falls through to CATEGORY when serviceBps is above maximum (invalid)', () => {
+    const result = resolveCommissionBps({ serviceBps: 4000, categoryBps: 2500, globalBps: 3000 });
+    expect(result).toEqual({ bps: 2500, from: 'CATEGORY' });
+  });
+
+  it('falls through to CATEGORY when serviceBps is not an integer (invalid)', () => {
+    const result = resolveCommissionBps({ serviceBps: 20.5, categoryBps: 2500, globalBps: 3000 });
+    expect(result).toEqual({ bps: 2500, from: 'CATEGORY' });
+  });
+
+  it('falls through to GLOBAL when categoryBps is invalid', () => {
+    const result = resolveCommissionBps({ categoryBps: 500, globalBps: 2200 });
+    expect(result).toEqual({ bps: 2200, from: 'GLOBAL' });
+  });
+
+  it('falls through to GLOBAL when categoryBps is not an integer', () => {
+    const result = resolveCommissionBps({ categoryBps: 25.5, globalBps: 2200 });
+    expect(result).toEqual({ bps: 2200, from: 'GLOBAL' });
+  });
+
+  it('throws when globalBps is out of range', () => {
+    expect(() => resolveCommissionBps({ globalBps: 1000 })).toThrow(
+      'commission config invalid: globalBps out of range',
+    );
+  });
+
+  it('throws when globalBps is above maximum', () => {
+    expect(() => resolveCommissionBps({ globalBps: 4000 })).toThrow(
+      'commission config invalid: globalBps out of range',
+    );
+  });
+
+  it('throws when globalBps is not an integer', () => {
+    expect(() => resolveCommissionBps({ globalBps: 22.5 })).toThrow(
+      'commission config invalid: globalBps out of range',
+    );
+  });
+
+  it('accepts boundary value MIN (1500) as valid', () => {
+    const result = resolveCommissionBps({ globalBps: 1500 });
+    expect(result).toEqual({ bps: 1500, from: 'GLOBAL' });
+  });
+
+  it('accepts boundary value MAX (3500) as valid', () => {
+    const result = resolveCommissionBps({ serviceBps: 3500, globalBps: 2200 });
+    expect(result).toEqual({ bps: 3500, from: 'SERVICE' });
+  });
+
+  it('returns correct from field for each resolved source', () => {
+    expect(resolveCommissionBps({ serviceBps: 2000, globalBps: 2200 }).from).toBe('SERVICE');
+    expect(resolveCommissionBps({ categoryBps: 2000, globalBps: 2200 }).from).toBe('CATEGORY');
+    expect(resolveCommissionBps({ globalBps: 2200 }).from).toBe('GLOBAL');
+  });
+});
+
+// ── getGlobalCommissionBps ────────────────────────────────────────────────────
+
+describe('getGlobalCommissionBps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    _resetCommissionConfigCacheForTest();
+  });
+
+  it('returns defaultCommissionBps from the doc when the repo returns a doc', async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue({
+      id: 'commission-config',
+      defaultCommissionBps: 2500,
+      updatedBy: 'admin',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+    });
+
+    const bps = await getGlobalCommissionBps();
+    expect(bps).toBe(2500);
+  });
+
+  it(`returns DEFAULT_COMMISSION_BPS (${DEFAULT_COMMISSION_BPS}) when repo returns null`, async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue(null);
+
+    const bps = await getGlobalCommissionBps();
+    expect(bps).toBe(DEFAULT_COMMISSION_BPS);
+    expect(DEFAULT_COMMISSION_BPS).toBe(2200);
+  });
+
+  it('caches the result so the repo is only called once', async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue({
+      id: 'commission-config',
+      defaultCommissionBps: 2800,
+      updatedBy: 'admin',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+    });
+
+    const first = await getGlobalCommissionBps();
+    const second = await getGlobalCommissionBps();
+
+    expect(first).toBe(2800);
+    expect(second).toBe(2800);
+    expect(vi.mocked(commissionConfigRepo.getCommissionConfig)).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after cache reset', async () => {
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue({
+      id: 'commission-config',
+      defaultCommissionBps: 2800,
+      updatedBy: 'admin',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+    });
+
+    await getGlobalCommissionBps();
+    _resetCommissionConfigCacheForTest();
+    await getGlobalCommissionBps();
+
+    expect(vi.mocked(commissionConfigRepo.getCommissionConfig)).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-fetches after TTL expires', async () => {
+    vi.useFakeTimers();
+    const NOW = Date.now();
+    vi.setSystemTime(NOW);
+
+    vi.mocked(commissionConfigRepo.getCommissionConfig).mockResolvedValue({
+      id: 'commission-config',
+      defaultCommissionBps: 2800,
+      updatedBy: 'admin',
+      updatedAt: '2026-05-24T00:00:00.000Z',
+    });
+
+    await getGlobalCommissionBps();
+
+    // Advance time past TTL (5 minutes)
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    await getGlobalCommissionBps();
+    expect(vi.mocked(commissionConfigRepo.getCommissionConfig)).toHaveBeenCalledTimes(2);
+  });
+});

--- a/api/tests/unit/commission.service.test.ts
+++ b/api/tests/unit/commission.service.test.ts
@@ -2,39 +2,42 @@ import { describe, it, expect } from 'vitest';
 import { calculateCommission } from '../../src/services/commission.service.js';
 
 describe('calculateCommission', () => {
-  it('applies 22% (2200 bps) when completedJobCount is 0', () => {
-    const result = calculateCommission(0, 10000);
+  it('computes commission for 2200 bps on 10000 paise', () => {
+    const result = calculateCommission(10000, 2200);
     expect(result).toEqual({ commissionBps: 2200, commissionAmount: 2200, techAmount: 7800 });
   });
 
-  it('applies 22% (2200 bps) when completedJobCount is 49', () => {
-    const result = calculateCommission(49, 10000);
-    expect(result).toEqual({ commissionBps: 2200, commissionAmount: 2200, techAmount: 7800 });
-  });
-
-  it('applies 25% (2500 bps) when completedJobCount is exactly 50', () => {
-    const result = calculateCommission(50, 10000);
+  it('computes commission for 2500 bps on 10000 paise', () => {
+    const result = calculateCommission(10000, 2500);
     expect(result).toEqual({ commissionBps: 2500, commissionAmount: 2500, techAmount: 7500 });
   });
 
-  it('applies 25% (2500 bps) when completedJobCount is above 50', () => {
-    const result = calculateCommission(99, 50000);
+  it('computes commission for 2500 bps on 50000 paise', () => {
+    const result = calculateCommission(50000, 2500);
     expect(result).toEqual({ commissionBps: 2500, commissionAmount: 12500, techAmount: 37500 });
   });
 
   it('rounds commission to nearest integer paise', () => {
-    // 9999 * 0.22 = 2199.78 → rounds to 2200; techAmount = 7799
-    const result = calculateCommission(0, 9999);
+    // 9999 * 2200 / 10000 = 2199.78 → rounds to 2200; techAmount = 7799
+    const result = calculateCommission(9999, 2200);
     expect(result.commissionAmount).toBe(2200);
     expect(result.techAmount).toBe(7799);
     expect(result.commissionAmount + result.techAmount).toBe(9999);
   });
 
-  it('techAmount + commissionAmount always equals bookingAmount', () => {
+  it('rounds down when fractional part < 0.5', () => {
+    // 10001 * 2200 / 10000 = 2200.22 → rounds to 2200; techAmount = 7801
+    const result = calculateCommission(10001, 2200);
+    expect(result.commissionAmount).toBe(2200);
+    expect(result.techAmount).toBe(7801);
+    expect(result.commissionAmount + result.techAmount).toBe(10001);
+  });
+
+  it('commissionAmount + techAmount always equals bookingAmountPaise', () => {
     for (const amount of [1, 100, 9999, 50000, 99999, 500000]) {
-      const r22 = calculateCommission(0, amount);
+      const r22 = calculateCommission(amount, 2200);
       expect(r22.commissionAmount + r22.techAmount).toBe(amount);
-      const r25 = calculateCommission(50, amount);
+      const r25 = calculateCommission(amount, 2500);
       expect(r25.commissionAmount + r25.techAmount).toBe(amount);
     }
   });

--- a/api/tests/unit/trigger-booking-completed.test.ts
+++ b/api/tests/unit/trigger-booking-completed.test.ts
@@ -1,22 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { InvocationContext } from '@azure/functions';
 
+vi.mock('../../src/cosmos/commission-receivable-repository.js');
 vi.mock('../../src/cosmos/wallet-ledger-repository.js');
 vi.mock('../../src/cosmos/technician-repository.js');
 vi.mock('../../src/cosmos/audit-log-repository.js');
+vi.mock('../../src/cosmos/catalogue-repository.js');
+vi.mock('../../src/services/commission-config.service.js');
 vi.mock('../../src/services/fcm.service.js');
 vi.mock('../../src/services/razorpayRoute.service.js');
 
 import { settleBooking } from '../../src/functions/trigger-booking-completed.js';
+import { commissionReceivableRepo } from '../../src/cosmos/commission-receivable-repository.js';
 import { walletLedgerRepo } from '../../src/cosmos/wallet-ledger-repository.js';
 import * as techRepo from '../../src/cosmos/technician-repository.js';
 import * as auditRepo from '../../src/cosmos/audit-log-repository.js';
+import { catalogueRepo } from '../../src/cosmos/catalogue-repository.js';
+import * as configSvc from '../../src/services/commission-config.service.js';
 import * as fcmService from '../../src/services/fcm.service.js';
 import { RazorpayRouteService } from '../../src/services/razorpayRoute.service.js';
 
 const mockCtx = { log: vi.fn() } as unknown as InvocationContext;
 
-const completedBooking = {
+const cashBooking = {
   id: 'booking-abc',
   customerId: 'customer-1',
   serviceId: 'svc-1',
@@ -27,6 +33,7 @@ const completedBooking = {
   addressLatLng: { lat: 12.9, lng: 77.6 },
   status: 'COMPLETED',
   paymentOrderId: 'order-1',
+  paymentMethod: 'CASH_ON_SERVICE',
   paymentId: 'pay-1',
   paymentSignature: 'sig-1',
   amount: 50000,
@@ -38,6 +45,16 @@ const mockTransfer = vi.fn();
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  // CASH path defaults
+  vi.mocked(commissionReceivableRepo.getByBookingId).mockResolvedValue(null);
+  vi.mocked(commissionReceivableRepo.createDueEntry).mockResolvedValue(true);
+  vi.mocked(configSvc.getGlobalCommissionBps).mockResolvedValue(2200);
+  vi.mocked(configSvc.resolveCommissionBps).mockReturnValue({ bps: 2200, from: 'GLOBAL' });
+  vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(null);
+  vi.mocked(catalogueRepo.getCategoryById).mockResolvedValue(null);
+
+  // Razorpay path defaults
   vi.mocked(walletLedgerRepo.getByBookingId).mockResolvedValue(null);
   vi.mocked(walletLedgerRepo.createPendingEntry).mockResolvedValue(true);
   vi.mocked(walletLedgerRepo.markPaid).mockResolvedValue(undefined);
@@ -46,8 +63,10 @@ beforeEach(() => {
     id: 'tech-1',
     completedJobCount: 5,
     razorpayLinkedAccountId: 'acc-rp-1',
-    payoutCadence: 'INSTANT', // default for existing tests: immediate transfer behaviour
+    payoutCadence: 'INSTANT',
   });
+
+  // Shared defaults
   vi.mocked(techRepo.incrementCompletedJobCount).mockResolvedValue(undefined);
   vi.mocked(auditRepo.appendAuditEntry).mockResolvedValue(undefined);
   vi.mocked(fcmService.sendTechEarningsUpdate).mockResolvedValue(undefined);
@@ -57,326 +76,246 @@ beforeEach(() => {
   }) as unknown as RazorpayRouteService);
 });
 
-describe('settleBooking', () => {
-  it('skips documents that are not COMPLETED status', async () => {
-    await settleBooking({ ...completedBooking, status: 'IN_PROGRESS' }, mockCtx);
+describe('settleBooking — common guards', () => {
+  it('skips non-COMPLETED status', async () => {
+    await settleBooking({ ...cashBooking, status: 'IN_PROGRESS' }, mockCtx);
+    expect(commissionReceivableRepo.createDueEntry).not.toHaveBeenCalled();
     expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
-    expect(mockTransfer).not.toHaveBeenCalled();
   });
 
   it('skips malformed documents silently', async () => {
     await settleBooking({ invalid: true }, mockCtx);
-    expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
+    expect(commissionReceivableRepo.createDueEntry).not.toHaveBeenCalled();
   });
 
   it('skips COMPLETED booking with no technicianId', async () => {
-    const noTech = { ...completedBooking, technicianId: undefined };
-    await settleBooking(noTech, mockCtx);
+    await settleBooking({ ...cashBooking, technicianId: undefined }, mockCtx);
+    expect(commissionReceivableRepo.createDueEntry).not.toHaveBeenCalled();
+  });
+});
+
+describe('settleBooking — CASH_ON_SERVICE path (pilot)', () => {
+  it('creates a DUE commission receivable with global bps when no service/category override', async () => {
+    await settleBooking(cashBooking, mockCtx);
+
+    expect(commissionReceivableRepo.createDueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bookingId: 'booking-abc',
+        technicianId: 'tech-1',
+        serviceId: 'svc-1',
+        categoryId: 'cat-1',
+        bookingAmount: 50000,
+        commissionBps: 2200,
+        commissionDue: 11000,
+        commissionResolvedFrom: 'GLOBAL',
+      }),
+    );
+  });
+
+  it('resolves service-level bps when service has commissionBps override', async () => {
+    vi.mocked(configSvc.resolveCommissionBps).mockReturnValue({ bps: 2500, from: 'SERVICE' });
+    vi.mocked(catalogueRepo.getServiceByIdCrossPartition).mockResolvedValue(
+      { commissionBps: 2500 } as never,
+    );
+
+    await settleBooking(cashBooking, mockCtx);
+
+    expect(commissionReceivableRepo.createDueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ commissionBps: 2500, commissionDue: 12500, commissionResolvedFrom: 'SERVICE' }),
+    );
+  });
+
+  it('resolves category-level bps when category has override but service does not', async () => {
+    vi.mocked(configSvc.resolveCommissionBps).mockReturnValue({ bps: 3000, from: 'CATEGORY' });
+    vi.mocked(catalogueRepo.getCategoryById).mockResolvedValue(
+      { commissionBps: 3000 } as never,
+    );
+
+    await settleBooking(cashBooking, mockCtx);
+
+    expect(commissionReceivableRepo.createDueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ commissionBps: 3000, commissionDue: 15000, commissionResolvedFrom: 'CATEGORY' }),
+    );
+  });
+
+  it('passes cashCollectedAmount to createDueEntry when present on booking', async () => {
+    await settleBooking({ ...cashBooking, cashCollectedAmount: 50000 }, mockCtx);
+
+    expect(commissionReceivableRepo.createDueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ cashCollectedAmount: 50000 }),
+    );
+  });
+
+  it('uses finalAmount over amount for commissionDue calculation', async () => {
+    // finalAmount=60000 at 2200 bps → commissionDue = round(60000*2200/10000) = 13200
+    await settleBooking({ ...cashBooking, finalAmount: 60000, amount: 50000 }, mockCtx);
+
+    expect(commissionReceivableRepo.createDueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ bookingAmount: 60000, commissionDue: 13200 }),
+    );
+  });
+
+  it('does NOT call RazorpayRouteService or walletLedgerRepo', async () => {
+    await settleBooking(cashBooking, mockCtx);
+    expect(RazorpayRouteService).not.toHaveBeenCalled();
+    expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
+  });
+
+  it('audits COMMISSION_DUE_RECORDED on success', async () => {
+    await settleBooking(cashBooking, mockCtx);
+
+    const auditCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
+      ([entry]) => entry.action === 'COMMISSION_DUE_RECORDED',
+    );
+    expect(auditCall).toBeDefined();
+  });
+
+  it('increments completedJobCount and sends FCM earnings update on success', async () => {
+    await settleBooking(cashBooking, mockCtx);
+    expect(techRepo.incrementCompletedJobCount).toHaveBeenCalledWith('tech-1');
+    expect(fcmService.sendTechEarningsUpdate).toHaveBeenCalledWith(
+      'tech-1',
+      expect.objectContaining({ bookingId: 'booking-abc', commissionDue: 11000 }),
+    );
+  });
+
+  it('treats undefined paymentMethod as CASH_ON_SERVICE', async () => {
+    const noMethod = { ...cashBooking, paymentMethod: undefined };
+    await settleBooking(noMethod, mockCtx);
+
+    expect(commissionReceivableRepo.createDueEntry).toHaveBeenCalled();
     expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
   });
 
   describe('idempotency', () => {
-    it('double-fire: second call does NOT create entry or call Razorpay when entry is PAID', async () => {
-      vi.mocked(walletLedgerRepo.getByBookingId).mockResolvedValue({
+    it('skips when commission receivable already exists (double-fire)', async () => {
+      vi.mocked(commissionReceivableRepo.getByBookingId).mockResolvedValue({
         id: 'booking-abc',
         bookingId: 'booking-abc',
         technicianId: 'tech-1',
         partitionKey: 'tech-1',
+        serviceId: 'svc-1',
+        categoryId: 'cat-1',
         bookingAmount: 50000,
-        completedJobCountAtSettlement: 5,
         commissionBps: 2200,
-        commissionAmount: 11000,
-        techAmount: 39000,
-        payoutStatus: 'PAID',
-        razorpayTransferId: 'trf-existing',
+        commissionDue: 11000,
+        commissionResolvedFrom: 'GLOBAL',
+        remittanceStatus: 'DUE',
         createdAt: '2026-04-24T10:00:00.000Z',
-        settledAt: '2026-04-24T10:00:01.000Z',
       });
 
-      await settleBooking(completedBooking, mockCtx);
+      await settleBooking(cashBooking, mockCtx);
 
-      expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
-      expect(mockTransfer).not.toHaveBeenCalled();
+      expect(commissionReceivableRepo.createDueEntry).not.toHaveBeenCalled();
     });
 
-    it('concurrent fire: returns early when createPendingEntry returns false (409 Conflict)', async () => {
-      vi.mocked(walletLedgerRepo.createPendingEntry).mockResolvedValue(false);
+    it('does not write audit when createDueEntry returns false (concurrent 409)', async () => {
+      vi.mocked(commissionReceivableRepo.createDueEntry).mockResolvedValue(false);
 
-      await settleBooking(completedBooking, mockCtx);
+      await settleBooking(cashBooking, mockCtx);
 
-      expect(mockTransfer).not.toHaveBeenCalled();
-    });
-
-    it('uses bookingId as Razorpay idempotency key', async () => {
-      await settleBooking(completedBooking, mockCtx);
-
-      expect(mockTransfer).toHaveBeenCalledWith(
-        expect.objectContaining({ idempotencyKey: 'booking-abc' }),
+      const dueCalls = vi.mocked(auditRepo.appendAuditEntry).mock.calls.filter(
+        ([e]) => e.action === 'COMMISSION_DUE_RECORDED',
       );
+      expect(dueCalls).toHaveLength(0);
     });
   });
+});
 
-  describe('commission', () => {
-    it('uses finalAmount over amount when both present', async () => {
-      await settleBooking({ ...completedBooking, finalAmount: 60000, amount: 50000 }, mockCtx);
-
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({ bookingAmount: 60000 }),
-      );
-    });
-
-    it('applies 22% commission for completedJobCount < 50 (INSTANT: fee also deducted)', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 49, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'INSTANT',
-      });
-
-      await settleBooking(completedBooking, mockCtx); // amount = 50000 paise
-
-      // commissionBps=2200, commission=11000, techAmountBeforeFee=39000, INSTANT fee=2500, techAmount=36500
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({ commissionBps: 2200, commissionAmount: 11000, techAmount: 36500 }),
-      );
-    });
-
-    it('applies 25% commission for completedJobCount >= 50 (INSTANT: fee also deducted)', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 50, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'INSTANT',
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      // commissionBps=2500, commission=12500, techAmountBeforeFee=37500, INSTANT fee=2500, techAmount=35000
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({ commissionBps: 2500, commissionAmount: 12500, techAmount: 35000 }),
-      );
-    });
+describe('settleBooking — RAZORPAY path (guarded, dead in cash pilot)', () => {
+  beforeEach(() => {
+    vi.stubEnv('RAZORPAY_KEY_ID', 'test-key-id');
+    vi.stubEnv('RAZORPAY_KEY_SECRET', 'test-key-secret');
   });
 
-  describe('audit logging', () => {
-    it('writes ROUTE_TRANSFER_ATTEMPT audit entry before Razorpay call', async () => {
-      const callOrder: string[] = [];
-      vi.mocked(auditRepo.appendAuditEntry).mockImplementation(async (entry) => {
-        callOrder.push(`audit:${entry.action}`);
-      });
-      mockTransfer.mockImplementation(async () => {
-        callOrder.push('razorpay:transfer');
-        return { transferId: 'trf-xyz' };
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      expect(callOrder[0]).toBe('audit:ROUTE_TRANSFER_ATTEMPT');
-      const razorpayIdx = callOrder.indexOf('razorpay:transfer');
-      const attemptIdx = callOrder.indexOf('audit:ROUTE_TRANSFER_ATTEMPT');
-      expect(attemptIdx).toBeLessThan(razorpayIdx);
-    });
-
-    it('writes ROUTE_TRANSFER_INSTANT audit entry on INSTANT success', async () => {
-      await settleBooking(completedBooking, mockCtx);
-
-      const successCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
-        ([entry]) => entry.action === 'ROUTE_TRANSFER_INSTANT',
-      );
-      expect(successCall).toBeDefined();
-    });
-
-    it('writes ROUTE_TRANSFER_FAILED audit entry on Razorpay error', async () => {
-      mockTransfer.mockRejectedValue(new Error('Razorpay timeout'));
-
-      await settleBooking(completedBooking, mockCtx);
-
-      const failCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
-        ([entry]) => entry.action === 'ROUTE_TRANSFER_FAILED',
-      );
-      expect(failCall).toBeDefined();
-    });
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
-  describe('payout cadence — conditional settlement (AC-3)', () => {
-    it('INSTANT: deducts ₹25 fee (2500 paise) from techAmount and transfers immediately', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'INSTANT',
-      });
+  const razorpayBooking = { ...cashBooking, paymentMethod: 'RAZORPAY' };
 
-      await settleBooking(completedBooking, mockCtx); // 50000 paise booking
+  it('skips gracefully when Razorpay credentials are not configured', async () => {
+    vi.unstubAllEnvs();
 
-      // 22% commission on 50000 = 11000, techAmount = 39000, minus INSTANT fee 2500 = 36500
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          techAmount: 36500,
-          payoutFeeAmount: 2500,
-          payoutCadence: 'INSTANT',
-          heldForCadence: false,
-        }),
-      );
-      expect(mockTransfer).toHaveBeenCalled(); // immediate transfer
-    });
+    await settleBooking(razorpayBooking, mockCtx);
 
-    it('INSTANT: audits ROUTE_TRANSFER_INSTANT on success', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'INSTANT',
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      const successCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
-        ([entry]) => entry.action === 'ROUTE_TRANSFER_INSTANT',
-      );
-      expect(successCall).toBeDefined();
-    });
-
-    it('NEXT_DAY: deducts ₹15 fee (1500 paise), creates PENDING with heldForCadence=true, no transfer', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'NEXT_DAY',
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      // 39000 - 1500 = 37500
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          techAmount: 37500,
-          payoutFeeAmount: 1500,
-          payoutCadence: 'NEXT_DAY',
-          heldForCadence: true,
-        }),
-      );
-      expect(mockTransfer).not.toHaveBeenCalled(); // held — no immediate transfer
-    });
-
-    it('NEXT_DAY: audits SETTLEMENT_HELD_NEXT_DAY and does NOT audit ROUTE_TRANSFER_SUCCESS', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'NEXT_DAY',
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      const heldCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
-        ([entry]) => entry.action === 'SETTLEMENT_HELD_NEXT_DAY',
-      );
-      expect(heldCall).toBeDefined();
-      const successCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
-        ([entry]) => entry.action === 'ROUTE_TRANSFER_SUCCESS',
-      );
-      expect(successCall).toBeUndefined();
-    });
-
-    it('WEEKLY: no fee, creates PENDING with heldForCadence=true, no transfer', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'WEEKLY',
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({
-          techAmount: 39000,
-          payoutFeeAmount: 0,
-          payoutCadence: 'WEEKLY',
-          heldForCadence: true,
-        }),
-      );
-      expect(mockTransfer).not.toHaveBeenCalled();
-    });
-
-    it('WEEKLY: audits SETTLEMENT_HELD_WEEKLY', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'WEEKLY',
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      const heldCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
-        ([entry]) => entry.action === 'SETTLEMENT_HELD_WEEKLY',
-      );
-      expect(heldCall).toBeDefined();
-    });
-
-    it('undefined cadence: treated as WEEKLY (legacy graceful degradation)', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1',
-        // no payoutCadence field
-      });
-
-      await settleBooking(completedBooking, mockCtx);
-
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({ payoutCadence: 'WEEKLY', heldForCadence: true }),
-      );
-      expect(mockTransfer).not.toHaveBeenCalled();
-    });
-
-    it('INSTANT minimum guard: if techAmount <= 2500 after commission, treats as WEEKLY (no fee, no transfer)', async () => {
-      // Very small booking: 3000 paise, 22% commission = 660, techAmount = 2340 < 2500
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'INSTANT',
-      });
-
-      await settleBooking({ ...completedBooking, amount: 3000 }, mockCtx);
-
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({ payoutCadence: 'WEEKLY', payoutFeeAmount: 0, heldForCadence: true }),
-      );
-      expect(mockTransfer).not.toHaveBeenCalled();
-    });
-
-    it('NEXT_DAY minimum guard: if techAmount <= 1500 after commission, treats as WEEKLY', async () => {
-      // Very small booking: 1800 paise, 22% commission = 396, techAmount = 1404 < 1500
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'NEXT_DAY',
-      });
-
-      await settleBooking({ ...completedBooking, amount: 1800 }, mockCtx);
-
-      expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
-        expect.objectContaining({ payoutCadence: 'WEEKLY', payoutFeeAmount: 0, heldForCadence: true }),
-      );
-      expect(mockTransfer).not.toHaveBeenCalled();
-    });
+    expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
+    expect(mockTransfer).not.toHaveBeenCalled();
   });
 
-  describe('failure isolation', () => {
-    it('marks wallet_ledger FAILED on Razorpay error — does NOT touch booking status', async () => {
-      mockTransfer.mockRejectedValue(new Error('network error'));
+  it('does NOT create commission receivable — uses wallet ledger instead', async () => {
+    await settleBooking(razorpayBooking, mockCtx);
 
-      await settleBooking(completedBooking, mockCtx);
+    expect(commissionReceivableRepo.createDueEntry).not.toHaveBeenCalled();
+    expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalled();
+  });
 
-      expect(walletLedgerRepo.markFailed).toHaveBeenCalledWith('booking-abc', 'tech-1', 'network error');
-      expect(walletLedgerRepo.markPaid).not.toHaveBeenCalled();
+  it('transfers immediately for INSTANT cadence', async () => {
+    await settleBooking(razorpayBooking, mockCtx);
+    expect(mockTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: 'booking-abc' }),
+    );
+  });
+
+  it('is idempotent: skips if wallet entry already exists', async () => {
+    vi.mocked(walletLedgerRepo.getByBookingId).mockResolvedValue({
+      id: 'booking-abc', bookingId: 'booking-abc', technicianId: 'tech-1',
+      partitionKey: 'tech-1', bookingAmount: 50000, completedJobCountAtSettlement: 5,
+      commissionBps: 2200, commissionAmount: 11000, techAmount: 39000,
+      payoutStatus: 'PAID', razorpayTransferId: 'trf-existing',
+      createdAt: '2026-04-24T10:00:00.000Z', settledAt: '2026-04-24T10:00:01.000Z',
     });
 
-    it('marks FAILED with "no Razorpay linked account" when INSTANT tech has no account', async () => {
-      vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
-        id: 'tech-1', completedJobCount: 5, payoutCadence: 'INSTANT',
-        // no razorpayLinkedAccountId
-      });
+    await settleBooking(razorpayBooking, mockCtx);
 
-      await settleBooking(completedBooking, mockCtx);
+    expect(walletLedgerRepo.createPendingEntry).not.toHaveBeenCalled();
+    expect(mockTransfer).not.toHaveBeenCalled();
+  });
 
-      expect(walletLedgerRepo.markFailed).toHaveBeenCalledWith(
-        'booking-abc', 'tech-1', 'no Razorpay linked account',
-      );
-      expect(mockTransfer).not.toHaveBeenCalled();
+  it('WEEKLY: no fee, heldForCadence=true, no transfer', async () => {
+    vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
+      id: 'tech-1', completedJobCount: 5, razorpayLinkedAccountId: 'acc-rp-1', payoutCadence: 'WEEKLY',
     });
 
-    it('increments completedJobCount only on success', async () => {
-      await settleBooking(completedBooking, mockCtx);
-      expect(techRepo.incrementCompletedJobCount).toHaveBeenCalledWith('tech-1');
+    await settleBooking(razorpayBooking, mockCtx);
+
+    expect(walletLedgerRepo.createPendingEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ payoutCadence: 'WEEKLY', payoutFeeAmount: 0, heldForCadence: true }),
+    );
+    expect(mockTransfer).not.toHaveBeenCalled();
+  });
+
+  it('marks wallet entry FAILED and audits ROUTE_TRANSFER_FAILED on Razorpay error', async () => {
+    mockTransfer.mockRejectedValue(new Error('Razorpay timeout'));
+
+    await settleBooking(razorpayBooking, mockCtx);
+
+    expect(walletLedgerRepo.markFailed).toHaveBeenCalledWith('booking-abc', 'tech-1', 'Razorpay timeout');
+    const failCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
+      ([e]) => e.action === 'ROUTE_TRANSFER_FAILED',
+    );
+    expect(failCall).toBeDefined();
+  });
+
+  it('marks wallet entry FAILED with "no Razorpay linked account" when INSTANT tech has no account', async () => {
+    vi.mocked(techRepo.getTechnicianForSettlement).mockResolvedValue({
+      id: 'tech-1', completedJobCount: 5, payoutCadence: 'INSTANT',
     });
 
-    it('does NOT increment completedJobCount on Razorpay failure', async () => {
-      mockTransfer.mockRejectedValue(new Error('fail'));
-      await settleBooking(completedBooking, mockCtx);
-      expect(techRepo.incrementCompletedJobCount).not.toHaveBeenCalled();
-    });
+    await settleBooking(razorpayBooking, mockCtx);
 
-    it('sends FCM earnings update to tech only on success (amount is post-fee for INSTANT)', async () => {
-      await settleBooking(completedBooking, mockCtx);
-      // INSTANT: 50000 booking, 22% commission (5 jobs) = 11000, techBeforeFee=39000, INSTANT fee=2500 → 36500
-      expect(fcmService.sendTechEarningsUpdate).toHaveBeenCalledWith('tech-1', {
-        bookingId: 'booking-abc',
-        techAmount: 36500,
-      });
-    });
+    expect(walletLedgerRepo.markFailed).toHaveBeenCalledWith(
+      'booking-abc', 'tech-1', 'no Razorpay linked account',
+    );
+    expect(mockTransfer).not.toHaveBeenCalled();
+  });
+
+  it('audits ROUTE_TRANSFER_INSTANT on INSTANT success', async () => {
+    await settleBooking(razorpayBooking, mockCtx);
+
+    const successCall = vi.mocked(auditRepo.appendAuditEntry).mock.calls.find(
+      ([entry]) => entry.action === 'ROUTE_TRANSFER_INSTANT',
+    );
+    expect(successCall).toBeDefined();
   });
 });

--- a/plans/E21-S01-cash-commission-api.md
+++ b/plans/E21-S01-cash-commission-api.md
@@ -1,0 +1,103 @@
+# E21-S01 — Cash-Pilot Commission Model: API Foundation
+
+**Epic:** E21 — Cash-Pilot Commission Model (new; reworks the E06-S04 / E08-S02 / E09-S04 prepaid-era finance model for the cash-only pilot).
+**Tier:** Foundation (money + Cosmos schema + change-feed trigger; security-sensitive).
+**Depends on:** nothing. **Blocks:** E21-S02 (admin-web), E21-S03 (technician-app) — both generate types from this story's OpenAPI contract, so the contract must be frozen + merged before they start.
+
+## Context / why
+
+The pilot is cash-only (Razorpay hidden, commit `13fa7280`). The technician collects the **full cash from the customer at the door**; the platform never touches the money. But the settlement engine was built for the prepaid/escrow model and **pays the technician out** on completion — the money arrow is inverted for cash:
+
+- `trigger-booking-completed.ts:130-150` transfers `techAmount` to the tech via Razorpay Routes (INSTANT) or holds a payout (WEEKLY/NEXT_DAY).
+- `admin/finance/approve-payouts.ts` "Approve All" sends money to techs.
+- Finance "Payout Queue" shows `netPayable` = what the platform owes the tech.
+
+Owner decisions: **(1) tech-remits-commission** — tech keeps the cash, owes the platform the commission; platform tracks "commission due" per tech; tech remits (UPI/cash deposit); an admin marks it received (audit-logged). **(2) commission config = cascade** — global default %, overridable per-category, overridable per-service; settlement resolves service → category → global.
+
+Three verified breakages this story fixes:
+1. `commission.service.ts:11` hardcodes `completedJobCount >= 50 ? 2500 : 2200` and never reads `Service.commissionBps` — the admin's commission editor is dead config.
+2. `cashCollectionStatus` is set to `'PENDING'` at creation and never updated; `'COLLECTED'` exists only in the enum. No admin visibility into collection.
+3. `finance-repository.ts:62,86` read `booking.commissionBps`, a field never written onto bookings — P&L silently falls back to 2200.
+
+## Work streams
+
+### WS-A — schema + Zod types (TDD; do first, commit) — orchestrator-owned
+- CREATE `api/src/schemas/commission-config.ts` — `CommissionConfigDocSchema { id:'commission-config', defaultCommissionBps: int[1500..3500], updatedBy, updatedAt }`; resolver I/O types.
+- CREATE `api/src/schemas/commission-receivable.ts` — model in "Data model" below.
+- MODIFY `api/src/schemas/service-category.ts` — add `commissionBps: z.number().int().min(1500).max(3500).optional()` (override). It flows into the admin create/update bodies and the OpenAPI `AdminServiceCategory`.
+- MODIFY `api/src/schemas/service.ts` — make `commissionBps` `.optional()` (a service may defer to category/global); allow omission in create body.
+- MODIFY `api/src/schemas/booking.ts` — add `cashCollectedAt: z.string().optional()`, `cashCollectedAmount: z.number().int().nonnegative().optional()`. No new status value.
+- Tests first: `api/tests/schemas/commission-config.test.ts`, `api/tests/schemas/commission-receivable.test.ts` (valid/invalid, range bounds, round-trip).
+
+### WS-B — repos + services + endpoints (TDD; fan out to Sonnet subagents after WS-A commit)
+Each subagent owns one impl file + its test, test written first.
+- CREATE `api/src/services/commission-config.service.ts` — pure `resolveCommissionBps({serviceBps, categoryBps, globalBps})` (precedence below) + cached `getGlobalCommissionBps()` mirroring the `truecaller.service.ts` cache (incl. `_resetCacheForTest()`).
+- CREATE `api/src/cosmos/commission-config-repository.ts` — get/upsert doc id `commission-config` in `getSystemContainer()`.
+- CREATE `api/src/cosmos/commission-receivable-repository.ts` — `getByBookingId`, `createDueEntry` (409-safe, mirror `walletLedgerRepo.createPendingEntry`), `markRemitted`, `markWaived`, `getOutstandingByTechnician` (single-partition), `getAllTechnicianOutstandingSummaries` (cross-partition aggregate).
+- MODIFY `api/src/services/commission.service.ts` — new signature `calculateCommission(bookingAmountPaise, commissionBps) => { commissionBps, commissionAmount, techAmount }`; drop the tenure tiers. Update `api/tests/unit/commission.service.test.ts`.
+- CREATE `api/src/functions/admin/finance/commission-receivables.ts` — GET per-tech outstanding dashboard + per-tech detail. `requireAdmin(['super-admin','ops-manager','finance'])` (read).
+- CREATE `api/src/functions/admin/finance/mark-commission-received.ts` — POST mark REMITTED/WAIVED; `requireAdmin(['super-admin','finance'])`; audit-logged; idempotent re-mark.
+- CREATE `api/src/functions/admin/catalogue/commission-config.ts` — GET/PUT global default; `requireAdmin(['super-admin'])` (write).
+- CREATE `api/src/functions/technicians/commission-due.ts` — GET `/v1/technicians/me/commission-due` (tech-facing owed/outstanding).
+- MODIFY `api/src/cosmos/booking-repository.ts` — add `markCashCollected(bookingId, amount)` (ETag-guarded, idempotent; mirror existing `markSosActivated`/`markPaid`).
+- MODIFY `api/src/functions/active-job.ts` — on `COMPLETED` transition, accept optional `cashCollected`/`collectedAmount` in body → flip `cashCollectionStatus`. Audit/visibility only; does NOT gate the receivable.
+
+### WS-B-risk — settlement trigger rewrite — orchestrator-owned (Opus)
+MODIFY `api/src/functions/trigger-booking-completed.ts` (`settleBooking`):
+1. Parse; return unless `status === 'COMPLETED'`; return if no `technicianId`. *(unchanged)*
+2. Idempotency: `commissionReceivableRepo.getByBookingId(bookingId, technicianId)` → skip if exists.
+3. `bookingAmount = finalAmount ?? amount`.
+4. Resolve rate: fetch service (`commissionBps`), category (`commissionBps`), `getGlobalCommissionBps()`; `bps = resolveCommissionBps(...)`; `commissionDue = round(bookingAmount * bps / 10000)`.
+5. `method = booking.paymentMethod ?? 'CASH_ON_SERVICE'`.
+6. **CASH branch (pilot):** `commissionReceivableRepo.createDueEntry({... remittanceStatus:'DUE', commissionBps, commissionResolvedFrom})` (409-safe → skip on false); audit `COMMISSION_DUE_RECORDED`; best-effort `incrementCompletedJobCount` + `sendTechEarningsUpdate`. **No Razorpay, no techAmount transfer, no cadence/fee logic.**
+7. **RAZORPAY branch (guarded; dead in pilot):** keep the old transfer path behind `if (method === 'RAZORPAY' && hasRazorpayCredentials())`.
+Rewrite `api/tests/unit/trigger-booking-completed.test.ts`: CASH creates DUE receivable with resolved bps; does NOT instantiate `RazorpayRouteService`; idempotent (existing → skip, 409 → skip); skip no-tech/non-COMPLETED; cascade precedence; RAZORPAY guarded branch still transfers.
+
+### WS-C — Semgrep
+- `api/.semgrep.yml` — rule flagging any `new RazorpayRouteService()` not lexically guarded by a `paymentMethod === 'RAZORPAY'` check (prevents reintroducing the cash-transfer bug).
+
+### WS-D — OpenAPI registry (freeze contract)
+- `api/src/openapi/registry.ts` — register updated `AdminServiceCategory` (+`commissionBps`), commission-config GET/PUT, commission-receivables GET, mark-received POST, tech commission-due GET.
+
+### WS-E — smoke gate + review
+- `bash tools/pre-codex-smoke-api.sh` → green.
+- `codex review --base main` (+ `/security-review` — money/auth) → `.codex-review-passed`.
+
+## Commission-cascade resolver
+Global doc in `system` container: `{ id:'commission-config', defaultCommissionBps:2200, updatedBy, updatedAt }`.
+```
+resolveCommissionBps({serviceBps, categoryBps, globalBps}):
+  valid(x) := Number.isInteger(x) && 1500 <= x <= 3500
+  if valid(serviceBps)  -> { bps: serviceBps,  from: 'SERVICE' }
+  if valid(categoryBps) -> { bps: categoryBps, from: 'CATEGORY' }
+  if valid(globalBps)   -> { bps: globalBps,   from: 'GLOBAL' }
+  else throw ConfigError   // global must always be valid; surfaced, never silent-clamped
+```
+Snapshot the resolved `commissionBps` + `commissionResolvedFrom` onto the receivable at settlement time (immutability — later config edits must not retroactively re-rate recorded receivables).
+
+## Data model — new container `commission_receivables` (pk `/technicianId`)
+`id` = bookingId (idempotency anchor; point read on (bookingId, technicianId)).
+Fields: `bookingId`, `technicianId`, `partitionKey`(=technicianId), `serviceId`, `categoryId`, `bookingAmount` (cash tech holds = finalAmount ?? amount), `cashCollectedAmount?`, `commissionBps` (resolved+snapshotted), `commissionDue`, `commissionResolvedFrom` (`SERVICE|CATEGORY|GLOBAL`), `remittanceStatus` (`DUE|REMITTED|WAIVED`), `remittedAmount?`, `remittedAt?`, `remittanceRef?` (UPI txn/deposit slip), `remittanceMethod?` (`UPI|CASH_DEPOSIT|ADJUSTMENT`), `markedByAdminId?`, `waivedReason?`, `createdAt`, `updatedAt?`.
+
+**Commission becomes DUE on `COMPLETED`** (not gated on the cash-confirm tap) so no completed job escapes the ledger. The tech "confirm cash collected" action sets `cashCollectionStatus=COLLECTED`/`cashCollectedAmount` on the booking for audit/visibility only.
+
+## Migration
+1. Add `{ id:'commission_receivables', partitionKey:'/technicianId' }` to `api/scripts/setup-cosmos.ts` (no lease container — it's a target, not a change-feed source). `system` already provisioned.
+2. Seed `{ id:'commission-config', defaultCommissionBps:2200 }` into `system` (matches the historical `finance-repository` default so P&L doesn't jump).
+3. Repoint `getDailyPnL`/`getPayoutQueue` off the non-existent `booking.commissionBps` to recorded commission (read `commission_receivables`).
+4. **OWNER DECISION (surface before finalizing seed):** seeded categories get `commissionBps` UNSET (fall through to global). Existing per-service `commissionBps` overrides will now actually take effect — keep them, or null them for a clean global-2200 start?
+5. No destructive `wallet_ledger` migration; no retroactive backfill — start clean from a documented cutover timestamp.
+6. Provision container + seed config **before** deploying the new trigger.
+
+## Verification
+- Unit (Vitest): resolver precedence + out-of-range + `commissionResolvedFrom`; `calculateCommission` arithmetic + `commission+tech===amount`; settlement rewrite (CASH→DUE, no Razorpay instantiation, idempotent, skip cases, RAZORPAY guarded transfer); receivable repo create/mark/aggregate (409 idempotency); admin endpoint auth (401/403/200 + audit + idempotent re-mark); config write super-admin-only; `active-job` COMPLETED flips `cashCollectionStatus`; catalogue category persists `commissionBps`.
+- Gate: `tools/pre-codex-smoke-api.sh` → `/codex-review-gate` + `/security-review` → CI.
+- End-to-end (manual, post-deploy): cash booking → complete → DUE receivable appears with cascade-resolved rate → admin sees per-tech outstanding → marks received → outstanding clears + audit written → tech `commission-due` reflects it.
+
+## Riskiest
+1. `trigger-booking-completed.ts` — change-feed; a bug double-charges/drops commission for every completed job. Preserve `bookingId` idempotency; test concurrent (409) + double fire.
+2. Turning `Service.commissionBps` live changes effective commission (was dead). Owner sign-off (migration #4).
+3. P&L on a missing field — repoint or the dashboard stays wrong.
+4. OpenAPI contract is the cross-repo dependency — freeze before E21-S02/S03.
+5. Dual meaning of `PAID` (cash booking is PAID at creation = dispatch-ready, not money received) — never treat PAID as settled; use `cashCollectionStatus`.
+6. Zero-cost infra — UPI remittance is a manual link + admin "mark received"; no payment-collection PSP.


### PR DESCRIPTION
## Summary

- **Inverts settlement direction for cash pilot**: technician already holds cash, platform records commission *owed by the tech* (`commission_receivables` ledger) instead of transferring money TO the technician via Razorpay.
- **Commission cascade**: global default (system container `commission-config`) → category `commissionBps` → service `commissionBps`, resolved and snapshotted at settlement time.
- **Admin APIs**: dashboard (`GET /v1/admin/finance/commission-receivables`), per-tech detail, `POST /v1/admin/finance/commission-receivables/settle` (REMIT / WAIVE), `GET/PUT /v1/admin/catalogue/commission-config`.
- **Tech API**: `GET /v1/technicians/me/commission-due` returns outstanding commission entries with totals.
- **Cash confirm on job completion**: `COMPLETED` transition body accepts `cashCollected: true` + optional `collectedAmount` → single Cosmos write flips `cashCollectionStatus`.
- **Semgrep guard** (`cash-razorpay-guard`): prevents unguarded `new RazorpayRouteService()` in the settlement trigger from re-introducing the cash-transfer bug.
- **Cosmos migration**: `commission_receivables` container provisioned; `commission-config` doc seeded (409-safe, defaultCommissionBps=2200).
- **Codex review**: gpt-5.5 found 4 P2s (amount-below-due guard, spurious audit on no-op, ops-manager RBAC on read endpoints, hardcoded 2200 in Razorpay path); all fixed.

## Changed files
- `api/src/schemas/commission-{config,receivable}.ts` (new)
- `api/src/cosmos/commission-{config,receivable}-repository.ts` (new)
- `api/src/services/commission-{config,commission}.service.ts` (new / modified)
- `api/src/functions/trigger-booking-completed.ts` (settlement rewrite)
- `api/src/functions/active-job.ts` (cash confirm on COMPLETED)
- `api/src/functions/admin/finance/{commission-receivables,mark-commission-received}.ts` (new)
- `api/src/functions/admin/catalogue/commission-config.ts` (new)
- `api/src/functions/technicians/commission-due.ts` (new)
- `api/src/services/fcm.service.ts` (sendTechEarningsUpdate accepts commissionDue)
- `api/src/openapi/registry.ts` (6 new paths registered)
- `api/.semgrep.yml` (cash-razorpay-guard rule)
- `api/scripts/setup-cosmos.ts` (commission_receivables container + seed)
- 186 test files, 1535 tests passing

## Test plan
- [ ] Smoke gate: `bash tools/pre-codex-smoke-api.sh` — 1535/1535 green
- [ ] Settlement direction: CASH booking → `commission_receivables` DUE entry created; no Razorpay transfer
- [ ] Cascade resolver: service bps wins > category > global
- [ ] Idempotency: duplicate COMPLETED event → no duplicate receivable (409-safe)
- [ ] Admin mark received: REMIT → REMITTED + audit; WAIVE → WAIVED + audit; no-op → 200 but no audit
- [ ] Amount guard: remittedAmount < commissionDue → 422
- [ ] Ops-manager can read commission dashboard (was 403, now 200)
- [ ] Tech `GET /v1/technicians/me/commission-due` returns outstanding entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)